### PR TITLE
fix: let finalize continue when release PR creation is blocked

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,7 @@ jobs:
 
       - name: Create PR to merge release back to main
         if: ${{ !inputs.dry_run }}
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ needs.validate-version.outputs.branch }}
@@ -309,13 +310,15 @@ jobs:
             echo "PR #$EXISTING_PR already exists; updating"
             gh pr edit "$EXISTING_PR" \
               --title "chore: merge release v${VERSION} to main" \
-              --body "Merge release branch back to main after v${VERSION} stable release."
+              --body "Merge release branch back to main after v${VERSION} stable release." \
+              || echo "::warning::Unable to update release PR automatically; continue with publish and update it manually."
           else
             gh pr create \
               --base main \
               --head "$BRANCH" \
               --title "chore: merge release v${VERSION} to main" \
-              --body "Merge release branch back to main after v${VERSION} stable release."
+              --body "Merge release branch back to main after v${VERSION} stable release." \
+              || echo "::warning::Unable to create release PR automatically; continue with publish and create it manually."
           fi
 
       - name: Tag and push


### PR DESCRIPTION
## Summary
- make the finalize workflow treat release-PR creation as best-effort only
- continue with tag/publish/release even when GitHub Actions cannot create or edit PRs

## Why
The repo's GitHub Actions token is not permitted to create pull requests. That should not block npm publication of a stable release.

## Result
If Actions cannot create or update the release-back-to-main PR, the workflow now emits a warning and continues. Maintainers can create that PR manually after publish.

Closes #20
