### PR TITLE
Release gsd-hermes 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`init` query agents-installed check looks at the correct directory** — `checkAgentsInstalled` in `sdk/src/query/init.ts` defaulted to `~/.claude/get-shit-done/agents/`, but the installer writes GSD agents to `~/.claude/agents/`. Every init query therefore reported `agents_installed: false` on clean installs, which made workflows refuse to spawn `gsd-executor` and other parallel subagents. The default now matches `sdk/src/init-runner.ts` and the installer (#2400)
 - **Installer now installs `@gsd-build/sdk` automatically** so `gsd-sdk` lands on PATH. Resolves `command not found: gsd-sdk` errors that affected every `/gsd-*` command after a fresh install or `/gsd-update` to 1.36+. Adds `--no-sdk` to opt out and `--sdk` to force reinstall. Implements the `--sdk` flag that was previously documented in README but never wired up (#2385)
 
+## [1.0.0] - 2026-04-19
+
+### Added
+- **Initial public GSD Hermes release** — Independent `gsd-hermes` package line for a Hermes-focused downstream fork. Based on upstream `get-shit-done-cc@1.37.1`, with first-class Hermes Agent install support and the upstream GSD workflow preserved.
+
+### Fixed
+- **Installer rebuilds stale SDK binaries** — The installer now checks whether an existing `gsd-sdk` on `PATH` supports `gsd-sdk query ...` before skipping SDK installation. This fixes Hermes sessions that found an old global `@gsd-build/sdk@0.1.0` binary and fell back to filesystem-only workflow checks.
+
 ## [1.37.1] - 2026-04-17
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.37.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.37.1",
+      "version": "1.0.0",
       "license": "MIT",
       "bin": {
         "get-shit-done-cc": "bin/install.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.37.1",
+  "version": "1.0.0",
   "description": "A get-shit-done fork that adds Hermes Agent runtime support while preserving upstream GSD workflows.",
   "bin": {
     "gsd-hermes": "bin/install.js",


### PR DESCRIPTION
## Summary
- Start the independent `gsd-hermes` package version line at `1.0.0`
- Record upstream base as `get-shit-done-cc@1.37.1` in the changelog
- Include the installer fix from main that rebuilds stale `gsd-sdk` binaries without `query` support

## Verification
- `npm test`
- `npm pack --dry-run`

## Release plan
After merge, publish `gsd-hermes@1.0.0` via the `Publish npm` workflow using Trusted Publishing (`auth_mode=trusted-publishing`, `dry_run=false`, `tag=latest`), then create GitHub Release `v1.0.0`.

Closes #5