### PR TITLE
chore: merge release v1.2.0 to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.2.0",
+  "version": "1.2.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.2.0",
+      "version": "1.2.0-rc.1",
       "license": "MIT",
       "bin": {
         "get-shit-done-cc": "bin/install.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "bin": {
         "get-shit-done-cc": "bin/install.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.2.0-rc.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.2.0-rc.1",
+      "version": "1.2.0",
       "license": "MIT",
       "bin": {
         "get-shit-done-cc": "bin/install.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.2.0",
+  "version": "1.2.0-rc.1",
   "description": "A get-shit-done fork that adds Hermes Agent runtime support while preserving upstream GSD workflows.",
   "bin": {
     "gsd-hermes": "bin/install.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A get-shit-done fork that adds Hermes Agent runtime support while preserving upstream GSD workflows.",
   "bin": {
     "gsd-hermes": "bin/install.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.2.0-rc.1",
+  "version": "1.2.0",
   "description": "A get-shit-done fork that adds Hermes Agent runtime support while preserving upstream GSD workflows.",
   "bin": {
     "gsd-hermes": "bin/install.js",


### PR DESCRIPTION
## Summary
- merge `release/1.2.0` back into `main` after the successful stable `gsd-hermes@1.2.0` publish
- keep `main` aligned with the released branch state and release-cycle commits

## Release status
- npm stable release published: `gsd-hermes@1.2.0`
- npm dist-tags: `latest -> 1.2.0`, `next -> 1.2.0`
- GitHub Release published: `v1.2.0`

## Why this PR exists
The formal release workflow published from `release/1.2.0`. This PR closes the loop by merging the release branch back into `main` so the mainline reflects the exact published release state.

Closes #22
