### PR TITLE
fix: use explicit latest tag in finalize release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,7 +293,7 @@ jobs:
           npm run test:coverage
 
       - name: Dry-run publish validation
-        run: npm publish --dry-run
+        run: npm publish --dry-run --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -339,7 +339,7 @@ jobs:
 
       - name: Publish to npm (latest)
         if: ${{ !inputs.dry_run }}
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary
- fix `release.yml` finalize dry-run to call `npm publish --dry-run --tag latest`
- fix the real finalize publish step to call `npm publish --provenance --access public --tag latest`

## Why
`1.2.0` finalize dry-run failed because npm refused to implicitly apply `latest` when an older higher semver (`1.37.1`) already exists in the registry history. npm's own error explicitly requires specifying a tag.

## Result
After this PR merges, the `1.2.0` finalize dry-run should pass, and the real finalize publish will use the same explicit `latest` tag path.

Closes #18
