### PR TITLE
docs(release): prepare gsd-hermes 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,25 @@ syncs from.
 
 ## [Unreleased]
 
+No unreleased changes yet.
+
+## [1.4.0] — 2026-04-25
+
+GSD Hermes package version: `1.4.0`
+Upstream GSD base: `upstream/main@cd057255` (25 commits after the v1.3.0 base `upstream/main@0a049149`)
+
 ### Synced
-- **Upstream sync candidate to `upstream/main@cd057255`** — brings in 25 commits after the shipped v1.3.0 base `upstream/main@0a049149`. This is sync work only and is not part of the already-published `gsd-hermes@1.3.0` release.
+- **Upstream sync to `upstream/main@cd057255`** — brings in the post-v1.3 upstream fixes and enhancements while preserving the independent `gsd-hermes` package identity, Hermes runtime adapter, and downstream release policy.
+
+### Added
+- **Release tarball guardrails from upstream** — release and smoke workflows now build SDK dist artifacts and verify `sdk/dist/cli.js` ships in the published tarball so fresh installs do not depend on build-from-source behavior.
+- **SDK query/config regression coverage** — imports upstream coverage for config-schema parity, state mutation, roadmap handling, init progress precedence, sub-repo root resolution, and workflow-agent skill consistency.
 
 ### Fixed
-- **`gsd-sdk query` parent `.planning/` root resolution in multi-repo (`sub_repos`) workspaces** — upstream fix for invoking SDK queries from a child repo listed under parent workspace `sub_repos` (#2623).
-- **Shell hooks falsely flagged as stale on every session** — upstream hook version header/substitution and stale-hook detector fixes for bash `#` comments (#2136, #2206, #2209, #2210, #2212).
+- **Installer fail-fast when SDK dist is missing** — preserves the upstream no-nested-install guard while keeping Hermes-specific package guidance.
+- **Codex/OpenCode runtime model override propagation** — imports upstream fix for passing per-agent model overrides through non-Claude transports.
+- **Workstream and roadmap state synchronization** — imports upstream fixes for `--ws` query dispatch, ROADMAP checkbox precedence, state frontmatter writes, and insert-phase roadmap evolution.
+- **Hermes skill frontmatter compatibility during upstream colon-form sync** — keeps Hermes command-discovery frontmatter hyphenated while allowing upstream-owned Claude/Qwen colon-form behavior in the imported tests and paths.
 
 ## [1.3.0] — 2026-04-24
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **GSD Hermes** is a downstream fork of [get-shit-done-cc](https://github.com/gsd-build/get-shit-done) that adds Hermes Agent runtime support while preserving upstream GSD workflows.
 
-- **Package:** `gsd-hermes@1.3.0`
-- **Upstream base:** `upstream/main@0a049149` (97 commits above `v1.38.2`)
+- **Package:** `gsd-hermes@1.4.0`
+- **Upstream base:** `upstream/main@cd057255` (25 commits after the v1.3.0 base `0a049149`)
 - **Install:** `npx gsd-hermes --hermes --global`
 
 ## Install & Quickstart
@@ -31,9 +31,10 @@ Compatibility gate: `npm run test:hermes` validates Hermes install modes + SDK q
 - [docs/fork-ownership.md](docs/fork-ownership.md) — Path ownership matrix + merge-conflict routing rules
 - [docs/upstream-sync.md](docs/upstream-sync.md) — Upstream sync workflow + sync-log precedent
 - [docs/sync-logs/2026-04-sync-0a049149.md](docs/sync-logs/2026-04-sync-0a049149.md) — Per-hunk classification for the v1.3 upstream sync
+- [docs/releases/v1.4.0-upstream-sync-cd057255.md](docs/releases/v1.4.0-upstream-sync-cd057255.md) — Release notes for the v1.4 upstream sync package
 
 See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## Based on Upstream GSD
 
-Based on upstream `get-shit-done-cc@0a049149` — see [the upstream project](https://github.com/gsd-build/get-shit-done) for the source GSD system this fork extends.
+Based on upstream `get-shit-done@cd057255` — see [the upstream project](https://github.com/gsd-build/get-shit-done) for the source GSD system this fork extends.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -6,9 +6,9 @@ GSD follows [Semantic Versioning 2.0.0](https://semver.org/) with three release 
 
 | Tier | What ships | Version format | npm tag | Branch | Install |
 |------|-----------|---------------|---------|--------|---------|
-| **Patch** | Bug fixes only | `1.27.1` | `latest` | `hotfix/1.27.1` | `npx get-shit-done-cc@latest` |
-| **Minor** | Fixes + enhancements | `1.28.0` | `latest` (after RC) | `release/1.28.0` | `npx get-shit-done-cc@next` (RC) |
-| **Major** | Fixes + enhancements + features | `2.0.0` | `latest` (after beta) | `release/2.0.0` | `npx get-shit-done-cc@next` (beta) |
+| **Patch** | Bug fixes only | `1.3.1` | `latest` | `hotfix/1.3.1` | `npx gsd-hermes@latest` |
+| **Minor** | Fixes + enhancements | `1.4.0` | `latest` (after RC) | `release/1.4.0` | `npx gsd-hermes@next` (RC) |
+| **Major** | Fixes + enhancements + features | `2.0.0` | `latest` (after beta) | `release/2.0.0` | `npx gsd-hermes@next` (beta) |
 
 ## npm Dist-Tags
 
@@ -16,7 +16,7 @@ Only two tags, following Angular/Next.js convention:
 
 | Tag | Meaning | Installed by |
 |-----|---------|-------------|
-| `latest` | Stable production release | `npm install get-shit-done-cc` (default) |
+| `latest` | Stable production release | `npm install gsd-hermes` (default) |
 | `next` | Pre-release (RC or beta) | `npm install get-shit-done-cc@next` (opt-in) |
 
 The version string (`-rc.1` vs `-beta.1`) communicates stability level. Users never get pre-releases unless they explicitly opt in.
@@ -25,7 +25,7 @@ The version string (`-rc.1` vs `-beta.1`) communicates stability level. Users ne
 
 | Increment | When | Examples |
 |-----------|------|----------|
-| **PATCH** (1.27.x) | Bug fixes, typo corrections, test additions | Hook filter fix, config corruption fix |
+| **PATCH** (1.3.x) | Bug fixes, typo corrections, test additions | Hook filter fix, config corruption fix |
 | **MINOR** (1.x.0) | Non-breaking enhancements, new commands, new runtime support | New workflow command, discuss-mode feature |
 | **MAJOR** (x.0.0) | Breaking changes to config format, CLI flags, or runtime API; new features that alter existing behavior | Removing a command, changing config schema |
 
@@ -34,7 +34,7 @@ The version string (`-rc.1` vs `-beta.1`) communicates stability level. Users ne
 Major and minor releases use different pre-release types:
 
 ```
-Minor: 1.28.0-rc.1  →  1.28.0-rc.2  →  1.28.0
+Minor: 1.4.0-rc.1  →  1.4.0-rc.2  →  1.4.0
 Major: 2.0.0-beta.1 →  2.0.0-beta.2 →  2.0.0
 ```
 
@@ -47,11 +47,11 @@ Major: 2.0.0-beta.1 →  2.0.0-beta.2 →  2.0.0
 ```
 main                              ← stable, always deployable
   │
-  ├── hotfix/1.27.1               ← patch: cherry-pick fix from main, publish to latest
+  ├── hotfix/1.3.1               ← patch: cherry-pick fix from main, publish to latest
   │
-  ├── release/1.28.0              ← minor: accumulate fixes + enhancements, RC cycle
-  │     ├── v1.28.0-rc.1          ← tag: published to next
-  │     └── v1.28.0               ← tag: promoted to latest
+  ├── release/1.4.0              ← minor: accumulate fixes + enhancements, RC cycle
+  │     ├── v1.4.0-rc.1          ← tag: published to next
+  │     └── v1.4.0               ← tag: promoted to latest
   │
   ├── release/2.0.0               ← major: features + breaking changes, beta cycle
   │     ├── v2.0.0-beta.1         ← tag: published to next
@@ -69,8 +69,8 @@ main                              ← stable, always deployable
 
 For critical bugs that can't wait for the next minor release.
 
-1. Trigger `hotfix.yml` with version (e.g., `1.27.1`)
-2. Workflow creates `hotfix/1.27.1` branch from the latest patch tag for that minor version (e.g., `v1.27.0` or `v1.27.1`)
+1. Trigger `hotfix.yml` with version (e.g., `1.3.1`)
+2. Workflow creates `hotfix/1.3.1` branch from the latest patch tag for that minor version (e.g., `v1.27.0` or `v1.3.1`)
 3. Cherry-pick or apply fix on the hotfix branch
 4. Push — CI runs tests automatically
 5. Trigger `hotfix.yml` finalize action
@@ -81,12 +81,12 @@ For critical bugs that can't wait for the next minor release.
 
 For accumulated fixes and enhancements.
 
-1. Trigger `release.yml` with action `create` and version (e.g., `1.28.0`)
-2. Workflow creates `release/1.28.0` branch from main, bumps package.json
-3. Trigger `release.yml` with action `rc` to publish `1.28.0-rc.1` to `next`
-4. Test the RC: `npx get-shit-done-cc@next`
+1. Trigger `release.yml` with action `create` and version (e.g., `1.4.0`)
+2. Workflow creates `release/1.4.0` branch from main, bumps package.json
+3. Trigger `release.yml` with action `rc` to publish `1.4.0-rc.1` to `next`
+4. Test the RC: `npx gsd-hermes@next`
 5. If issues found: fix on release branch, publish `rc.2`, `rc.3`, etc.
-6. Trigger `release.yml` with action `finalize` — publishes `1.28.0` to `latest`
+6. Trigger `release.yml` with action `finalize` — publishes `1.4.0` to `latest`
 7. Merge release branch to main
 
 ### Major Release
@@ -122,5 +122,5 @@ npm publish
 npm publish --tag next
 
 # Verify what latest and next point to
-npm dist-tag ls get-shit-done-cc
+npm dist-tag ls gsd-hermes
 ```

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -4,6 +4,12 @@
 
 ---
 
+## GSD Hermes v1.4 Release Note
+
+`gsd-hermes@1.4.0` syncs the command surface with upstream `get-shit-done@cd057255` while keeping Hermes command files installable through the downstream package. Upstream-owned Claude/Qwen assets may reference the newer `gsd:<command>` identity, but Hermes-installed commands remain available through the `gsd-<command>` frontmatter names expected by Hermes command discovery.
+
+---
+
 ## Command Syntax
 
 - **Claude Code / Gemini / Copilot:** `/gsd-command-name [args]`

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,6 +4,12 @@
 
 ---
 
+## GSD Hermes v1.4 Release Note
+
+`gsd-hermes@1.4.0` carries upstream config and SDK query fixes through `upstream/main@cd057255`, including runtime-aware model override propagation, config-schema parity checks, workstream-aware query dispatch, ROADMAP checkbox precedence, and state frontmatter mutation guards. Hermes keeps the downstream default of avoiding silent model fallback: configured model bindings must resolve as configured or fail with actionable diagnostics.
+
+---
+
 ## Configuration File
 
 GSD stores project settings in `.planning/config.json`. Created during `/gsd-new-project`, updated via `/gsd-settings`.

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -8,12 +8,14 @@ Use the `Publish npm` workflow in `.github/workflows/publish-npm.yml`.
 
 The workflow validates the package name and version, runs the test suite, checks the npm tarball with `npm pack --dry-run`, publishes to npm, and verifies that the expected package version is visible in the npm registry.
 
-For the upcoming `gsd-hermes@1.2.0` Cross-Provider Agent Execution release, keep the publishing flow simple:
+For the `gsd-hermes@1.4.0` upstream-sync release, use the formal `Release` workflow rather than republishing the already-published `1.3.0` package:
 
-1. Update README / CHANGELOG / release notes first.
-2. Run `Publish npm` with `dry_run: true`.
-3. If dry run is clean, rerun with `dry_run: false`.
-4. Prefer `auth_mode: trusted-publishing`, but keep `npm-token` as the break-glass fallback until issue #6 is closed.
+1. Merge release docs and workflow readiness updates to `main`.
+2. Run `Release` with `action=create`, `version=1.4.0`.
+3. Run `Release` with `action=rc`, `version=1.4.0` to publish `1.4.0-rc.1` to `next`.
+4. Validate the RC install path with `npx gsd-hermes@next`.
+5. Run `Release` with `action=finalize`, `version=1.4.0` to publish `latest`.
+6. Merge the release branch back to `main` so the repository version matches the published package.
 
 ## Publish Workflow Inputs
 

--- a/docs/releases/v1.4.0-upstream-sync-cd057255.md
+++ b/docs/releases/v1.4.0-upstream-sync-cd057255.md
@@ -1,0 +1,68 @@
+# gsd-hermes v1.4.0 — Upstream Sync to get-shit-done cd057255
+
+Release date: 2026-04-25
+Package: `gsd-hermes@1.4.0`
+Upstream GSD base: `upstream/main@cd057255`
+Previous package: `gsd-hermes@1.3.0`
+Previous upstream base: `upstream/main@0a049149`
+
+## Summary
+
+`gsd-hermes@1.4.0` publishes the upstream alignment that merged `gsd-build/get-shit-done` through `upstream/main@cd057255` into the Hermes downstream package line.
+
+This release is intended for users who want the latest synced GSD workflow/SDK fixes while continuing to install and run through the Hermes-focused `gsd-hermes` package.
+
+## Highlights
+
+- Syncs 25 upstream commits after the `v1.3.0` base.
+- Preserves the independent `gsd-hermes` package identity and Hermes runtime adapter.
+- Keeps Hermes command discovery compatible with hyphenated command frontmatter while importing upstream colon-form Claude/Qwen behavior where upstream owns the path.
+- Adds upstream tarball guardrails that build SDK dist artifacts and verify `sdk/dist/cli.js` ships in the package.
+- Imports upstream SDK/query regression coverage for config schema parity, state mutation, roadmap handling, sub-repo root resolution, init progress precedence, and workflow-agent skill consistency.
+
+## Notable fixes from upstream
+
+- Per-agent model overrides now propagate through Codex/OpenCode transports.
+- Workstream-aware query dispatch and root state synchronization are improved.
+- ROADMAP checkbox precedence and milestone state/frontmatter mutation are hardened.
+- `gsd-sdk query` failures are surfaced instead of silently swallowed.
+- Installer behavior fails fast when SDK dist artifacts are missing rather than attempting unsafe nested npm installs.
+- Tarball publication now validates that bundled SDK dist files are present before publishing.
+
+## Hermes-specific compatibility retained
+
+- Hermes install remains available through:
+
+```bash
+npx gsd-hermes --hermes --global
+```
+
+- Stable package install after this release:
+
+```bash
+npm install -g gsd-hermes@latest
+# or
+npx gsd-hermes@latest --hermes --global
+```
+
+- Hermes-owned skill frontmatter remains command-discoverable by Hermes. Upstream-owned Claude/Qwen colon-form paths remain tracked separately.
+- Model/runtime routing remains strict: configured per-agent model bindings should run as configured or fail with actionable diagnostics, not silently fall back.
+
+## Verification
+
+Before release preparation:
+
+- `git diff --check`
+- `node --test tests/bug-2649-sdk-fail-fast.test.cjs tests/stale-colon-refs.test.cjs`
+- `node --test tests/bugs-1656-1657.test.cjs tests/hermes-install.test.cjs tests/hermes-core-workflow.test.cjs tests/hermes-lifecycle.test.cjs`
+- `npm run test:hermes`
+- `npm test` — 5591 tests passed
+- Pull request CI for the upstream sync passed before merge.
+
+The formal release workflow additionally runs `npm ci`, `npm run test:coverage`, `npm run build:sdk`, `scripts/verify-tarball-sdk-dist.sh`, `npm publish --dry-run --tag latest`, npm publish verification, and GitHub Release creation.
+
+## Links
+
+- Upstream sync PR: https://github.com/pingchesu/gsd-hermes/pull/26
+- Upstream sync tracking issue: https://github.com/pingchesu/gsd-hermes/issues/27
+- Upstream repository: https://github.com/gsd-build/get-shit-done


### PR DESCRIPTION
## Summary

- Prepare release-facing docs for `gsd-hermes@1.4.0`.
- Add curated release notes for the upstream sync to `upstream/main@cd057255`.
- Refresh README, CHANGELOG, COMMANDS, CONFIGURATION, npm publishing guidance, and VERSIONING examples before the formal release workflow runs.

## Validation

- [x] `git diff --check`
- [x] `npm run test:hermes`

## Release plan after merge

1. Run Release workflow: `action=create`, `version=1.4.0`.
2. Run Release workflow: `action=rc`, `version=1.4.0`.
3. Validate `gsd-hermes@next`.
4. Run Release workflow: `action=finalize`, `version=1.4.0`.
5. Merge `release/1.4.0` back to main if the workflow-created PR needs manual follow-up.

Closes #28
