### PR TITLE
chore: prepare 1.2.0 release and publish flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ concurrency:
 
 env:
   NODE_VERSION: 24
+  PACKAGE_NAME: gsd-hermes
 
 jobs:
   validate-version:
@@ -225,14 +226,14 @@ jobs:
           PRE_VERSION: ${{ steps.prerelease.outputs.pre_version }}
         run: |
           sleep 10
-          PUBLISHED=$(npm view get-shit-done-cc@"$PRE_VERSION" version 2>/dev/null || echo "NOT_FOUND")
+          PUBLISHED=$(npm view "${PACKAGE_NAME}@${PRE_VERSION}" version 2>/dev/null || echo "NOT_FOUND")
           if [ "$PUBLISHED" != "$PRE_VERSION" ]; then
             echo "::error::Published version verification failed. Expected $PRE_VERSION, got $PUBLISHED"
             exit 1
           fi
-          echo "✓ Verified: get-shit-done-cc@$PRE_VERSION is live on npm"
+          echo "✓ Verified: ${PACKAGE_NAME}@$PRE_VERSION is live on npm"
           # Also verify dist-tag
-          NEXT_TAG=$(npm dist-tag ls get-shit-done-cc 2>/dev/null | grep "next:" | awk '{print $2}')
+          NEXT_TAG=$(npm dist-tag ls "$PACKAGE_NAME" 2>/dev/null | grep "next:" | awk '{print $2}')
           echo "✓ next tag points to: $NEXT_TAG"
 
       - name: Summary
@@ -245,7 +246,7 @@ jobs:
             echo "**DRY RUN** — npm publish, tagging, and push skipped" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- Published to npm as \`next\`" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Install: \`npx get-shit-done-cc@next\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Install: \`npx ${PACKAGE_NAME}@next\`" >> "$GITHUB_STEP_SUMMARY"
           fi
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "To publish another pre-release: run \`rc\` again" >> "$GITHUB_STEP_SUMMARY"
@@ -348,10 +349,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
         run: |
-          gh release create "v${VERSION}" \
-            --title "v${VERSION}" \
-            --generate-notes \
-            --latest
+          NOTES_FILE=$(find docs/releases -maxdepth 1 -type f -name "v${VERSION}*.md" | sort | head -n 1)
+          if [ -n "$NOTES_FILE" ]; then
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --notes-file "$NOTES_FILE" \
+              --latest
+          else
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --generate-notes \
+              --latest
+          fi
 
       - name: Clean up next dist-tag
         if: ${{ !inputs.dry_run }}
@@ -361,7 +370,7 @@ jobs:
         run: |
           # Point next to the stable release so @next never returns something
           # older than @latest. This prevents stale pre-release installs.
-          npm dist-tag add "get-shit-done-cc@${VERSION}" next 2>/dev/null || true
+          npm dist-tag add "${PACKAGE_NAME}@${VERSION}" next 2>/dev/null || true
           echo "✓ next dist-tag updated to v${VERSION}"
 
       - name: Verify publish
@@ -370,14 +379,14 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           sleep 10
-          PUBLISHED=$(npm view get-shit-done-cc@"$VERSION" version 2>/dev/null || echo "NOT_FOUND")
+          PUBLISHED=$(npm view "${PACKAGE_NAME}@${VERSION}" version 2>/dev/null || echo "NOT_FOUND")
           if [ "$PUBLISHED" != "$VERSION" ]; then
             echo "::error::Published version verification failed. Expected $VERSION, got $PUBLISHED"
             exit 1
           fi
-          echo "✓ Verified: get-shit-done-cc@$VERSION is live on npm"
+          echo "✓ Verified: ${PACKAGE_NAME}@$VERSION is live on npm"
           # Verify latest tag
-          LATEST_TAG=$(npm dist-tag ls get-shit-done-cc 2>/dev/null | grep "latest:" | awk '{print $2}')
+          LATEST_TAG=$(npm dist-tag ls "$PACKAGE_NAME" 2>/dev/null | grep "latest:" | awk '{print $2}')
           echo "✓ latest tag points to: $LATEST_TAG"
 
       - name: Summary
@@ -392,5 +401,5 @@ jobs:
             echo "- Published to npm as \`latest\`" >> "$GITHUB_STEP_SUMMARY"
             echo "- Tagged \`v${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
             echo "- PR created to merge back to main" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Install: \`npx get-shit-done-cc@latest\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Install: \`npx ${PACKAGE_NAME}@latest\`" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ syncs from.
 ## [Unreleased]
 
 ### Added
-- **Downstream version policy docs** — README and release docs now state that `gsd-hermes` starts at `1.0.0` and records the upstream `get-shit-done-cc` base separately instead of mirroring upstream package versions.
+- **Cross-Provider Agent Execution release messaging** — README, CHANGELOG, release draft, and canonical operator docs now present the upcoming `gsd-hermes@1.2.0` release as a downstream capability milestone centered on strict per-agent runtime/model binding, Hermes mixed-provider direct execution, and explicit `cross_ai_execution` fallback semantics.
 - **`/gsd-ingest-docs` command** — Scan a repo containing mixed ADRs, PRDs, SPECs, and DOCs and bootstrap or merge the full `.planning/` setup from them in a single pass. Parallel classification (`gsd-doc-classifier`), synthesis with precedence rules and cycle detection (`gsd-doc-synthesizer`), three-bucket conflicts report (`INGEST-CONFLICTS.md`: auto-resolved, competing-variants, unresolved-blockers), and hard-block on LOCKED-vs-LOCKED ADR contradictions in both new and merge modes. Supports directory-convention discovery and `--manifest <file>` YAML override with per-doc precedence. v1 caps at 50 docs per invocation; `--resolve interactive` is reserved. Extracts shared conflict-detection contract into `references/doc-conflict-engine.md` which `/gsd-import` now also consumes (#2387)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ That is why this project exists: preserve the upstream GSD workflow, track upstr
 
 > [!NOTE]
 > **Version identity:** `gsd-hermes` uses its own npm version line starting at `1.0.0`.
-> This release is based on upstream `get-shit-done-cc@1.38.2`.
-> This upstream minor sync is released as `gsd-hermes@1.1.0`.
-> Do not mirror upstream as `gsd-hermes@1.38.2`; the downstream package version and upstream base are tracked separately.
+> The upstream GSD base and the downstream `gsd-hermes` release line are tracked separately.
+> The next downstream feature release is `gsd-hermes@1.2.0`, centered on **Cross-Provider Agent Execution** rather than a plain upstream sync.
+> That release line packages strict runtime/model binding, Hermes mixed-provider direct execution, and explicit `cross_ai_execution` fallback semantics without changing the standard GSD workflow.
+> Do not mirror upstream package numbers directly into `gsd-hermes`; the fork ships its own release story.
 
 ---
 
@@ -24,7 +25,7 @@ That is why this project exists: preserve the upstream GSD workflow, track upstr
 
 **English** · [Português](README.pt-BR.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [한국어](README.ko-KR.md)
 
-**A downstream get-shit-done fork with first-class Hermes Agent runtime support, while preserving the upstream GSD workflow for Claude Code, OpenCode, Gemini CLI, Kilo, Codex, Copilot, Cursor, Windsurf, Antigravity, Augment, Trae, Qwen Code, Cline, and CodeBuddy.**
+**A downstream get-shit-done fork with first-class Hermes Agent runtime support and cross-provider runtime/model execution semantics, while preserving the upstream GSD workflow for Claude Code, OpenCode, Gemini CLI, Kilo, Codex, Copilot, Cursor, Windsurf, Antigravity, Augment, Trae, Qwen Code, Cline, and CodeBuddy.**
 
 **Solves context rot — the quality degradation that happens as Claude fills its context window.**
 
@@ -107,11 +108,12 @@ People who want to describe what they want and have it built correctly — witho
 
 Built-in quality gates catch real problems: schema drift detection flags ORM changes missing migrations, security enforcement anchors verification to threat models, and scope reduction detection prevents the planner from silently dropping your requirements.
 
-### v1.37.0 Highlights
+### v1.2.0 Highlights
 
-- **Spiking & sketching** — `/gsd-spike` runs 2–5 focused experiments with Given/When/Then verdicts; `/gsd-sketch` produces 2–3 interactive HTML mockup variants per design question — both store artifacts in `.planning/` and pair with wrap-up commands to package findings into project-local skills
-- **Agent size-budget enforcement** — Tiered line-count limits (XL: 1 600, Large: 1 000, Default: 500) keep agent prompts lean; violations surface in CI
-- **Shared boilerplate extraction** — Mandatory-initial-read and project-skills-discovery logic extracted to reference files, reducing duplication across a dozen agents
+- **Cross-Provider Agent Execution** — Hermes can now honor different provider/model bindings per agent in the same project, so planning, checking, execution, and verification no longer have to pretend one runtime model fits every role.
+- **Strict runtime/model binding** — Configured bindings are now enforced exactly or fail fast with actionable diagnostics; unsupported direct bindings no longer silently fall back to a different provider or model.
+- **Explicit external fallback path** — `cross_ai_execution` remains available, but only as a deliberate opt-in fallback path rather than an implicit provider-translation shortcut.
+- **Operator-visible runtime state** — Init/workflow surfaces and canonical docs now make the four runtime-model paths easier to reason about: explicit binding, `inherit`, runtime-default omission, and explicit cross-AI fallback.
 
 ---
 
@@ -121,13 +123,15 @@ Built-in quality gates catch real problems: schema drift detection flags ORM cha
 npx gsd-hermes@latest
 ```
 
-If the npm package is not published yet, install directly from GitHub:
+If you need the unreleased main branch before the next npm publish, install directly from GitHub:
 
 ```bash
 npx --yes github:pingchesu/gsd-hermes
 ```
 
-Release maintainers can publish through GitHub Actions; see [docs/npm-publishing.md](docs/npm-publishing.md).
+Release maintainers can publish through GitHub Actions; see [docs/npm-publishing.md](docs/npm-publishing.md). The prepared release copy for the next feature release lives at [docs/releases/v1.2.0-cross-provider-agent-execution.md](docs/releases/v1.2.0-cross-provider-agent-execution.md).
+
+Hermes users who want planner/checker/executor/verifier to run on different LLMs should start with the mixed-provider examples in [docs/CONFIGURATION.md](docs/CONFIGURATION.md#cross-provider-agent-execution-hermes-example).
 
 The installer prompts you to choose:
 1. **Runtime** — Hermes Agent, Claude Code, OpenCode, Gemini, Kilo, Codex, Copilot, Cursor, Windsurf, Antigravity, Augment, Trae, Qwen Code, CodeBuddy, Cline, or all (interactive multi-select — pick multiple runtimes in a single install session)

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -26,7 +26,7 @@ users which upstream GSD base it contains.
 | Tier | What ships | Version format | npm tag | Branch | Install |
 |------|-----------|---------------|---------|--------|---------|
 | **Patch** | Bug fixes, docs, upstream patch syncs | `1.0.1` | `latest` | `hotfix/1.0.1` | `npx gsd-hermes@latest` |
-| **Minor** | Non-breaking Hermes support improvements or upstream minor syncs | `1.1.0` | `latest` (after RC) | `release/1.1.0` | `npx gsd-hermes@next` (RC) |
+| **Minor** | Non-breaking Hermes support improvements, downstream feature milestones, or upstream minor syncs | `1.2.0` | `latest` (after RC) | `release/1.2.0` | `npx gsd-hermes@next` (RC) |
 | **Major** | Breaking downstream CLI, install, or config behavior | `2.0.0` | `latest` (after beta) | `release/2.0.0` | `npx gsd-hermes@next` (beta) |
 
 ## npm Dist-Tags
@@ -53,7 +53,7 @@ The version string (`-rc.1` vs `-beta.1`) communicates stability level. Users ne
 Major and minor releases use different pre-release types:
 
 ```
-Minor: 1.1.0-rc.1   →  1.1.0-rc.2   →  1.1.0
+Minor: 1.2.0-rc.1   →  1.2.0-rc.2   →  1.2.0
 Major: 2.0.0-beta.1 →  2.0.0-beta.2 →  2.0.0
 ```
 
@@ -68,9 +68,9 @@ main                              ← stable, always deployable
   │
   ├── hotfix/1.0.1                ← patch: cherry-pick fix from main, publish to latest
   │
-  ├── release/1.1.0               ← minor: accumulate fixes + enhancements, RC cycle
-  │     ├── v1.1.0-rc.1           ← tag: published to next
-  │     └── v1.1.0                ← tag: promoted to latest
+  ├── release/1.2.0               ← minor: accumulate fixes + enhancements, RC cycle
+  │     ├── v1.2.0-rc.1           ← tag: published to next
+  │     └── v1.2.0                ← tag: promoted to latest
   │
   ├── release/2.0.0               ← major: features + breaking changes, beta cycle
   │     ├── v2.0.0-beta.1         ← tag: published to next
@@ -100,12 +100,12 @@ For critical bugs that can't wait for the next minor release.
 
 For accumulated fixes and enhancements.
 
-1. Trigger `release.yml` with action `create` and version (e.g., `1.1.0`)
-2. Workflow creates `release/1.1.0` branch from main, bumps package.json
-3. Trigger `release.yml` with action `rc` to publish `1.1.0-rc.1` to `next`
+1. Trigger `release.yml` with action `create` and version (e.g., `1.2.0`)
+2. Workflow creates `release/1.2.0` branch from main, bumps package.json
+3. Trigger `release.yml` with action `rc` to publish `1.2.0-rc.1` to `next`
 4. Test the RC: `npx gsd-hermes@next`
 5. If issues found: fix on release branch, publish `rc.2`, `rc.3`, etc.
-6. Trigger `release.yml` with action `finalize` — publishes `1.1.0` to `latest`
+6. Trigger `release.yml` with action `finalize` — publishes `1.2.0` to `latest`
 7. Merge release branch to main
 
 ### Major Release

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -161,6 +161,8 @@ Research, plan, and verify a phase.
 
 Runtime-model semantics for this command follow the canonical four-path model in [`CONFIGURATION.md`](CONFIGURATION.md#canonical-runtime-model-semantics): explicit binding, `inherit`, runtime-default omission, and explicit `cross_ai_execution` fallback.
 
+For the `gsd-hermes` v1.2.0 Cross-Provider Agent Execution path, that means phase research, planning, and plan checking may each resolve to different provider/model bindings under `runtime: "hermes"`. Unsupported explicit direct bindings fail before planning starts and surface a suggested fix instead of silently falling back.
+
 ```bash
 /gsd-plan-phase 1                   # Research + plan + verify phase 1
 /gsd-plan-phase 3 --skip-research   # Plan without research (familiar domain)
@@ -224,6 +226,8 @@ Execute all plans in a phase with wave-based parallelization, or run a specific 
 **Produces:** per-plan `{phase}-{N}-SUMMARY.md`, git commits, and `{phase}-VERIFICATION.md` when the phase is fully complete
 
 This command prefers direct runtime support when available. `--cross-ai` and `workflow.cross_ai_execution` opt into the explicit external fallback path; they do not imply automatic provider translation.
+
+In the `gsd-hermes` v1.2.0 Cross-Provider Agent Execution model, Hermes can execute directly with mixed provider/model bindings (for example, planner on Claude and executor/verifier on OpenAI) as long as the runtime can honor those bindings. `--cross-ai` remains the explicit fallback knob when you want external delegation instead.
 
 ```bash
 /gsd-execute-phase 1                # Execute phase 1

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -539,30 +539,37 @@ When GSD is installed for a non-Claude runtime, the installer automatically sets
 
 That installer default is the runtime-default omission path from the canonical four-path model above. It is a valid steady-state configuration, not a missing setting.
 
-If you want different agents to use different models, use `model_overrides` with fully-qualified model IDs that your runtime recognizes:
+If you want different agents to use different models, use `model_overrides` with fully-qualified model IDs that your runtime recognizes. For Hermes, this is the direct **Cross-Provider Agent Execution** path:
 
 ```json
 {
+  "runtime": "hermes",
+  "model_profile": "inherit",
   "resolve_model_ids": "omit",
   "model_overrides": {
-    "gsd-planner": "openai/o3",
-    "gsd-executor": "openai/o4-mini",
-    "gsd-debugger": "openai/o3",
-    "gsd-codebase-mapper": "openai/o4-mini"
+    "gsd-phase-researcher": "claude-opus-4-7",
+    "gsd-planner": "claude-opus-4-7",
+    "gsd-plan-checker": "openai/gpt-5.4",
+    "gsd-executor": "openai/gpt-5.4",
+    "gsd-verifier": "openai/gpt-5.4"
   }
 }
 ```
 
-The intent is the same as the Claude profile tiers -- use a stronger model for planning and debugging (where reasoning quality matters most), and a cheaper model for execution and mapping (where the plan already contains the reasoning).
+In this setup Hermes stays on the direct runtime path: GSD asks for the configured bindings directly and only accepts them when the runtime can honor them. Unsupported direct bindings fail fast with explicit diagnostics instead of silently translating into `cross_ai_execution`.
+
+The intent is the same as the Claude profile tiers -- use a stronger model for planning and debugging (where reasoning quality matters most), and a cheaper or faster model for execution and verification when that trade-off makes sense.
 
 **When to use which approach:**
 
 | Scenario | Setting | Effect |
 |----------|---------|--------|
 | Non-Claude runtime, single model | `resolve_model_ids: "omit"` (installer default) | All agents use the runtime's default model |
+| Hermes, mixed-provider direct execution | `runtime: "hermes"` + `resolve_model_ids: "omit"` + fully-qualified `model_overrides` | Hermes honors each agent's configured provider/model directly |
 | Non-Claude runtime, tiered models | `resolve_model_ids: "omit"` + `model_overrides` | Named agents use specific models, others use runtime default |
 | Claude Code with OpenRouter/local provider | `model_profile: "inherit"` | All agents follow the session model |
 | Claude Code with OpenRouter, tiered | `model_profile: "inherit"` + `model_overrides` | Named agents use specific models, others inherit |
+| Provider-restricted runtime needing external delegation | `workflow.cross_ai_execution: true` + `workflow.cross_ai_command` | Execution uses an explicit external fallback path |
 
 **`resolve_model_ids` values:**
 
@@ -571,6 +578,16 @@ The intent is the same as the Claude profile tiers -- use a stronger model for p
 | `false` (default) | Returns Claude aliases (`opus`, `sonnet`, `haiku`) | Claude Code with native Anthropic API |
 | `true` | Maps aliases to full Claude model IDs (`claude-opus-4-6`) | Claude Code with API that requires full IDs |
 | `"omit"` | Returns empty string (runtime picks its default) | Non-Claude runtimes (Codex, OpenCode, Gemini CLI, Kilo, Hermes) |
+
+### Cross-Provider Agent Execution (Hermes example)
+
+The flagship `gsd-hermes` v1.2.0 capability is direct mixed-provider execution under `runtime: "hermes"`. The important rule is simple:
+
+- If Hermes can honor the configured provider/model binding directly, GSD keeps it on the direct runtime path.
+- If the configured direct binding is unsupported, GSD fails fast with an actionable error.
+- GSD does **not** silently rewrite an invalid direct binding into `cross_ai_execution`.
+
+That separation keeps runtime truthfulness intact: Hermes can act as a multi-provider runtime adapter, while `cross_ai_execution` stays an explicit external fallback rather than an invisible downgrade.
 
 ### Profile Philosophy
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -587,7 +587,7 @@ The flagship `gsd-hermes` v1.2.0 capability is direct mixed-provider execution u
 - If the configured direct binding is unsupported, GSD fails fast with an actionable error.
 - GSD does **not** silently rewrite an invalid direct binding into `cross_ai_execution`.
 
-That separation keeps runtime truthfulness intact: Hermes can act as a multi-provider runtime adapter, while `cross_ai_execution` stays an explicit external fallback rather than an invisible downgrade.
+That separation keeps runtime truthfulness intact: Hermes can serve as a multi-provider runtime adapter, while `cross_ai_execution` stays an explicit external fallback rather than an invisible downgrade.
 
 ### Profile Philosophy
 

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -8,39 +8,38 @@ Use the `Publish npm` workflow in `.github/workflows/publish-npm.yml`.
 
 The workflow validates the package name and version, runs the test suite, checks the npm tarball with `npm pack --dry-run`, publishes to npm, and verifies that the expected package version is visible in the npm registry.
 
-## First Publish
+For the upcoming `gsd-hermes@1.2.0` Cross-Provider Agent Execution release, keep the publishing flow simple:
 
-Because `gsd-hermes` is not published yet, the first npm publish cannot use Trusted Publishing. npm trusted publisher configuration is attached to an existing npm package, so bootstrap the package once with a short-lived npm token.
+1. Update README / CHANGELOG / release notes first.
+2. Run `Publish npm` with `dry_run: true`.
+3. If dry run is clean, rerun with `dry_run: false`.
+4. Prefer `auth_mode: trusted-publishing`, but keep `npm-token` as the break-glass fallback until issue #6 is closed.
 
-1. Create a granular npm token that can publish `gsd-hermes`.
-2. Add it to the GitHub repository as the `NPM_TOKEN` secret.
-3. Open GitHub Actions, run `Publish npm`, and use:
-   - `tag`: `latest`
-   - `auth_mode`: `npm-token`
-   - `dry_run`: `false`
-4. Delete or rotate the temporary token after the package exists.
+## Publish Workflow Inputs
+
+Use these workflow inputs in GitHub Actions:
+
+- `tag`: `latest` for stable release, `next` for preview distribution
+- `auth_mode`: `trusted-publishing` first, `npm-token` if trusted publishing is still failing
+- `dry_run`: `true` for readiness validation, `false` for the actual publish
 
 ## Trusted Publishing Setup
 
-After the first publish, configure npm Trusted Publishing so future releases do not require a long-lived token.
-
-Use npm's package settings UI, or run:
-
-```bash
-npm trust github gsd-hermes --repo pingchesu/gsd-hermes --file publish-npm.yml --env npm-publish
-```
-
-The trusted publisher configuration must match the workflow filename and GitHub environment name exactly:
+The preferred long-term path is npm Trusted Publishing. The trusted publisher configuration must match the workflow filename and GitHub environment name exactly:
 
 - Repository: `pingchesu/gsd-hermes`
 - Workflow filename: `publish-npm.yml`
 - Environment: `npm-publish`
 
-Future publishes should use:
+You can configure it with npm package settings UI, or run:
 
-- `tag`: `latest` or `next`
-- `auth_mode`: `trusted-publishing`
-- `dry_run`: `false`
+```bash
+npm trust github gsd-hermes --repo pingchesu/gsd-hermes --file publish-npm.yml --env npm-publish
+```
+
+## Token Fallback
+
+Trusted publishing for this repo still has a tracked setup issue in [#6](https://github.com/pingchesu/gsd-hermes/issues/6). Until that issue is fully closed and re-verified, keep `NPM_TOKEN` available as a controlled fallback for release maintainers.
 
 ## Dry Runs
 
@@ -52,7 +51,7 @@ GitHub Actions -> Publish npm -> Run workflow -> dry_run=true
 
 ## Local Fallback Before npm Publish
 
-Until the package is visible in npm, users can install from GitHub:
+If you need the unreleased main branch before the next npm publish, install directly from GitHub:
 
 ```bash
 npx --yes github:pingchesu/gsd-hermes

--- a/docs/releases/v1.2.0-cross-provider-agent-execution.md
+++ b/docs/releases/v1.2.0-cross-provider-agent-execution.md
@@ -6,7 +6,7 @@ Draft GitHub release copy for the next downstream feature release.
 
 `gsd-hermes@1.2.0` is the release that turns Cross-Provider Agent Execution into a first-class downstream capability.
 
-The core change is that Hermes can now act as a truthful multi-provider runtime adapter for GSD: planner, researcher, checker, executor, and verifier no longer need to collapse onto one pretend runtime model. When a provider/model binding is configured explicitly, GSD now either honors it directly or fails fast with an actionable error instead of silently falling back.
+The core change is that Hermes becomes a truthful multi-provider runtime adapter for GSD: planner, researcher, checker, executor, and verifier no longer need to collapse onto one pretend runtime model. When a provider/model binding is configured explicitly, GSD now either honors it directly or fails fast with an actionable error instead of silently falling back.
 
 ## Highlights
 

--- a/docs/releases/v1.2.0-cross-provider-agent-execution.md
+++ b/docs/releases/v1.2.0-cross-provider-agent-execution.md
@@ -1,0 +1,70 @@
+# gsd-hermes v1.2.0 — Cross-Provider Agent Execution
+
+Draft GitHub release copy for the next downstream feature release.
+
+## Summary
+
+`gsd-hermes@1.2.0` is the release that turns Cross-Provider Agent Execution into a first-class downstream capability.
+
+The core change is that Hermes can now act as a truthful multi-provider runtime adapter for GSD: planner, researcher, checker, executor, and verifier no longer need to collapse onto one pretend runtime model. When a provider/model binding is configured explicitly, GSD now either honors it directly or fails fast with an actionable error instead of silently falling back.
+
+## Highlights
+
+- **Cross-Provider Agent Execution** — run different GSD agents on different providers/models under `runtime: "hermes"` while preserving the standard upstream workflow shape.
+- **Strict runtime/model binding** — explicit provider/model bindings are enforced exactly or rejected with clear diagnostics; silent fallback is no longer accepted.
+- **Explicit external fallback** — `cross_ai_execution` stays available, but only as a deliberate fallback path rather than an invisible provider-translation layer.
+- **Clearer operator visibility** — init/workflow/doc surfaces now expose the four runtime-model paths consistently: explicit binding, `inherit`, runtime-default omission, and explicit external fallback.
+
+## Why this release matters
+
+Before this release, mixed-provider setups risked being flattened into misleading runtime assumptions or hidden fallback behavior. With v1.2.0:
+
+- runtime and provider/model are treated as separate concepts
+- Hermes direct bindings remain direct when supported
+- unsupported direct bindings fail before plan/execute work starts
+- external delegation requires explicit opt-in instead of happening silently
+
+That makes `gsd-hermes` much safer for teams that want to mix LLM vendors intentionally without losing confidence in what model actually executed each step.
+
+## Example configuration
+
+```json
+{
+  "runtime": "hermes",
+  "model_profile": "inherit",
+  "resolve_model_ids": "omit",
+  "model_overrides": {
+    "gsd-phase-researcher": "claude-opus-4-7",
+    "gsd-planner": "claude-opus-4-7",
+    "gsd-plan-checker": "openai/gpt-5.4",
+    "gsd-executor": "openai/gpt-5.4",
+    "gsd-verifier": "openai/gpt-5.4"
+  }
+}
+```
+
+## Install
+
+```bash
+npx gsd-hermes@latest
+```
+
+For unreleased main-branch testing before npm publish:
+
+```bash
+npx --yes github:pingchesu/gsd-hermes
+```
+
+## Verification
+
+Recommended release verification references:
+
+- PR: https://github.com/pingchesu/gsd-hermes/pull/15
+- Milestone tag: `v1.2`
+- Canonical config docs: `docs/CONFIGURATION.md`
+- Command behavior docs: `docs/COMMANDS.md`
+- Publish procedure: `docs/npm-publishing.md`
+
+## Suggested release title
+
+`gsd-hermes v1.2.0 — Cross-Provider Agent Execution`


### PR DESCRIPTION
## Summary
- update README and canonical docs to position `gsd-hermes@1.2.0` as the Cross-Provider Agent Execution release
- add a prepared GitHub release notes draft under `docs/releases/`
- fix `.github/workflows/release.yml` so formal RC/finalize flow targets `gsd-hermes` instead of the old `get-shit-done-cc` package name
- refresh `VERSIONING.md` examples to use the upcoming `1.2.0` minor-release cycle

## Why
The product-facing messaging and the formal release workflow were out of sync:
- README / docs still read like `1.1.0` upstream-sync copy
- release workflow still verified and advertised `get-shit-done-cc`
- there was no prepared release body emphasizing Cross-Provider Agent Execution

This PR makes the `1.2.0` release/publish path operational and reviewer-visible before package publication.

## Validation
- `node --test tests/config-schema-docs-parity.test.cjs tests/commands-doc-parity.test.cjs tests/cross-ai-execution.test.cjs tests/product-name-purity.test.cjs tests/hermes-docs.test.cjs`

## Notes
- prepared release notes draft: `docs/releases/v1.2.0-cross-provider-agent-execution.md`
- release workflow now auto-uses `docs/releases/v${VERSION}*.md` when present
- local release/publish execution is intentionally not part of this PR; this change prepares the formal flow so release can be triggered from GitHub Actions after merge

Closes #17
