### PR TITLE
Fix SDK install on root-owned npm prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ syncs from.
 - **`init` query agents-installed check looks at the correct directory** — `checkAgentsInstalled` in `sdk/src/query/init.ts` defaulted to `~/.claude/get-shit-done/agents/`, but the installer writes GSD agents to `~/.claude/agents/`. Every init query therefore reported `agents_installed: false` on clean installs, which made workflows refuse to spawn `gsd-executor` and other parallel subagents. The default now matches `sdk/src/init-runner.ts` and the installer (#2400)
 - **Installer now installs `@gsd-build/sdk` automatically** so `gsd-sdk` lands on PATH. Resolves `command not found: gsd-sdk` errors that affected every `/gsd-*` command after a fresh install or `/gsd-update` to 1.36+. Adds `--no-sdk` to opt out and `--sdk` to force reinstall. Implements the `--sdk` flag that was previously documented in README but never wired up (#2385)
 
+## [1.0.1] - 2026-04-20
+
+GSD Hermes package version: `1.0.1`
+Upstream GSD base: `get-shit-done-cc@1.37.1`
+
+### Fixed
+- **SDK install no longer requires sudo on root-owned npm prefixes** — When `npm install -g .` fails while building the bundled SDK, the installer now retries with a user-writable npm prefix at `~/.local`. This fixes `EACCES: permission denied, mkdir '/usr/lib/node_modules/@gsd-build'` during `npx gsd-hermes --hermes --global` on machines whose npm global prefix points to `/usr`.
+
 ## [1.0.0] - 2026-04-19
 
 GSD Hermes package version: `1.0.0`

--- a/bin/install.js
+++ b/bin/install.js
@@ -7280,8 +7280,44 @@ function installSdkIfNeeded() {
     console.warn(`  ${yellow}⚠${reset}  ${reason}`);
     console.warn(`     Build manually from the repo sdk/ directory:`);
     console.warn(`       ${cyan}cd ${sdkDir} && npm install && npm run build && npm install -g .${reset}`);
+    console.warn(`     If your npm global prefix is not writable, use a user prefix instead:`);
+    console.warn(`       ${cyan}cd ${sdkDir} && npm install && npm run build && npm install -g --prefix ~/.local .${reset}`);
+    console.warn(`       ${cyan}export PATH="$HOME/.local/bin:$PATH"${reset}`);
     console.warn(`     Then restart your shell so the updated PATH is picked up.`);
     console.warn(`     Without it, /gsd-* commands will fail with "command not found: gsd-sdk".`);
+  };
+
+  const userPrefix = process.env.GSD_NPM_PREFIX || path.join(os.homedir(), '.local');
+  const userBinDir = process.platform === 'win32' ? userPrefix : path.join(userPrefix, 'bin');
+  const userSdkBin = path.join(userBinDir, process.platform === 'win32' ? 'gsd-sdk.cmd' : 'gsd-sdk');
+  const isOnPath = (dir) => {
+    const currentPath = process.env.PATH || '';
+    return currentPath
+      .split(path.delimiter)
+      .filter(Boolean)
+      .some((entry) => path.resolve(entry) === path.resolve(dir));
+  };
+
+  const installSdkPackage = () => {
+    const globalResult = spawnSync(npmCmd, ['install', '-g', '.'], { cwd: sdkDir, stdio: 'inherit' });
+    if (globalResult.status === 0) {
+      return { ok: true, mode: 'global' };
+    }
+
+    console.warn(`  ${yellow}⚠${reset}  Global SDK install failed. Retrying with user npm prefix: ${userPrefix}`);
+    fs.mkdirSync(userBinDir, { recursive: true });
+    const userResult = spawnSync(npmCmd, ['install', '-g', '--prefix', userPrefix, '.'], { cwd: sdkDir, stdio: 'inherit' });
+    if (userResult.status !== 0) {
+      return { ok: false, mode: 'user-prefix' };
+    }
+
+    if (!isOnPath(userBinDir)) {
+      console.warn(`  ${yellow}⚠${reset}  Installed gsd-sdk to ${userSdkBin}, but ${userBinDir} is not on PATH.`);
+      console.warn(`     Add it before using /gsd-* commands:`);
+      console.warn(`       ${cyan}export PATH="${userBinDir}:$PATH"${reset}`);
+    }
+
+    return { ok: true, mode: 'user-prefix', bin: userSdkBin };
   };
 
   if (!fs.existsSync(sdkPackageJson)) {
@@ -7306,10 +7342,12 @@ function installSdkIfNeeded() {
     return;
   }
 
-  // 3. Install the built package globally so `gsd-sdk` lands on PATH.
-  const globalResult = spawnSync(npmCmd, ['install', '-g', '.'], { cwd: sdkDir, stdio: 'inherit' });
-  if (globalResult.status !== 0) {
-    warnManual('Failed to `npm install -g .` from sdk/.');
+  // 3. Install the built package so `gsd-sdk` lands on PATH. Prefer npm's
+  // global prefix, but fall back to a user-writable prefix for machines where
+  // the global prefix is /usr or another root-owned location.
+  const packageInstall = installSdkPackage();
+  if (!packageInstall.ok) {
+    warnManual('Failed to install built SDK package from sdk/.');
     return;
   }
 
@@ -7321,6 +7359,8 @@ function installSdkIfNeeded() {
   const verify = spawnSync(resolverCmd, ['gsd-sdk'], { encoding: 'utf-8' });
   if (verify.status === 0 && verify.stdout && verify.stdout.trim()) {
     console.log(`  ${green}✓${reset} Built and installed GSD SDK from source (gsd-sdk resolved at ${verify.stdout.trim().split('\n')[0]})`);
+  } else if (packageInstall.bin && fs.existsSync(packageInstall.bin)) {
+    console.log(`  ${green}✓${reset} Built and installed GSD SDK from source (${packageInstall.bin})`);
   } else {
     warnManual('Built and installed GSD SDK from source but gsd-sdk is not on PATH — npm global bin may not be in your PATH.');
     if (verify.stderr) console.warn(`     resolver stderr: ${verify.stderr.trim()}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "bin": {
         "get-shit-done-cc": "bin/install.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A get-shit-done fork that adds Hermes Agent runtime support while preserving upstream GSD workflows.",
   "bin": {
     "gsd-hermes": "bin/install.js",

--- a/tests/bugs-1656-1657.test.cjs
+++ b/tests/bugs-1656-1657.test.cjs
@@ -83,10 +83,9 @@ describe('#1657 / #2385: SDK install must be wired into installer source', () =>
   test('install.js builds gsd-sdk from in-repo sdk/ source (#2385)', () => {
     src = src || fs.readFileSync(INSTALL_SRC, 'utf-8');
     // The installer must locate the in-repo sdk/ directory, run the build,
-    // and install it globally. We intentionally do NOT install
-    // @gsd-build/sdk from npm because that published version lags the source
-    // tree and shipping it breaks query handlers added since the last
-    // publish.
+    // and install it as a CLI. We intentionally do NOT install @gsd-build/sdk
+    // from npm because that published version lags the source tree and
+    // shipping it breaks query handlers added since the last publish.
     assert.ok(
       src.includes("path.resolve(__dirname, '..', 'sdk')") ||
       src.includes('path.resolve(__dirname, "..", "sdk")'),
@@ -116,6 +115,26 @@ describe('#1657 / #2385: SDK install must be wired into installer source', () =>
     assert.ok(
       src.includes('Existing GSD SDK lacks query support'),
       'installer should explain when it rebuilds over a stale SDK'
+    );
+  });
+
+  test('install.js falls back to a user npm prefix when global SDK install is not writable', () => {
+    src = src || fs.readFileSync(INSTALL_SRC, 'utf-8');
+    assert.ok(
+      src.includes('GSD_NPM_PREFIX') && src.includes("path.join(os.homedir(), '.local')"),
+      'installer must support a user-writable npm prefix for machines where the global prefix is root-owned'
+    );
+    assert.ok(
+      src.includes("['install', '-g', '--prefix', userPrefix, '.']"),
+      'installer must retry SDK installation with npm --prefix instead of requiring sudo'
+    );
+    assert.ok(
+      src.includes('Global SDK install failed. Retrying with user npm prefix'),
+      'installer should explain the fallback path when global SDK install fails'
+    );
+    assert.ok(
+      src.includes('export PATH=') && src.includes('not on PATH'),
+      'installer must tell users how to add the user-prefix bin directory to PATH'
     );
   });
 


### PR DESCRIPTION
## Summary

- Retry bundled SDK installation with a user-writable npm prefix (`~/.local`) when global `npm install -g .` fails.
- Print PATH guidance if the fallback `gsd-sdk` binary is not immediately discoverable.
- Bump patch release to `1.0.1` and document the fix in CHANGELOG.

Closes #9

## Verification

- `node --test tests/bugs-1656-1657.test.cjs`
- `npm test`
