### PR TITLE
Document gsd-hermes version strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
-All notable changes to GSD will be documented in this file.
+All notable changes to GSD Hermes will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+GSD Hermes uses an independent downstream package version line. Each release should
+record both the `gsd-hermes` package version and the upstream GSD base version it
+syncs from.
 
 ## [Unreleased]
 
 ### Added
+- **Downstream version policy docs** — README and release docs now state that `gsd-hermes` starts at `1.0.0` and records the upstream `get-shit-done-cc` base separately instead of mirroring upstream package versions.
 - **`/gsd-ingest-docs` command** — Scan a repo containing mixed ADRs, PRDs, SPECs, and DOCs and bootstrap or merge the full `.planning/` setup from them in a single pass. Parallel classification (`gsd-doc-classifier`), synthesis with precedence rules and cycle detection (`gsd-doc-synthesizer`), three-bucket conflicts report (`INGEST-CONFLICTS.md`: auto-resolved, competing-variants, unresolved-blockers), and hard-block on LOCKED-vs-LOCKED ADR contradictions in both new and merge modes. Supports directory-convention discovery and `--manifest <file>` YAML override with per-doc precedence. v1 caps at 50 docs per invocation; `--resolve interactive` is reserved. Extracts shared conflict-detection contract into `references/doc-conflict-engine.md` which `/gsd-import` now also consumes (#2387)
 
 ### Fixed
@@ -15,6 +20,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Installer now installs `@gsd-build/sdk` automatically** so `gsd-sdk` lands on PATH. Resolves `command not found: gsd-sdk` errors that affected every `/gsd-*` command after a fresh install or `/gsd-update` to 1.36+. Adds `--no-sdk` to opt out and `--sdk` to force reinstall. Implements the `--sdk` flag that was previously documented in README but never wired up (#2385)
 
 ## [1.0.0] - 2026-04-19
+
+GSD Hermes package version: `1.0.0`
+Upstream GSD base: `get-shit-done-cc@1.37.1`
 
 ### Added
 - **Initial public GSD Hermes release** — Independent `gsd-hermes` package line for a Hermes-focused downstream fork. Based on upstream `get-shit-done-cc@1.37.1`, with first-class Hermes Agent install support and the upstream GSD workflow preserved.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ The upstream maintainers [declined Hermes Agent support in core GSD](https://git
 
 That is why this project exists: preserve the upstream GSD workflow, track upstream closely, and add first-class Hermes Agent support where the official project reasonably chooses not to carry that maintenance cost.
 
+> [!NOTE]
+> **Version identity:** `gsd-hermes` uses its own npm version line starting at `1.0.0`.
+> This release is based on upstream `get-shit-done-cc@1.37.1`.
+> Future upstream syncs should bump `gsd-hermes` independently, for example `gsd-hermes@1.0.1` based on `get-shit-done-cc@1.37.2`, instead of mirroring upstream package versions.
+
 ---
 
 <div align="center">

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,14 +1,33 @@
 # Versioning & Release Strategy
 
-GSD follows [Semantic Versioning 2.0.0](https://semver.org/) with three release tiers mapped to npm dist-tags.
+GSD Hermes follows [Semantic Versioning 2.0.0](https://semver.org/) for the
+downstream `gsd-hermes` npm package.
+
+This project does not mirror upstream `get-shit-done-cc` package versions.
+Instead, every release records two separate values:
+
+| Field | Meaning | Example |
+|-------|---------|---------|
+| `gsd-hermes` version | Public npm package version for this Hermes-focused fork | `1.0.0` |
+| Upstream GSD base | Upstream package or release synced into this fork | `get-shit-done-cc@1.37.1` |
+
+If upstream releases `get-shit-done-cc@1.37.2`, the normal downstream release is
+`gsd-hermes@1.0.1` with release notes that say it is based on
+`get-shit-done-cc@1.37.2`. Do not jump the downstream package to `1.37.2`
+unless the downstream project intentionally decides to abandon the independent
+version line.
+
+This keeps the npm user experience clear: `npx gsd-hermes@latest` installs the
+latest Hermes-focused fork, while the README, changelog, and release notes tell
+users which upstream GSD base it contains.
 
 ## Release Tiers
 
 | Tier | What ships | Version format | npm tag | Branch | Install |
 |------|-----------|---------------|---------|--------|---------|
-| **Patch** | Bug fixes only | `1.27.1` | `latest` | `hotfix/1.27.1` | `npx get-shit-done-cc@latest` |
-| **Minor** | Fixes + enhancements | `1.28.0` | `latest` (after RC) | `release/1.28.0` | `npx get-shit-done-cc@next` (RC) |
-| **Major** | Fixes + enhancements + features | `2.0.0` | `latest` (after beta) | `release/2.0.0` | `npx get-shit-done-cc@next` (beta) |
+| **Patch** | Bug fixes, docs, upstream patch syncs | `1.0.1` | `latest` | `hotfix/1.0.1` | `npx gsd-hermes@latest` |
+| **Minor** | Non-breaking Hermes support improvements or upstream minor syncs | `1.1.0` | `latest` (after RC) | `release/1.1.0` | `npx gsd-hermes@next` (RC) |
+| **Major** | Breaking downstream CLI, install, or config behavior | `2.0.0` | `latest` (after beta) | `release/2.0.0` | `npx gsd-hermes@next` (beta) |
 
 ## npm Dist-Tags
 
@@ -16,8 +35,8 @@ Only two tags, following Angular/Next.js convention:
 
 | Tag | Meaning | Installed by |
 |-----|---------|-------------|
-| `latest` | Stable production release | `npm install get-shit-done-cc` (default) |
-| `next` | Pre-release (RC or beta) | `npm install get-shit-done-cc@next` (opt-in) |
+| `latest` | Stable production release | `npm install gsd-hermes` (default) |
+| `next` | Pre-release (RC or beta) | `npm install gsd-hermes@next` (opt-in) |
 
 The version string (`-rc.1` vs `-beta.1`) communicates stability level. Users never get pre-releases unless they explicitly opt in.
 
@@ -25,16 +44,16 @@ The version string (`-rc.1` vs `-beta.1`) communicates stability level. Users ne
 
 | Increment | When | Examples |
 |-----------|------|----------|
-| **PATCH** (1.27.x) | Bug fixes, typo corrections, test additions | Hook filter fix, config corruption fix |
-| **MINOR** (1.x.0) | Non-breaking enhancements, new commands, new runtime support | New workflow command, discuss-mode feature |
-| **MAJOR** (x.0.0) | Breaking changes to config format, CLI flags, or runtime API; new features that alter existing behavior | Removing a command, changing config schema |
+| **PATCH** (1.0.x) | Bug fixes, docs, test additions, upstream patch syncs with no downstream behavior break | Hermes install fix, SDK repair fix, upstream `1.37.2` sync |
+| **MINOR** (1.x.0) | Non-breaking enhancements, new Hermes compatibility features, upstream minor syncs | New Hermes doctor check, new install mode |
+| **MAJOR** (x.0.0) | Breaking changes to config format, CLI flags, install layout, or runtime API | Removing a command, changing Hermes config schema |
 
 ## Pre-Release Version Progression
 
 Major and minor releases use different pre-release types:
 
 ```
-Minor: 1.28.0-rc.1  →  1.28.0-rc.2  →  1.28.0
+Minor: 1.1.0-rc.1   →  1.1.0-rc.2   →  1.1.0
 Major: 2.0.0-beta.1 →  2.0.0-beta.2 →  2.0.0
 ```
 
@@ -47,11 +66,11 @@ Major: 2.0.0-beta.1 →  2.0.0-beta.2 →  2.0.0
 ```
 main                              ← stable, always deployable
   │
-  ├── hotfix/1.27.1               ← patch: cherry-pick fix from main, publish to latest
+  ├── hotfix/1.0.1                ← patch: cherry-pick fix from main, publish to latest
   │
-  ├── release/1.28.0              ← minor: accumulate fixes + enhancements, RC cycle
-  │     ├── v1.28.0-rc.1          ← tag: published to next
-  │     └── v1.28.0               ← tag: promoted to latest
+  ├── release/1.1.0               ← minor: accumulate fixes + enhancements, RC cycle
+  │     ├── v1.1.0-rc.1           ← tag: published to next
+  │     └── v1.1.0                ← tag: promoted to latest
   │
   ├── release/2.0.0               ← major: features + breaking changes, beta cycle
   │     ├── v2.0.0-beta.1         ← tag: published to next
@@ -69,8 +88,8 @@ main                              ← stable, always deployable
 
 For critical bugs that can't wait for the next minor release.
 
-1. Trigger `hotfix.yml` with version (e.g., `1.27.1`)
-2. Workflow creates `hotfix/1.27.1` branch from the latest patch tag for that minor version (e.g., `v1.27.0` or `v1.27.1`)
+1. Trigger `hotfix.yml` with version (e.g., `1.0.1`)
+2. Workflow creates `hotfix/1.0.1` branch from the latest patch tag for that minor version (e.g., `v1.0.0` or `v1.0.1`)
 3. Cherry-pick or apply fix on the hotfix branch
 4. Push — CI runs tests automatically
 5. Trigger `hotfix.yml` finalize action
@@ -81,12 +100,12 @@ For critical bugs that can't wait for the next minor release.
 
 For accumulated fixes and enhancements.
 
-1. Trigger `release.yml` with action `create` and version (e.g., `1.28.0`)
-2. Workflow creates `release/1.28.0` branch from main, bumps package.json
-3. Trigger `release.yml` with action `rc` to publish `1.28.0-rc.1` to `next`
-4. Test the RC: `npx get-shit-done-cc@next`
+1. Trigger `release.yml` with action `create` and version (e.g., `1.1.0`)
+2. Workflow creates `release/1.1.0` branch from main, bumps package.json
+3. Trigger `release.yml` with action `rc` to publish `1.1.0-rc.1` to `next`
+4. Test the RC: `npx gsd-hermes@next`
 5. If issues found: fix on release branch, publish `rc.2`, `rc.3`, etc.
-6. Trigger `release.yml` with action `finalize` — publishes `1.28.0` to `latest`
+6. Trigger `release.yml` with action `finalize` — publishes `1.1.0` to `latest`
 7. Merge release branch to main
 
 ### Major Release
@@ -114,6 +133,11 @@ Branch names map to commit types:
 
 ## Publishing Commands (Reference)
 
+Current manual npm publishing should use `.github/workflows/publish-npm.yml`
+from `main` after the release PR is merged. Prefer Trusted Publishing once npm
+trust is configured; use `auth_mode=npm-token` only as a fallback until
+[#6](https://github.com/pingchesu/gsd-hermes/issues/6) is resolved.
+
 ```bash
 # Stable release (sets latest tag automatically)
 npm publish
@@ -122,5 +146,5 @@ npm publish
 npm publish --tag next
 
 # Verify what latest and next point to
-npm dist-tag ls get-shit-done-cc
+npm dist-tag ls gsd-hermes
 ```

--- a/docs/upstream-sync.md
+++ b/docs/upstream-sync.md
@@ -44,6 +44,24 @@ git merge upstream/main
 Merges are required per D-05, and visible merge history is preserved per D-06
 so future Hermes-specific conflicts stay reviewable.
 
+## Version Policy for Upstream Syncs
+
+`gsd-hermes` has an independent npm version line. Upstream GSD versions are
+recorded as compatibility metadata, not copied into the downstream npm version.
+
+Use this mapping when preparing a release after an upstream sync:
+
+| Scenario | Downstream release | Release note wording |
+|----------|-------------------|----------------------|
+| Upstream patch sync, no downstream breaking change | Patch bump, for example `gsd-hermes@1.0.1` | `Based on get-shit-done-cc@1.37.2` |
+| Upstream minor sync or new Hermes capability | Minor bump, for example `gsd-hermes@1.1.0` | `Based on get-shit-done-cc@1.38.0` |
+| Downstream breaking installer/config behavior | Major bump, for example `gsd-hermes@2.0.0` | Include upstream base and migration notes |
+
+Do not publish `gsd-hermes@1.37.2` just because upstream releases
+`get-shit-done-cc@1.37.2`. The package identity is the Hermes fork; the
+upstream base is documented separately in README, CHANGELOG, release notes, and
+sync PRs.
+
 ## Post-Sync Validation Checklist
 
 Run this checklist after every routine sync from `upstream/main`:
@@ -73,6 +91,10 @@ Run this checklist after every routine sync from `upstream/main`:
    ```
 7. Review `docs/hermes-compatibility.md` when the sync changes runtime
    behavior, support status, install paths, lifecycle behavior, or known gaps.
+8. Update release metadata:
+   - README version identity banner, if the upstream base changed.
+   - CHANGELOG release heading with both `gsd-hermes` version and upstream base.
+   - GitHub Release notes with the same two-version wording.
 
 `npm run test:hermes` is the targeted Hermes compatibility gate. `npm test` is
 the full-suite release gate when feasible.


### PR DESCRIPTION
## Summary

- Add a README banner explaining that `gsd-hermes` uses an independent version line starting at `1.0.0`.
- Record the upstream base separately in CHANGELOG release entries.
- Update VERSIONING and upstream sync docs so future syncs publish `gsd-hermes` semver independently from `get-shit-done-cc`.

Closes #7

## Verification

- `npm test`
