### PR TITLE
chore: merge release v1.4.0 to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.4.0",
+  "version": "1.4.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.4.0",
+      "version": "1.4.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.4.0-rc.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.4.0-rc.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A get-shit-done fork that adds Hermes Agent runtime support while preserving upstream GSD workflows.",
   "bin": {
     "gsd-hermes": "bin/install.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.4.0-rc.1",
+  "version": "1.4.0",
   "description": "A get-shit-done fork that adds Hermes Agent runtime support while preserving upstream GSD workflows.",
   "bin": {
     "gsd-hermes": "bin/install.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.4.0",
+  "version": "1.4.0-rc.1",
   "description": "A get-shit-done fork that adds Hermes Agent runtime support while preserving upstream GSD workflows.",
   "bin": {
     "gsd-hermes": "bin/install.js",


### PR DESCRIPTION
## Summary

Merge `release/1.4.0` back to `main` after the stable `gsd-hermes@1.4.0` publish.

## Release status

- npm package published: `gsd-hermes@1.4.0`
- npm dist-tags verified: `latest -> 1.4.0`, `next -> 1.4.0`
- GitHub Release created: https://github.com/pingchesu/gsd-hermes/releases/tag/v1.4.0
- Release workflow run: https://github.com/pingchesu/gsd-hermes/actions/runs/24926059533

## Repository delta

This PR brings the release branch version bump back to `main`:

- `package.json`: `1.3.0` -> `1.4.0`
- `package-lock.json`: `1.3.0` -> `1.4.0`

## Verification

- Release workflow `create`: success
- Release workflow `rc`: success, published `1.4.0-rc.1` to `next`
- RC install path checked via `npx gsd-hermes@next`
- Release workflow `finalize`: success, published `1.4.0` to `latest`
- Registry verified with `npm view gsd-hermes dist-tags`

Closes #30
