### PR TITLE
Ship Hermes runtime model binding receipts

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,124 @@
+# GSD Hermes
+
+## What This Is
+
+`gsd-hermes` is a downstream fork of [gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done) that preserves the upstream GSD workflow and adds first-class Hermes Agent runtime support, cross-provider runtime/model execution semantics, and independent release cadence. Published to npm as `gsd-hermes`, it lets users install the GSD workflow into Hermes (and other runtimes already supported by upstream) without waiting for upstream to carry Hermes-specific maintenance cost.
+
+## Core Value
+
+A user running Hermes Agent can `npx gsd-hermes --hermes --global` and immediately use the standard GSD workflow (plan, execute, verify) with Hermes-native runtime/model semantics, while the fork tracks closely behind upstream GSD.
+
+## Current Milestone: v1.4 Hermes Runtime Model Binding Receipts
+
+**Goal:** Make GSD/Hermes per-agent model overrides observable, enforceable, and impossible to silently ignore at runtime.
+
+**Target features:**
+- `/gsd-plan-phase` and `/gsd-execute-phase` emit per-agent model binding receipts before spawning work.
+- Hermes subagents receive the configured per-agent model through a real binding channel, or GSD fails fast before spawn.
+- Explicit `model_overrides` cannot silently fall back to the parent/default Hermes model.
+- Regression tests prove invalid explicit models fail, child `AIAgent.model` matches the expected override, and provider request metadata is inspectable.
+
+## Requirements
+
+### Validated
+
+<!-- Shipped and confirmed valuable. -->
+
+**v1.0 — Fork Foundation (Cross-Provider Agent Execution baseline):**
+- ✓ Independent `gsd-hermes` npm package identity preserved alongside upstream `get-shit-done-cc` — v1.0
+- ✓ Hermes runtime installer (`bin/install.js`) with path ownership and runtime selection — v1.0
+- ✓ Fork rationale, version strategy, and compatibility docs in `docs/` and `README.md` — v1.0
+- ✓ npm publish workflow and CI smoke tests for the fork — v1.0
+
+**v1.1 — Upstream Sync and Release (synced to `get-shit-done-cc@1.38.2`):**
+- ✓ **SYNC-01..04** — Traceable upstream merge from upstream base with conflict ownership routing — v1.1
+- ✓ **HERM-01..04** — Hermes install, local/external-dir, SDK query, non-Claude model config preserved after merge — v1.1
+- ✓ **REL-01..05** — `npm run test:hermes`, package metadata update, PR, CI publish — v1.1
+
+**v1.2 — Cross-Provider Agent Execution (shipped 2026-04-22):**
+- ✓ Strict runtime/model binding semantics shared between SDK and legacy CJS via `model-profiles.cjs` adapter — v1.2
+- ✓ `resolve_model_ids: "omit"` behavior for inherit and runtime-default bindings — v1.2
+- ✓ Cross-provider `cross_ai_execution` fallback config recognition — v1.2
+- ✓ Parity test matrix (`tests/runtime-model-parity.test.cjs`) preventing SDK/legacy contract drift — v1.2
+
+**v1.3 — Upstream Sync to v1.39-main + Runtime-Aware Profile Compatibility (shipped 2026-04-24 as `gsd-hermes@1.3.0`, GitHub Release `v1.3.0`):**
+- ✓ **SYNC-01..05** — Upstream synced `v1.38.2 → upstream/main@0a049149` (97 commits); sync log `docs/sync-logs/2026-04-sync-0a049149.md` with 56 per-hunk `bin/install.js` rows + 226 per-file category rows — v1.3
+- ✓ **HERM-01..04** — Install (global + external-dir + macOS canonicalization), SDK query, non-Claude model config all preserved post-merge — v1.3
+- ✓ **PROFILE-01..04** — Upstream #2517 runtime-aware profiles compose with Hermes v1.2 adapter via 13-row parity matrix; PROFILE-03 inherit-projection fixed via `options.initContext` — v1.3
+- ✓ **SLASH-01..02** — Dual-track `/gsd:` (upstream #2543) / `/gsd-` (Hermes skills) syntax coexistence per `docs/hermes-compatibility.md §Slash Command Inventory` — v1.3
+- ✓ **INST-01..02** — SDK install decoupled (upstream #2441), `sdk/dist` shipped in tarball; `sdk/dist/cli.js` three-layer chmod 0o755 defense — v1.3
+- ✓ **REL-01..05** — `npm test` 5505/5505, `npm run test:hermes` 97+25; CHANGELOG + README rewritten Hermes-first; PR #24 squash-merged; `gsd-hermes@1.3.0@latest` on npm; GitHub Release `v1.3.0` — v1.3
+- ✓ **ARCHIVE-01..03** — v1.2 MILESTONES.md §Requirements + RETROSPECTIVE.md v1.2 section + Cross-Milestone Trends rows all backfilled — v1.3
+
+### Active
+
+<!-- Current scope. Building toward these. -->
+
+**v1.4 — Hermes Runtime Model Binding Receipts:**
+- [ ] **RCPT-01..04** — Users can see binding receipts for every spawned GSD agent, including configured/resolved model, runtime/provider, source, binding kind, and enforcement path.
+- [ ] **BIND-01..04** — Hermes receives per-agent model bindings through an explicit runtime channel, or GSD reports that the binding cannot be enforced before any subagent is spawned.
+- [ ] **ENF-01..03** — Explicit overrides fail fast when unsupported or unprovable; invalid model smoke tests cannot pass through parent/default fallback.
+- [ ] **TEST-01..04** — SDK, workflow, Hermes child construction, and provider-request diagnostics have regression coverage for no-silent-fallback behavior.
+- [ ] **REL-01..04** — Tracker issue/PR/release docs document the root cause, solution, validation evidence, and `gsd-hermes@1.4.0` release path.
+
+### Out of Scope
+
+<!-- Explicit boundaries. Includes reasoning to prevent re-adding. -->
+
+- **Rebase-only sync strategy** — Merge commits preserve traceable upstream history across repeated syncs; rebase erases that audit trail
+- **Direct npm publish without PR** — Downstream fork must preserve both upstream and Hermes behavior; PR review is the gate that catches regressions in either
+- **Upstream prerelease `v1.39.0-rc.1` as the pinned sync target** — rc.1 predates the runtime-aware model profiles commit the fork needs to verify (`cc17886c`); we target `upstream/main@0a049149` instead
+- **New Hermes feature work unrelated to this sync** — scope kept to merge + compatibility + release to avoid cross-cutting risk in a 97-commit sync
+- **Automated upstream sync preflight / automated release notes** — tracked as future AUTO-01/AUTO-02 from v1.1 carryover; valuable but not required for v1.3
+
+## Context
+
+- Upstream GSD maintainers [declined Hermes runtime support in core](https://github.com/gsd-build/get-shit-done/issues/2272#issuecomment-4254178547) citing installer leanness and long-term maintenance cost
+- Fork ownership rules are codified in `docs/fork-ownership.md`: `sdk/`, `agents/`, `commands/`, `hooks/`, `get-shit-done/` are upstream-owned; `bin/install.js` and `tests/` are Hermes adapter seam; `.planning/`, `AGENTS.md`, `docs/` are downstream governance
+- `.planning/` is gitignored — planning state is local, not part of the published package or PRs
+- Previous sync (v1.1) established the repeatable 4-phase pattern: merge baseline → Hermes compat → release metadata → PR-release
+- v1.2 milestone planning artifacts were not formally archived (no `/gsd-complete-milestone` run); v1.3 backfills that gap
+- Downstream semver is independent from upstream; fork ships its own release story and records the upstream base explicitly in README/CHANGELOG
+- v1.4 addresses a discovered runtime-truthfulness gap: GSD can resolve `.planning/config.json` `model_overrides` and render `Task(model=...)` strings, but current Hermes `delegate_task` has no per-call `model` field and children inherit the parent model when `delegation.model` is unset.
+
+## Constraints
+
+- **Tech stack**: Node.js package with CJS + SDK in TypeScript (compiled), installer in plain JS, tests in `node --test` + Vitest (SDK only)
+- **Compatibility**: Must support every runtime upstream supports (Claude Code, OpenCode, Gemini, Codex, Cursor, Windsurf, Antigravity, Augment, Trae, Qwen Code, Cline, CodeBuddy, Copilot, Kilo) plus Hermes; regressions on any of these block release
+- **Release**: Two-step external action — npm publish dry-run must pass before actual publish; GitHub release tag follows npm release version (`v1.3.0`)
+- **Fork maintenance**: Downstream deltas must stay concentrated in the adapter seam paths to keep merges tractable; broad workflow rewrites are deferred unless explicitly decided
+- **Scanning performance**: Base64-heavy upstream diffs have historically stressed CI security scans (v1.1 hit this); sync milestones must budget for scan efficiency
+
+## Key Decisions
+
+<!-- Decisions that constrain future work. Add throughout project lifecycle. -->
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Keep upstream repo layout at root; no restructuring | Merge-friendliness per `docs/fork-ownership.md` D-03 | ✓ Good — v1.1 and v1.2 syncs stayed tractable |
+| Downstream semver independent from upstream version | Fork ships its own release story; conflating versions confuses users | ✓ Good — validated at v1.0, v1.1, v1.2 |
+| `.planning/` is gitignored fork-local governance | Prevents planning artifacts leaking into product PRs and keeps milestones private to maintainer | ✓ Good — observed at v1.1 |
+| Two-step npm release (dry-run then publish) | Prior CI issues would have shipped broken tarballs; dry-run catches them | ✓ Good — v1.1 caught real CI drift |
+| Target `upstream/main@0a049149` for v1.3 (not `v1.39.0-rc.1`) | rc.1 predates `cc17886c` runtime-aware model profiles which must be verified against Hermes runtime-model adapter | — Pending |
+| Record `resolves_phase` on phase dirs to detect archive gaps | v1.2 milestone closed without archival; v1.3 adds explicit backfill step | — Pending |
+| Treat Hermes per-agent model binding as a runtime proof problem, not just resolver correctness | Resolver metadata and workflow strings do not prove spawned Hermes subagents used the requested model; explicit overrides must be observable and enforceable | — Pending |
+
+## Evolution
+
+This document evolves at phase transitions and milestone boundaries.
+
+**After each phase transition** (via `/gsd-transition`):
+1. Requirements invalidated? → Move to Out of Scope with reason
+2. Requirements validated? → Move to Validated with phase reference
+3. New requirements emerged? → Add to Active
+4. Decisions to log? → Add to Key Decisions
+5. "What This Is" still accurate? → Update if drifted
+
+**After each milestone** (via `/gsd-complete-milestone`):
+1. Full review of all sections
+2. Core Value check — still the right priority?
+3. Audit Out of Scope — reasons still valid?
+4. Update Context with current state
+
+---
+*Last updated: 2026-04-25 after milestone v1.4 initialization*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -39,7 +39,7 @@
 - [ ] **REL-01**: A GitHub tracker issue exists for the v1.4 root cause and acceptance criteria: Hermes `/gsd` commands must emit and enforce per-agent model binding receipts.
 - [ ] **REL-02**: Documentation explains how users can verify resolver output, workflow receipt output, Hermes child construction, and provider request model metadata.
 - [ ] **REL-03**: `README.md`, `COMMANDS.md`, `CONFIGURATION.md`, and release notes describe strict per-agent model binding semantics for Hermes.
-- [ ] **REL-04**: The next publishable v1.4 patch release is released after tests and CI pass, with GitHub Release and npm publish evidence recorded. Discovery on 2026-04-26 found `gsd-hermes@1.4.0` already published, so execution should default to `gsd-hermes@1.4.1` unless the maintainer chooses a different semver.
+- [ ] **REL-04**: The next publishable v1.4 patch release is released after tests and CI pass, with GitHub Release and npm publish evidence recorded. Discovery on 2026-04-26 found `gsd-hermes@1.4.0` already published, so execution should default to `gsd-hermes@1.4.30` unless the maintainer chooses a different semver.
 
 ## Future Requirements
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,105 @@
+# Requirements: GSD Hermes v1.4 Hermes Runtime Model Binding Receipts
+
+**Defined:** 2026-04-25
+**Core Value:** A user running Hermes Agent can `npx gsd-hermes --hermes --global` and immediately use the standard GSD workflow with Hermes-native runtime/model semantics, while the fork tracks closely behind upstream GSD.
+
+**Milestone scope summary:** Fix the gap where GSD resolver and workflow surfaces can show explicit per-agent `model_overrides`, but Hermes spawned subagents may still inherit the parent/default model because the current Hermes `delegate_task` interface has no per-call `model` binding. This milestone makes model binding receipts visible, adds or proves a real Hermes binding channel, and fails fast whenever explicit overrides cannot be enforced.
+
+## v1.4 Requirements
+
+### Binding Receipts
+
+- [ ] **RCPT-01**: User can run `gsd-sdk query init.plan-phase <phase>` and see structured binding metadata for researcher, planner, and checker agents: agent, configured model, resolved model, source, binding kind, runtime, provider/family, and enforceability status.
+- [ ] **RCPT-02**: User can run `gsd-sdk query init.execute-phase <phase>` and see structured binding metadata for executor and verifier agents with the same fields as plan-phase.
+- [ ] **RCPT-03**: User running `/gsd-plan-phase` or `/gsd-execute-phase` in Hermes sees a concise binding receipt before subagents spawn, so the effective runtime/model intent is visible in the transcript.
+- [ ] **RCPT-04**: Receipt output clearly distinguishes resolver truth from runtime proof: `resolved_by_gsd`, `passed_to_runtime`, and `runtime_enforced` must not be conflated.
+
+### Hermes Binding Channel
+
+- [ ] **BIND-01**: Maintainer can identify the exact Hermes runtime channel used to set child agent model (`delegate_task model`, ACP `--model`, generated config, or another explicit path) and document it in code comments/tests.
+- [ ] **BIND-02**: When a GSD workflow specifies an explicit per-agent model override, the Hermes child `AIAgent` is constructed with that model rather than inheriting the parent model by default.
+- [ ] **BIND-03**: Batch subagent spawning preserves per-task model bindings; different agents in the same workflow can use different configured models where the runtime supports it.
+- [ ] **BIND-04**: If Hermes cannot support per-agent explicit model binding for a workflow path, GSD reports that limitation before spawning and points to the config/runtime setting that must change.
+
+### Fail-Fast Enforcement
+
+- [ ] **ENF-01**: Explicit `model_overrides` that are unsupported, unknown to the runtime, or not enforceable by Hermes cause a clear actionable error before any subagent begins work.
+- [ ] **ENF-02**: An intentionally invalid override such as `definitely-not-a-real-model-gsd-binding-test` cannot complete successfully by falling back to the parent/default Hermes model.
+- [ ] **ENF-03**: `workflow.cross_ai_execution` remains an explicit alternative path, but GSD never silently routes or falls back without reporting the effective execution mode.
+
+### Regression Tests and Diagnostics
+
+- [ ] **TEST-01**: SDK tests assert `init.plan-phase` and `init.execute-phase` include binding receipt metadata for override, inherit, and runtime-default cases.
+- [ ] **TEST-02**: Hermes integration/unit tests prove the child agent receives the expected model from a GSD-originated explicit override.
+- [ ] **TEST-03**: A no-silent-fallback test proves invalid explicit model names fail before or at provider request time instead of succeeding with the parent/default model.
+- [ ] **TEST-04**: Development diagnostics can expose provider request `model` metadata without leaking API keys, tokens, credentials, or connection strings.
+
+### Release and Tracking
+
+- [ ] **REL-01**: A GitHub tracker issue exists for the v1.4 root cause and acceptance criteria: Hermes `/gsd` commands must emit and enforce per-agent model binding receipts.
+- [ ] **REL-02**: Documentation explains how users can verify resolver output, workflow receipt output, Hermes child construction, and provider request model metadata.
+- [ ] **REL-03**: `README.md`, `COMMANDS.md`, `CONFIGURATION.md`, and release notes describe strict per-agent model binding semantics for Hermes.
+- [ ] **REL-04**: `gsd-hermes@1.4.0` is released after tests and CI pass, with GitHub Release and npm publish evidence recorded.
+
+## Future Requirements
+
+### Runtime Proof UI
+
+- **UI-01**: Hermes `/agents` or equivalent runtime UI can show each live subagent's provider/model/source while it is running.
+- **UI-02**: Runtime receipts can be exported as structured audit artifacts for long-running GSD workflows.
+
+### Multi-Runtime Model Binding
+
+- **MRT-01**: Apply the same runtime proof pattern to other non-Claude runtimes where workflow-level `Task(model=...)` semantics may not map cleanly to the host runtime.
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Rewriting GSD workflows to be Hermes-native only | Fork must remain GSD-first and upstream-syncable; prefer adapter/seam changes over broad workflow rewrites |
+| Assuming resolver success proves runtime enforcement | This milestone exists because resolver truth and runtime truth are different layers |
+| Silent fallback from explicit override to parent/default model | Violates strict model binding semantics and hides expensive/wrong-model execution |
+| Storing or printing credentials in diagnostics | Diagnostics must redact API keys, tokens, passwords, and connection strings |
+| Upstream sync unrelated to this binding issue | Keep v1.4 focused on runtime truthfulness; upstream sync resumes in a separate milestone if needed |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| RCPT-01 | Phase 10 | Pending |
+| RCPT-02 | Phase 10 | Pending |
+| RCPT-03 | Phase 10 | Pending |
+| RCPT-04 | Phase 10 | Pending |
+| BIND-01 | Phase 11 | Pending |
+| BIND-02 | Phase 11 | Pending |
+| BIND-03 | Phase 11 | Pending |
+| BIND-04 | Phase 11 | Pending |
+| ENF-01 | Phase 12 | Pending |
+| ENF-02 | Phase 12 | Pending |
+| ENF-03 | Phase 12 | Pending |
+| TEST-01 | Phase 12 | Pending |
+| TEST-02 | Phase 12 | Pending |
+| TEST-03 | Phase 12 | Pending |
+| TEST-04 | Phase 12 | Pending |
+| REL-01 | Phase 13 | Pending |
+| REL-02 | Phase 13 | Pending |
+| REL-03 | Phase 13 | Pending |
+| REL-04 | Phase 13 | Pending |
+
+**Coverage:**
+- v1.4 requirements: 19 total
+- Mapped to phases: 19 (100%)
+- Unmapped: 0 ✓
+
+### Phase Coverage Distribution
+
+| Phase | Count | Requirements |
+|-------|-------|--------------|
+| Phase 10 — Runtime Binding Receipt Surface | 4 | RCPT-01, RCPT-02, RCPT-03, RCPT-04 |
+| Phase 11 — Hermes Per-Agent Binding Channel | 4 | BIND-01, BIND-02, BIND-03, BIND-04 |
+| Phase 12 — Fail-Fast Validation and Proof Tests | 7 | ENF-01, ENF-02, ENF-03, TEST-01, TEST-02, TEST-03, TEST-04 |
+| Phase 13 — Tracker, Documentation, Release | 4 | REL-01, REL-02, REL-03, REL-04 |
+
+---
+*Requirements defined: 2026-04-25*
+*Last updated: 2026-04-25 after roadmap phase mapping (v1.4)*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -39,7 +39,7 @@
 - [ ] **REL-01**: A GitHub tracker issue exists for the v1.4 root cause and acceptance criteria: Hermes `/gsd` commands must emit and enforce per-agent model binding receipts.
 - [ ] **REL-02**: Documentation explains how users can verify resolver output, workflow receipt output, Hermes child construction, and provider request model metadata.
 - [ ] **REL-03**: `README.md`, `COMMANDS.md`, `CONFIGURATION.md`, and release notes describe strict per-agent model binding semantics for Hermes.
-- [ ] **REL-04**: `gsd-hermes@1.4.0` is released after tests and CI pass, with GitHub Release and npm publish evidence recorded.
+- [ ] **REL-04**: The next publishable v1.4 patch release is released after tests and CI pass, with GitHub Release and npm publish evidence recorded. Discovery on 2026-04-26 found `gsd-hermes@1.4.0` already published, so execution should default to `gsd-hermes@1.4.1` unless the maintainer chooses a different semver.
 
 ## Future Requirements
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -13,7 +13,7 @@
 ## Phases
 
 - [x] **Phase 10: Runtime Binding Receipt Surface** — Extend SDK init payloads and Hermes-visible workflow output so users can see per-agent model binding receipts before any GSD subagent is spawned.
-- [ ] **Phase 11: Hermes Per-Agent Binding Channel** — Implement or prove the runtime channel that carries GSD per-agent model overrides into Hermes child agents; if the channel cannot enforce a binding, stop before spawn.
+- [x] **Phase 11: Hermes Per-Agent Binding Channel** — Implement or prove the runtime channel that carries GSD per-agent model overrides into Hermes child agents; if the channel cannot enforce a binding, stop before spawn.
 - [ ] **Phase 12: Fail-Fast Validation and Proof Tests** — Add invalid-model, child-construction, receipt, and provider-request diagnostics tests proving explicit overrides cannot silently fall back.
 - [ ] **Phase 13: Tracker, Documentation, Release** — Open/maintain tracker issue, update docs and release notes, run CI/PR flow, and publish `gsd-hermes@1.4.0` after validation.
 
@@ -59,17 +59,17 @@ Plans:
   3. Batch/multi-agent workflows can assign different configured models to different agents where the runtime supports it.
   4. If no enforceable channel exists for a path, GSD emits a clear pre-spawn validation error that names the agent, configured model, runtime, and suggested fix.
 
-**Plans:** 3/3 plans created; 0/3 plans executed
+**Plans:** 3/3 plans executed
 
 Plans:
 **Wave 1**
-- [ ] 11-01-PLAN.md — Trace Hermes delegation entry points and choose the smallest upstream-syncable binding seam.
+- [x] 11-01-PLAN.md — Trace Hermes delegation entry points and choose the smallest upstream-syncable binding seam.
 
 **Wave 2** *(blocked on Wave 1 completion)*
-- [ ] 11-02-PLAN.md — Implement binding propagation for single and batch subagent spawns, preserving existing inheritance behavior when no explicit override is configured.
+- [x] 11-02-PLAN.md — Implement binding propagation for single and batch subagent spawns, preserving existing inheritance behavior when no explicit override is configured.
 
 **Wave 3** *(blocked on Wave 2 completion)*
-- [ ] 11-03-PLAN.md — Add pre-spawn unsupported-path errors and update runtime capability semantics so Hermes does not overclaim enforcement.
+- [x] 11-03-PLAN.md — Add pre-spawn unsupported-path errors and update runtime capability semantics so Hermes does not overclaim enforcement.
 
 ### Phase 12: Fail-Fast Validation and Proof Tests
 
@@ -120,7 +120,7 @@ Plans:
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
 | 10. Runtime Binding Receipt Surface | 3/3 | Complete | 2026-04-26 |
-| 11. Hermes Per-Agent Binding Channel | 0/3 | Planned | - |
+| 11. Hermes Per-Agent Binding Channel | 3/3 | Complete | 2026-04-26 |
 | 12. Fail-Fast Validation and Proof Tests | 0/4 | Planned | - |
 | 13. Tracker, Documentation, Release | 0/3 | Planned | - |
 
@@ -141,7 +141,7 @@ Plans:
 
 ## Next Action
 
-Proceed to Phase 11 execution via `/gsd-execute-phase 11`.
+Proceed to Phase 12 planning via `/gsd-plan-phase 12`.
 
 ---
 *Roadmap created: 2026-04-25*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -86,7 +86,7 @@ Plans:
   4. `workflow.cross_ai_execution` stays explicit and observable; no automatic or silent cross-runtime fallback is introduced.
   5. Full relevant test gates pass (`npm run test:hermes`, runtime-model parity tests, and any new Hermes binding tests).
 
-**Plans:** 0/4 plans executed
+**Plans:** 4/4 plans created; 0/4 plans executed
 
 Plans:
 - [ ] 12-01-PLAN.md — Add SDK validation tests for enforceability errors and receipt metadata across override/inherit/runtime-default cases.
@@ -141,7 +141,7 @@ Plans:
 
 ## Next Action
 
-Proceed to Phase 12 planning via `/gsd-plan-phase 12`.
+Proceed to Phase 12 execution via `/gsd-execute-phase 12`.
 
 ---
 *Roadmap created: 2026-04-25*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -106,14 +106,14 @@ Plans:
   1. A GitHub issue or PR tracker documents root cause, static evidence (`delegate_task` lacks per-call model), runtime evidence, acceptance criteria, and validation commands.
   2. README, COMMANDS.md, CONFIGURATION.md, and release notes explain how Hermes per-agent model overrides are resolved, passed, enforced, and diagnosed.
   3. A PR against `main` contains the implementation, tests, docs, and explicit validation evidence; CI passes before merge.
-  4. `gsd-hermes@1.4.0` is published to npm and a GitHub Release `v1.4.0` exists with release notes and verification evidence.
+  4. The next publishable v1.4 patch release is published to npm and a matching GitHub Release exists with release notes and verification evidence. Discovery on 2026-04-26 found `gsd-hermes@1.4.0` and GitHub Release `v1.4.0` already exist, so execution should default to `1.4.1` unless the maintainer chooses a different semver.
 
-**Plans:** 0/3 plans executed
+**Plans:** 3/3 plans created; 0/3 plans executed
 
 Plans:
 - [ ] 13-01-PLAN.md — Open/update GitHub tracker issue and prepare PR body acceptance checklist.
-- [ ] 13-02-PLAN.md — Update README, COMMANDS.md, CONFIGURATION.md, CHANGELOG/release notes for strict Hermes model binding semantics.
-- [ ] 13-03-PLAN.md — Execute PR/CI/release flow and publish `gsd-hermes@1.4.0` after validation.
+- [ ] 13-02-PLAN.md — Update README, COMMANDS.md, CONFIGURATION.md, CHANGELOG/release notes, and publishable version metadata for strict Hermes model binding semantics.
+- [ ] 13-03-PLAN.md — Execute PR/CI/release flow and publish the next v1.4 patch release after validation.
 
 ## Progress Table
 
@@ -137,11 +137,11 @@ Plans:
 | Runtime-model parity | Yes | Existing parity tests remain green |
 | Hermes compatibility | Yes | `npm run test:hermes` passes |
 | Documentation | Yes | README, COMMANDS.md, CONFIGURATION.md, release notes updated |
-| Release | Yes | npm `gsd-hermes@1.4.0` + GitHub Release `v1.4.0` |
+| Release | Yes | next publishable v1.4 patch release (default `gsd-hermes@1.4.1`) + matching GitHub Release |
 
 ## Next Action
 
-Proceed to Phase 13 planning via `/gsd-plan-phase 13`.
+Proceed to Phase 13 execution via `/gsd-execute-phase 13`.
 
 ---
 *Roadmap created: 2026-04-25*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -14,7 +14,7 @@
 
 - [x] **Phase 10: Runtime Binding Receipt Surface** — Extend SDK init payloads and Hermes-visible workflow output so users can see per-agent model binding receipts before any GSD subagent is spawned.
 - [x] **Phase 11: Hermes Per-Agent Binding Channel** — Implement or prove the runtime channel that carries GSD per-agent model overrides into Hermes child agents; if the channel cannot enforce a binding, stop before spawn.
-- [ ] **Phase 12: Fail-Fast Validation and Proof Tests** — Add invalid-model, child-construction, receipt, and provider-request diagnostics tests proving explicit overrides cannot silently fall back.
+- [x] **Phase 12: Fail-Fast Validation and Proof Tests** — Add invalid-model, child-construction, receipt, and provider-request diagnostics tests proving explicit overrides cannot silently fall back.
 - [ ] **Phase 13: Tracker, Documentation, Release** — Open/maintain tracker issue, update docs and release notes, run CI/PR flow, and publish `gsd-hermes@1.4.0` after validation.
 
 ## Phase Details
@@ -86,13 +86,13 @@ Plans:
   4. `workflow.cross_ai_execution` stays explicit and observable; no automatic or silent cross-runtime fallback is introduced.
   5. Full relevant test gates pass (`npm run test:hermes`, runtime-model parity tests, and any new Hermes binding tests).
 
-**Plans:** 4/4 plans created; 0/4 plans executed
+**Plans:** 4/4 plans executed
 
 Plans:
-- [ ] 12-01-PLAN.md — Add SDK validation tests for enforceability errors and receipt metadata across override/inherit/runtime-default cases.
-- [ ] 12-02-PLAN.md — Add Hermes child-construction test proving expected child model/provider for GSD-originated override.
-- [ ] 12-03-PLAN.md — Add invalid-model no-silent-fallback smoke test and provider-request diagnostic coverage with credential redaction.
-- [ ] 12-04-PLAN.md — Run full regression gates and close any discovered compatibility drift.
+- [x] 12-01-PLAN.md — Add SDK validation tests for enforceability errors and receipt metadata across override/inherit/runtime-default cases.
+- [x] 12-02-PLAN.md — Add Hermes child-construction test proving expected child model/provider for GSD-originated override.
+- [x] 12-03-PLAN.md — Add invalid-model no-silent-fallback smoke test and provider-request diagnostic coverage with credential redaction.
+- [x] 12-04-PLAN.md — Run full regression gates and close any discovered compatibility drift.
 
 ### Phase 13: Tracker, Documentation, Release
 
@@ -121,7 +121,7 @@ Plans:
 |-------|----------------|--------|-----------|
 | 10. Runtime Binding Receipt Surface | 3/3 | Complete | 2026-04-26 |
 | 11. Hermes Per-Agent Binding Channel | 3/3 | Complete | 2026-04-26 |
-| 12. Fail-Fast Validation and Proof Tests | 0/4 | Planned | - |
+| 12. Fail-Fast Validation and Proof Tests | 4/4 | Complete | 2026-04-26 |
 | 13. Tracker, Documentation, Release | 0/3 | Planned | - |
 
 ## Validation Matrix
@@ -141,7 +141,7 @@ Plans:
 
 ## Next Action
 
-Proceed to Phase 12 execution via `/gsd-execute-phase 12`.
+Proceed to Phase 13 planning via `/gsd-plan-phase 13`.
 
 ---
 *Roadmap created: 2026-04-25*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -12,7 +12,7 @@
 
 ## Phases
 
-- [ ] **Phase 10: Runtime Binding Receipt Surface** — Extend SDK init payloads and Hermes-visible workflow output so users can see per-agent model binding receipts before any GSD subagent is spawned.
+- [x] **Phase 10: Runtime Binding Receipt Surface** — Extend SDK init payloads and Hermes-visible workflow output so users can see per-agent model binding receipts before any GSD subagent is spawned.
 - [ ] **Phase 11: Hermes Per-Agent Binding Channel** — Implement or prove the runtime channel that carries GSD per-agent model overrides into Hermes child agents; if the channel cannot enforce a binding, stop before spawn.
 - [ ] **Phase 12: Fail-Fast Validation and Proof Tests** — Add invalid-model, child-construction, receipt, and provider-request diagnostics tests proving explicit overrides cannot silently fall back.
 - [ ] **Phase 13: Tracker, Documentation, Release** — Open/maintain tracker issue, update docs and release notes, run CI/PR flow, and publish `gsd-hermes@1.4.0` after validation.
@@ -33,17 +33,17 @@
   3. Hermes-visible `/gsd-plan-phase` and `/gsd-execute-phase` transcript output prints a concise pre-spawn receipt table and does not require users to manually inspect JSON.
   4. Receipt labels explicitly distinguish `resolved_by_gsd`, `passed_to_runtime`, and `runtime_enforced`; fields default to conservative/unknown values rather than claiming proof that does not exist.
 
-**Plans:** 0/3 plans executed
+**Plans:** 3/3 plans executed
 
 Plans:
 **Wave 1**
-- [ ] 10-01-PLAN.md — Create the shared model-binding receipt projection used by Phase 10 init surfaces without changing legacy flat model-token behavior.
+- [x] 10-01-PLAN.md — Create the shared model-binding receipt projection used by Phase 10 init surfaces without changing legacy flat model-token behavior.
 
 **Wave 2** *(blocked on Wave 1 completion)*
-- [ ] 10-02-PLAN.md — Add structured binding receipt payloads to `init.plan-phase` and `init.execute-phase` while preserving existing flat model fields and SDK/CJS golden parity.
+- [x] 10-02-PLAN.md — Add structured binding receipt payloads to `init.plan-phase` and `init.execute-phase` while preserving existing flat model fields and SDK/CJS golden parity.
 
 **Wave 3** *(blocked on Wave 2 completion)*
-- [ ] 10-03-PLAN.md — Surface binding receipts in `/gsd-plan-phase` and `/gsd-execute-phase` transcript instructions so users see model intent and runtime proof status before subagents spawn.
+- [x] 10-03-PLAN.md — Surface binding receipts in `/gsd-plan-phase` and `/gsd-execute-phase` transcript instructions so users see model intent and runtime proof status before subagents spawn.
 
 ### Phase 11: Hermes Per-Agent Binding Channel
 
@@ -114,7 +114,7 @@ Plans:
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
-| 10. Runtime Binding Receipt Surface | 0/3 | Planned | - |
+| 10. Runtime Binding Receipt Surface | 3/3 | Complete | 2026-04-26 |
 | 11. Hermes Per-Agent Binding Channel | 0/3 | Planned | - |
 | 12. Fail-Fast Validation and Proof Tests | 0/4 | Planned | - |
 | 13. Tracker, Documentation, Release | 0/3 | Planned | - |
@@ -136,7 +136,7 @@ Plans:
 
 ## Next Action
 
-Start Phase 10: Runtime Binding Receipt Surface via `/gsd-discuss-phase 10` or `/gsd-plan-phase 10`.
+Proceed to Phase 11: Hermes Per-Agent Binding Channel via `/gsd-discuss-phase 11` or `/gsd-plan-phase 11`.
 
 ---
 *Roadmap created: 2026-04-25*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -59,11 +59,16 @@ Plans:
   3. Batch/multi-agent workflows can assign different configured models to different agents where the runtime supports it.
   4. If no enforceable channel exists for a path, GSD emits a clear pre-spawn validation error that names the agent, configured model, runtime, and suggested fix.
 
-**Plans:** 0/3 plans executed
+**Plans:** 3/3 plans created; 0/3 plans executed
 
 Plans:
+**Wave 1**
 - [ ] 11-01-PLAN.md — Trace Hermes delegation entry points and choose the smallest upstream-syncable binding seam.
+
+**Wave 2** *(blocked on Wave 1 completion)*
 - [ ] 11-02-PLAN.md — Implement binding propagation for single and batch subagent spawns, preserving existing inheritance behavior when no explicit override is configured.
+
+**Wave 3** *(blocked on Wave 2 completion)*
 - [ ] 11-03-PLAN.md — Add pre-spawn unsupported-path errors and update runtime capability semantics so Hermes does not overclaim enforcement.
 
 ### Phase 12: Fail-Fast Validation and Proof Tests
@@ -136,7 +141,7 @@ Plans:
 
 ## Next Action
 
-Proceed to Phase 11: Hermes Per-Agent Binding Channel via `/gsd-discuss-phase 11` or `/gsd-plan-phase 11`.
+Proceed to Phase 11 execution via `/gsd-execute-phase 11`.
 
 ---
 *Roadmap created: 2026-04-25*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,137 @@
+# Roadmap: GSD Hermes v1.4 Hermes Runtime Model Binding Receipts
+
+## Current Milestone: v1.4 Hermes Runtime Model Binding Receipts
+
+**Status:** Active
+
+**Milestone:** v1.4 Hermes Runtime Model Binding Receipts
+**Created:** 2026-04-25
+**Downstream package line:** `gsd-hermes@1.4.0`
+
+**Phase numbering:** Phases continue from v1.3 (which used Phase 6 through Phase 9 plus urgent Phase 09.1). v1.4 phases start at **Phase 10**.
+
+## Phases
+
+- [ ] **Phase 10: Runtime Binding Receipt Surface** — Extend SDK init payloads and Hermes-visible workflow output so users can see per-agent model binding receipts before any GSD subagent is spawned.
+- [ ] **Phase 11: Hermes Per-Agent Binding Channel** — Implement or prove the runtime channel that carries GSD per-agent model overrides into Hermes child agents; if the channel cannot enforce a binding, stop before spawn.
+- [ ] **Phase 12: Fail-Fast Validation and Proof Tests** — Add invalid-model, child-construction, receipt, and provider-request diagnostics tests proving explicit overrides cannot silently fall back.
+- [ ] **Phase 13: Tracker, Documentation, Release** — Open/maintain tracker issue, update docs and release notes, run CI/PR flow, and publish `gsd-hermes@1.4.0` after validation.
+
+## Phase Details
+
+### Phase 10: Runtime Binding Receipt Surface
+
+**Goal:** Make model binding intent visible at GSD entry points before spawning agents, with structured metadata that separates resolver truth from runtime enforcement proof.
+
+**Depends on:** Nothing (first phase of milestone)
+
+**Requirements:** RCPT-01, RCPT-02, RCPT-03, RCPT-04
+
+**Success Criteria** (what must be TRUE):
+  1. `gsd-sdk query init.plan-phase <phase>` returns a structured receipt for `gsd-phase-researcher`, `gsd-planner`, and `gsd-plan-checker`, including configured model, resolved model, source, binding kind, runtime, provider/family, and enforceability fields.
+  2. `gsd-sdk query init.execute-phase <phase>` returns the same receipt shape for `gsd-executor` and `gsd-verifier`.
+  3. Hermes-visible `/gsd-plan-phase` and `/gsd-execute-phase` transcript output prints a concise pre-spawn receipt table and does not require users to manually inspect JSON.
+  4. Receipt labels explicitly distinguish `resolved_by_gsd`, `passed_to_runtime`, and `runtime_enforced`; fields default to conservative/unknown values rather than claiming proof that does not exist.
+
+**Plans:** 0/3 plans executed
+
+Plans:
+- [ ] 10-01-PLAN.md — Add structured binding receipt metadata to SDK init queries for plan/execute phase without breaking existing flat `*_model` fields.
+- [ ] 10-02-PLAN.md — Render concise binding receipt table in workflows before Task/delegate spawn; preserve text-mode compatibility.
+- [ ] 10-03-PLAN.md — Add SDK/workflow tests for receipt shape, backward compatibility, and conservative enforcement status.
+
+### Phase 11: Hermes Per-Agent Binding Channel
+
+**Goal:** Ensure GSD explicit per-agent model overrides reach Hermes child agents through a real binding path, or fail before spawn when Hermes cannot enforce the override.
+
+**Depends on:** Phase 10
+
+**Requirements:** BIND-01, BIND-02, BIND-03, BIND-04
+
+**Success Criteria** (what must be TRUE):
+  1. Code identifies and documents the authoritative Hermes binding path for per-agent model selection (`delegate_task` model field, ACP `--model`, generated config, or another explicit mechanism).
+  2. A GSD-originated explicit override constructs the Hermes child `AIAgent` with the expected model instead of inheriting `parent_agent.model` when `delegation.model` is unset.
+  3. Batch/multi-agent workflows can assign different configured models to different agents where the runtime supports it.
+  4. If no enforceable channel exists for a path, GSD emits a clear pre-spawn validation error that names the agent, configured model, runtime, and suggested fix.
+
+**Plans:** 0/3 plans executed
+
+Plans:
+- [ ] 11-01-PLAN.md — Trace Hermes delegation entry points and choose the smallest upstream-syncable binding seam.
+- [ ] 11-02-PLAN.md — Implement binding propagation for single and batch subagent spawns, preserving existing inheritance behavior when no explicit override is configured.
+- [ ] 11-03-PLAN.md — Add pre-spawn unsupported-path errors and update runtime capability semantics so Hermes does not overclaim enforcement.
+
+### Phase 12: Fail-Fast Validation and Proof Tests
+
+**Goal:** Prove no silent fallback remains by combining SDK validation, Hermes child construction assertions, invalid-model smoke tests, and redacted provider-request diagnostics.
+
+**Depends on:** Phase 11
+
+**Requirements:** ENF-01, ENF-02, ENF-03, TEST-01, TEST-02, TEST-03, TEST-04
+
+**Success Criteria** (what must be TRUE):
+  1. An explicit invalid model override cannot complete successfully by inheriting the parent/default Hermes model.
+  2. Unit/integration tests prove the child `AIAgent.model` equals the configured per-agent override for at least planner and executor paths.
+  3. Provider-request diagnostics can expose the request model and subagent id while redacting credentials and avoiding API key/token leakage.
+  4. `workflow.cross_ai_execution` stays explicit and observable; no automatic or silent cross-runtime fallback is introduced.
+  5. Full relevant test gates pass (`npm run test:hermes`, runtime-model parity tests, and any new Hermes binding tests).
+
+**Plans:** 0/4 plans executed
+
+Plans:
+- [ ] 12-01-PLAN.md — Add SDK validation tests for enforceability errors and receipt metadata across override/inherit/runtime-default cases.
+- [ ] 12-02-PLAN.md — Add Hermes child-construction test proving expected child model/provider for GSD-originated override.
+- [ ] 12-03-PLAN.md — Add invalid-model no-silent-fallback smoke test and provider-request diagnostic coverage with credential redaction.
+- [ ] 12-04-PLAN.md — Run full regression gates and close any discovered compatibility drift.
+
+### Phase 13: Tracker, Documentation, Release
+
+**Goal:** Make the fix reviewable and shippable: tracker issue captures root cause/acceptance criteria, docs teach users how to verify model binding, and `gsd-hermes@1.4.0` ships with release evidence.
+
+**Depends on:** Phase 12
+
+**Requirements:** REL-01, REL-02, REL-03, REL-04
+
+**Success Criteria** (what must be TRUE):
+  1. A GitHub issue or PR tracker documents root cause, static evidence (`delegate_task` lacks per-call model), runtime evidence, acceptance criteria, and validation commands.
+  2. README, COMMANDS.md, CONFIGURATION.md, and release notes explain how Hermes per-agent model overrides are resolved, passed, enforced, and diagnosed.
+  3. A PR against `main` contains the implementation, tests, docs, and explicit validation evidence; CI passes before merge.
+  4. `gsd-hermes@1.4.0` is published to npm and a GitHub Release `v1.4.0` exists with release notes and verification evidence.
+
+**Plans:** 0/3 plans executed
+
+Plans:
+- [ ] 13-01-PLAN.md — Open/update GitHub tracker issue and prepare PR body acceptance checklist.
+- [ ] 13-02-PLAN.md — Update README, COMMANDS.md, CONFIGURATION.md, CHANGELOG/release notes for strict Hermes model binding semantics.
+- [ ] 13-03-PLAN.md — Execute PR/CI/release flow and publish `gsd-hermes@1.4.0` after validation.
+
+## Progress Table
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 10. Runtime Binding Receipt Surface | 0/3 | Planned | - |
+| 11. Hermes Per-Agent Binding Channel | 0/3 | Planned | - |
+| 12. Fail-Fast Validation and Proof Tests | 0/4 | Planned | - |
+| 13. Tracker, Documentation, Release | 0/3 | Planned | - |
+
+## Validation Matrix
+
+| Gate | Required | Command / Evidence |
+|------|----------|--------------------|
+| Resolver override still works | Yes | `gsd-sdk query resolve-model gsd-planner` shows `source=override`, `binding=explicit` |
+| Init receipts emitted | Yes | `gsd-sdk query init.plan-phase <phase>` and `init.execute-phase <phase>` include binding metadata |
+| Workflow receipt visible | Yes | Hermes `/gsd-plan-phase` / `/gsd-execute-phase` transcript shows receipt before spawn |
+| Child model proof | Yes | Hermes test/log proves child `AIAgent.model` equals expected override |
+| Invalid model no-silent-fallback | Yes | Invalid explicit override fails before/at provider request instead of succeeding with parent/default model |
+| Credential redaction | Yes | Diagnostics never print API keys, tokens, passwords, or connection strings |
+| Runtime-model parity | Yes | Existing parity tests remain green |
+| Hermes compatibility | Yes | `npm run test:hermes` passes |
+| Documentation | Yes | README, COMMANDS.md, CONFIGURATION.md, release notes updated |
+| Release | Yes | npm `gsd-hermes@1.4.0` + GitHub Release `v1.4.0` |
+
+## Next Action
+
+Start Phase 10: Runtime Binding Receipt Surface via `/gsd-discuss-phase 10` or `/gsd-plan-phase 10`.
+
+---
+*Roadmap created: 2026-04-25*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -36,9 +36,14 @@
 **Plans:** 0/3 plans executed
 
 Plans:
-- [ ] 10-01-PLAN.md — Add structured binding receipt metadata to SDK init queries for plan/execute phase without breaking existing flat `*_model` fields.
-- [ ] 10-02-PLAN.md — Render concise binding receipt table in workflows before Task/delegate spawn; preserve text-mode compatibility.
-- [ ] 10-03-PLAN.md — Add SDK/workflow tests for receipt shape, backward compatibility, and conservative enforcement status.
+**Wave 1**
+- [ ] 10-01-PLAN.md — Create the shared model-binding receipt projection used by Phase 10 init surfaces without changing legacy flat model-token behavior.
+
+**Wave 2** *(blocked on Wave 1 completion)*
+- [ ] 10-02-PLAN.md — Add structured binding receipt payloads to `init.plan-phase` and `init.execute-phase` while preserving existing flat model fields and SDK/CJS golden parity.
+
+**Wave 3** *(blocked on Wave 2 completion)*
+- [ ] 10-03-PLAN.md — Surface binding receipts in `/gsd-plan-phase` and `/gsd-execute-phase` transcript instructions so users see model intent and runtime proof status before subagents spawn.
 
 ### Phase 11: Hermes Per-Agent Binding Channel
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -106,7 +106,7 @@ Plans:
   1. A GitHub issue or PR tracker documents root cause, static evidence (`delegate_task` lacks per-call model), runtime evidence, acceptance criteria, and validation commands.
   2. README, COMMANDS.md, CONFIGURATION.md, and release notes explain how Hermes per-agent model overrides are resolved, passed, enforced, and diagnosed.
   3. A PR against `main` contains the implementation, tests, docs, and explicit validation evidence; CI passes before merge.
-  4. The next publishable v1.4 patch release is published to npm and a matching GitHub Release exists with release notes and verification evidence. Discovery on 2026-04-26 found `gsd-hermes@1.4.0` and GitHub Release `v1.4.0` already exist, so execution should default to `1.4.1` unless the maintainer chooses a different semver.
+  4. The next publishable v1.4 patch release is published to npm and a matching GitHub Release exists with release notes and verification evidence. Discovery on 2026-04-26 found `gsd-hermes@1.4.0` and GitHub Release `v1.4.0` already exist, so execution should default to `1.4.30` unless the maintainer chooses a different semver.
 
 **Plans:** 3/3 plans created; 0/3 plans executed
 
@@ -137,7 +137,7 @@ Plans:
 | Runtime-model parity | Yes | Existing parity tests remain green |
 | Hermes compatibility | Yes | `npm run test:hermes` passes |
 | Documentation | Yes | README, COMMANDS.md, CONFIGURATION.md, release notes updated |
-| Release | Yes | next publishable v1.4 patch release (default `gsd-hermes@1.4.1`) + matching GitHub Release |
+| Release | Yes | next publishable v1.4 patch release (default `gsd-hermes@1.4.30`) + matching GitHub Release |
 
 ## Next Action
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,39 @@
+# State: GSD Hermes
+
+## Current Position
+
+Phase: Not started (defining requirements complete)
+Plan: —
+Status: Ready to start milestone v1.4
+Last activity: 2026-04-25 — Milestone v1.4 started for Hermes runtime model binding receipts
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-04-25)
+
+**Core value:** A user running Hermes Agent can `npx gsd-hermes --hermes --global` and immediately use the standard GSD workflow with Hermes-native runtime/model semantics, while the fork tracks closely behind upstream GSD.
+**Current focus:** v1.4 Hermes Runtime Model Binding Receipts — prove and enforce per-agent model bindings in Hermes.
+
+## Current Milestone
+
+**v1.4 — Hermes Runtime Model Binding Receipts**
+
+Goal: Make GSD/Hermes per-agent model overrides observable, enforceable, and impossible to silently ignore at runtime.
+
+## Next Action
+
+Run one of:
+
+- `/gsd-discuss-phase 10` — gather implementation context before planning.
+- `/gsd-plan-phase 10` — plan Phase 10 directly.
+
+## Accumulated Context
+
+- v1.3 shipped 2026-04-24 as `gsd-hermes@1.3.0` after upstream sync to `upstream/main@0a049149`.
+- Manual investigation on 2026-04-25 confirmed `.planning/config.json` model overrides resolve correctly in GSD (`source=override`, `binding=explicit`) and workflow init payloads expose flat `*_model` strings.
+- Manual investigation also found current Hermes `delegate_task` schema has no per-call `model` field; with `delegation.model` unset, child agents inherit the parent model.
+- v1.4 treats this as runtime truthfulness/correctness work: resolver success is not enough; spawned Hermes subagents must prove the effective model or GSD must fail fast.
+
+## Blockers
+
+None currently. Phase 10 should begin by preserving backward compatibility for existing flat `*_model` init fields while adding structured receipts.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v1.4
 milestone_name: Hermes Runtime Model Binding Receipts
-status: ready_to_plan
-last_updated: "2026-04-26T03:01:52+08:00"
-last_activity: 2026-04-26 -- Phase 11 execution completed
+status: ready_to_execute
+last_updated: "2026-04-26T03:11:15+08:00"
+last_activity: 2026-04-26 -- Phase 12 planned
 progress:
   total_phases: 4
   completed_phases: 2
@@ -17,10 +17,10 @@ progress:
 
 ## Current Position
 
-Phase: 12 (Fail-Fast Validation and Proof Tests) — READY TO PLAN
+Phase: 12 (Fail-Fast Validation and Proof Tests) — PLANNED
 Plan: 0 of 4
-Status: Phase 11 complete; ready to plan Phase 12
-Last activity: 2026-04-26 -- Phase 11 execution completed
+Status: Ready to execute Phase 12
+Last activity: 2026-04-26 -- Phase 12 planned
 
 ## Project Reference
 
@@ -39,7 +39,7 @@ Goal: Make GSD/Hermes per-agent model overrides observable, enforceable, and imp
 
 Run:
 
-- `/gsd-plan-phase 12` — plan fail-fast validation, child-construction proof tests, provider-request diagnostics, and regression coverage.
+- `/gsd-execute-phase 12` — execute fail-fast validation, child-construction proof tests, provider-request diagnostics, and regression closeout.
 
 ## Accumulated Context
 
@@ -51,7 +51,8 @@ Run:
 - Phase 10 receipt semantics intentionally remain conservative: `runtime_enforced=unknown` is not runtime proof; actual Hermes binding propagation/proof remains Phase 11/12 scope.
 - Phase 11 plan-phase completed 2026-04-26. Research selected the canonical Hermes seam as direct `delegate_task(model=...)` plus batch `tasks[].model`, with `delegation.model` remaining a global fallback. The plan set preserved the proof boundary: child `AIAgent(model=...)` construction is Phase 11 proof; provider wire-level `model=` proof remains Phase 12 unless explicitly instrumented.
 - Phase 11 execution completed 2026-04-26. Local Hermes Agent now supports `delegate_task(model=...)` and batch `tasks[].model` with precedence `tasks[i].model > top-level model > delegation.model > parent inheritance`; tests prove child `AIAgent(model=...)` construction. GSD receipts now include `runtime_binding_channel` with Hermes child-construction metadata and fail-fast validation for unavailable explicit binding channels. Full GSD suite passed `5593/5593`.
+- Phase 12 plan-phase completed 2026-04-26. Plans cover SDK/CJS validation matrix, Hermes GSD-role child-construction tests, invalid-model no-silent-fallback diagnostics, redaction proof, and full regression closeout.
 
 ## Blockers
 
-None currently. Phase 12 should add provider/request diagnostics and invalid-model no-silent-fallback proof while keeping credentials redacted and `runtime_enforced` conservative until provider proof exists.
+None currently. Phase 12 is ready to execute.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,25 +2,25 @@
 gsd_state_version: 1.0
 milestone: v1.4
 milestone_name: Hermes Runtime Model Binding Receipts
-status: ready_to_execute
-last_updated: "2026-04-26T09:06:22+08:00"
-last_activity: 2026-04-26 -- Phase 13 planning completed
+status: executing
+last_updated: "2026-04-26T01:30:18.765Z"
+last_activity: 2026-04-26 -- Phase 13 execution started
 progress:
   total_phases: 4
-  completed_phases: 3
+  completed_phases: 0
   total_plans: 13
-  completed_plans: 10
-  percent: 77
+  completed_plans: 3
+  percent: 23
 ---
 
 # State: GSD Hermes
 
 ## Current Position
 
-Phase: 13 (Tracker, Documentation, Release) — READY TO EXECUTE
-Plan: 0 of 3
-Status: Phase 13 planning complete; ready to execute tracker/docs/release flow
-Last activity: 2026-04-26 -- Phase 13 planning completed
+Phase: 13 (Tracker, Documentation, Release) — EXECUTING
+Plan: 1 of 3
+Status: Executing Phase 13
+Last activity: 2026-04-26 -- Phase 13 execution started
 
 ## Project Reference
 
@@ -53,7 +53,7 @@ Run:
 - Phase 11 execution completed 2026-04-26. Local Hermes Agent now supports `delegate_task(model=...)` and batch `tasks[].model` with precedence `tasks[i].model > top-level model > delegation.model > parent inheritance`; tests prove child `AIAgent(model=...)` construction. GSD receipts now include `runtime_binding_channel` with Hermes child-construction metadata and fail-fast validation for unavailable explicit binding channels. Full GSD suite passed `5593/5593`.
 - Phase 12 plan-phase completed 2026-04-26. Plans cover SDK/CJS validation matrix, Hermes GSD-role child-construction tests, invalid-model no-silent-fallback diagnostics, redaction proof, and full regression closeout.
 - Phase 12 execution completed 2026-04-26. SDK/CJS tests now cover fail-fast unavailable-channel validation, inherit/runtime-default non-errors, invalid explicit token preservation, and explicit cross-AI metadata. Hermes Agent tests prove GSD planner/executor model tokens reach child construction, including invalid explicit tokens. Offline provider diagnostics preserve model/provider/subagent metadata while redacting credentials. Full GSD suite passed `5597/5597`; Hermes targeted tests passed `128/128`.
-- Phase 13 plan-phase completed 2026-04-26. Discovery found `gsd-hermes@1.4.0` and GitHub Release `v1.4.0` already exist from the upstream-sync release, so execution should default to the next publishable v1.4 patch release, recommended `1.4.1`, unless the maintainer chooses a different semver.
+- Phase 13 plan-phase completed 2026-04-26. Discovery found `gsd-hermes@1.4.0` and GitHub Release `v1.4.0` already exist from the upstream-sync release, so execution should default to the next publishable v1.4 patch release, selected `1.4.30`, unless the maintainer chooses a different semver.
 
 ## Blockers
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v1.4
 milestone_name: Hermes Runtime Model Binding Receipts
-status: ready_to_plan
-last_updated: "2026-04-26T03:30:10+08:00"
-last_activity: 2026-04-26 -- Phase 12 execution completed
+status: ready_to_execute
+last_updated: "2026-04-26T09:06:22+08:00"
+last_activity: 2026-04-26 -- Phase 13 planning completed
 progress:
   total_phases: 4
   completed_phases: 3
@@ -17,10 +17,10 @@ progress:
 
 ## Current Position
 
-Phase: 13 (Tracker, Documentation, Release) — READY TO PLAN
+Phase: 13 (Tracker, Documentation, Release) — READY TO EXECUTE
 Plan: 0 of 3
-Status: Phase 12 complete; ready to plan Phase 13
-Last activity: 2026-04-26 -- Phase 12 execution completed
+Status: Phase 13 planning complete; ready to execute tracker/docs/release flow
+Last activity: 2026-04-26 -- Phase 13 planning completed
 
 ## Project Reference
 
@@ -39,7 +39,7 @@ Goal: Make GSD/Hermes per-agent model overrides observable, enforceable, and imp
 
 Run:
 
-- `/gsd-plan-phase 13` — plan tracker issue, docs/release notes, PR/CI, and `gsd-hermes@1.4.0` publish flow.
+- `/gsd-execute-phase 13` — open/update tracker issue, update docs/release metadata, run PR/CI/release flow, and publish the next publishable v1.4 patch release after validation.
 
 ## Accumulated Context
 
@@ -53,7 +53,12 @@ Run:
 - Phase 11 execution completed 2026-04-26. Local Hermes Agent now supports `delegate_task(model=...)` and batch `tasks[].model` with precedence `tasks[i].model > top-level model > delegation.model > parent inheritance`; tests prove child `AIAgent(model=...)` construction. GSD receipts now include `runtime_binding_channel` with Hermes child-construction metadata and fail-fast validation for unavailable explicit binding channels. Full GSD suite passed `5593/5593`.
 - Phase 12 plan-phase completed 2026-04-26. Plans cover SDK/CJS validation matrix, Hermes GSD-role child-construction tests, invalid-model no-silent-fallback diagnostics, redaction proof, and full regression closeout.
 - Phase 12 execution completed 2026-04-26. SDK/CJS tests now cover fail-fast unavailable-channel validation, inherit/runtime-default non-errors, invalid explicit token preservation, and explicit cross-AI metadata. Hermes Agent tests prove GSD planner/executor model tokens reach child construction, including invalid explicit tokens. Offline provider diagnostics preserve model/provider/subagent metadata while redacting credentials. Full GSD suite passed `5597/5597`; Hermes targeted tests passed `128/128`.
+- Phase 13 plan-phase completed 2026-04-26. Discovery found `gsd-hermes@1.4.0` and GitHub Release `v1.4.0` already exist from the upstream-sync release, so execution should default to the next publishable v1.4 patch release, recommended `1.4.1`, unless the maintainer chooses a different semver.
 
 ## Blockers
 
-None currently. Phase 13 is ready to plan.
+None currently. Phase 13 is ready to execute.
+
+## Release Caution
+
+Do not attempt to publish `gsd-hermes@1.4.0` again. npm versions are immutable and `1.4.0` is already published. Phase 13 execution must bump to a publishable version before npm publish.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,12 +3,12 @@ gsd_state_version: 1.0
 milestone: v1.4
 milestone_name: Hermes Runtime Model Binding Receipts
 status: active
-last_updated: "2026-04-25T17:27:32.863Z"
-last_activity: 2026-04-26 -- Phase 10 complete
+last_updated: "2026-04-25T18:05:47.235Z"
+last_activity: 2026-04-26 -- Phase 11 planned
 progress:
   total_phases: 4
   completed_phases: 1
-  total_plans: 3
+  total_plans: 6
   completed_plans: 3
   percent: 25
 ---
@@ -17,17 +17,17 @@ progress:
 
 ## Current Position
 
-Phase: 10 (Runtime Binding Receipt Surface) — COMPLETE
-Plan: 3 of 3
-Status: Ready for Phase 11
-Last activity: 2026-04-26 -- Phase 10 complete
+Phase: 11 (Hermes Per-Agent Binding Channel) — PLANNED
+Plan: 0 of 3 executed
+Status: Ready for Phase 11 execution
+Last activity: 2026-04-26 -- Phase 11 plan-phase complete
 
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-04-25)
 
 **Core value:** A user running Hermes Agent can `npx gsd-hermes --hermes --global` and immediately use the standard GSD workflow with Hermes-native runtime/model semantics, while the fork tracks closely behind upstream GSD.
-**Current focus:** Phase 11 — Hermes Per-Agent Binding Channel
+**Current focus:** Execute Phase 11 — Hermes Per-Agent Binding Channel
 
 ## Current Milestone
 
@@ -37,10 +37,9 @@ Goal: Make GSD/Hermes per-agent model overrides observable, enforceable, and imp
 
 ## Next Action
 
-Run one of:
+Run:
 
-- `/gsd-discuss-phase 11` — gather implementation context before planning.
-- `/gsd-plan-phase 11` — plan Phase 11 directly.
+- `/gsd-execute-phase 11` — implement the planned Hermes per-agent binding channel work.
 
 ## Accumulated Context
 
@@ -50,7 +49,8 @@ Run one of:
 - v1.4 treats this as runtime truthfulness/correctness work: resolver success is not enough; spawned Hermes subagents must prove the effective model or GSD must fail fast.
 - Phase 10 completed 2026-04-26. It added structured runtime/model binding receipts to SDK and legacy init surfaces, mirrored SDK/CJS receipt projection, and updated `/gsd-plan-phase` plus `/gsd-execute-phase` transcript instructions to display conservative receipt status before dispatch.
 - Phase 10 receipt semantics intentionally remain conservative: `runtime_enforced=unknown` is not runtime proof; actual Hermes binding propagation/proof remains Phase 11/12 scope.
+- Phase 11 plan-phase completed 2026-04-26. Research selected the canonical Hermes seam as direct `delegate_task(model=...)` plus batch `tasks[].model`, with `delegation.model` remaining a global fallback. The plan set preserves the proof boundary: child `AIAgent(model=...)` construction is Phase 11 proof; provider wire-level `model=` proof remains Phase 12 unless explicitly instrumented.
 
 ## Blockers
 
-None currently. Phase 11 should identify the smallest upstream-syncable Hermes binding channel or fail fast before spawn when a configured model cannot be enforced.
+None currently. Phase 11 execution should coordinate the sibling Hermes Agent patch and the GSD fail-fast/capability updates, then run focused Hermes Agent and GSD verification gates.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,32 +2,32 @@
 gsd_state_version: 1.0
 milestone: v1.4
 milestone_name: Hermes Runtime Model Binding Receipts
-status: ready_to_execute
-last_updated: "2026-04-26T03:11:15+08:00"
-last_activity: 2026-04-26 -- Phase 12 planned
+status: ready_to_plan
+last_updated: "2026-04-26T03:30:10+08:00"
+last_activity: 2026-04-26 -- Phase 12 execution completed
 progress:
   total_phases: 4
-  completed_phases: 2
-  total_plans: 10
-  completed_plans: 6
-  percent: 60
+  completed_phases: 3
+  total_plans: 13
+  completed_plans: 10
+  percent: 77
 ---
 
 # State: GSD Hermes
 
 ## Current Position
 
-Phase: 12 (Fail-Fast Validation and Proof Tests) — PLANNED
-Plan: 0 of 4
-Status: Ready to execute Phase 12
-Last activity: 2026-04-26 -- Phase 12 planned
+Phase: 13 (Tracker, Documentation, Release) — READY TO PLAN
+Plan: 0 of 3
+Status: Phase 12 complete; ready to plan Phase 13
+Last activity: 2026-04-26 -- Phase 12 execution completed
 
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-04-25)
 
 **Core value:** A user running Hermes Agent can `npx gsd-hermes --hermes --global` and immediately use the standard GSD workflow with Hermes-native runtime/model semantics, while the fork tracks closely behind upstream GSD.
-**Current focus:** Phase 12 — Fail-Fast Validation and Proof Tests
+**Current focus:** Phase 13 — Tracker, Documentation, Release
 
 ## Current Milestone
 
@@ -39,7 +39,7 @@ Goal: Make GSD/Hermes per-agent model overrides observable, enforceable, and imp
 
 Run:
 
-- `/gsd-execute-phase 12` — execute fail-fast validation, child-construction proof tests, provider-request diagnostics, and regression closeout.
+- `/gsd-plan-phase 13` — plan tracker issue, docs/release notes, PR/CI, and `gsd-hermes@1.4.0` publish flow.
 
 ## Accumulated Context
 
@@ -52,7 +52,8 @@ Run:
 - Phase 11 plan-phase completed 2026-04-26. Research selected the canonical Hermes seam as direct `delegate_task(model=...)` plus batch `tasks[].model`, with `delegation.model` remaining a global fallback. The plan set preserved the proof boundary: child `AIAgent(model=...)` construction is Phase 11 proof; provider wire-level `model=` proof remains Phase 12 unless explicitly instrumented.
 - Phase 11 execution completed 2026-04-26. Local Hermes Agent now supports `delegate_task(model=...)` and batch `tasks[].model` with precedence `tasks[i].model > top-level model > delegation.model > parent inheritance`; tests prove child `AIAgent(model=...)` construction. GSD receipts now include `runtime_binding_channel` with Hermes child-construction metadata and fail-fast validation for unavailable explicit binding channels. Full GSD suite passed `5593/5593`.
 - Phase 12 plan-phase completed 2026-04-26. Plans cover SDK/CJS validation matrix, Hermes GSD-role child-construction tests, invalid-model no-silent-fallback diagnostics, redaction proof, and full regression closeout.
+- Phase 12 execution completed 2026-04-26. SDK/CJS tests now cover fail-fast unavailable-channel validation, inherit/runtime-default non-errors, invalid explicit token preservation, and explicit cross-AI metadata. Hermes Agent tests prove GSD planner/executor model tokens reach child construction, including invalid explicit tokens. Offline provider diagnostics preserve model/provider/subagent metadata while redacting credentials. Full GSD suite passed `5597/5597`; Hermes targeted tests passed `128/128`.
 
 ## Blockers
 
-None currently. Phase 12 is ready to execute.
+None currently. Phase 13 is ready to plan.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,32 +2,32 @@
 gsd_state_version: 1.0
 milestone: v1.4
 milestone_name: Hermes Runtime Model Binding Receipts
-status: active
-last_updated: "2026-04-25T18:05:47.235Z"
-last_activity: 2026-04-26 -- Phase 11 planned
+status: ready_to_plan
+last_updated: "2026-04-26T03:01:52+08:00"
+last_activity: 2026-04-26 -- Phase 11 execution completed
 progress:
   total_phases: 4
-  completed_phases: 1
-  total_plans: 6
-  completed_plans: 3
-  percent: 25
+  completed_phases: 2
+  total_plans: 10
+  completed_plans: 6
+  percent: 60
 ---
 
 # State: GSD Hermes
 
 ## Current Position
 
-Phase: 11 (Hermes Per-Agent Binding Channel) — PLANNED
-Plan: 0 of 3 executed
-Status: Ready for Phase 11 execution
-Last activity: 2026-04-26 -- Phase 11 plan-phase complete
+Phase: 12 (Fail-Fast Validation and Proof Tests) — READY TO PLAN
+Plan: 0 of 4
+Status: Phase 11 complete; ready to plan Phase 12
+Last activity: 2026-04-26 -- Phase 11 execution completed
 
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-04-25)
 
 **Core value:** A user running Hermes Agent can `npx gsd-hermes --hermes --global` and immediately use the standard GSD workflow with Hermes-native runtime/model semantics, while the fork tracks closely behind upstream GSD.
-**Current focus:** Execute Phase 11 — Hermes Per-Agent Binding Channel
+**Current focus:** Phase 12 — Fail-Fast Validation and Proof Tests
 
 ## Current Milestone
 
@@ -39,18 +39,19 @@ Goal: Make GSD/Hermes per-agent model overrides observable, enforceable, and imp
 
 Run:
 
-- `/gsd-execute-phase 11` — implement the planned Hermes per-agent binding channel work.
+- `/gsd-plan-phase 12` — plan fail-fast validation, child-construction proof tests, provider-request diagnostics, and regression coverage.
 
 ## Accumulated Context
 
 - v1.3 shipped 2026-04-24 as `gsd-hermes@1.3.0` after upstream sync to `upstream/main@0a049149`.
 - Manual investigation on 2026-04-25 confirmed `.planning/config.json` model overrides resolve correctly in GSD (`source=override`, `binding=explicit`) and workflow init payloads expose flat `*_model` strings.
-- Manual investigation also found current Hermes `delegate_task` schema has no per-call `model` field; with `delegation.model` unset, child agents inherit the parent model.
+- Manual investigation also found pre-Phase 11 Hermes `delegate_task` schema had no per-call `model` field; with `delegation.model` unset, child agents inherited the parent model.
 - v1.4 treats this as runtime truthfulness/correctness work: resolver success is not enough; spawned Hermes subagents must prove the effective model or GSD must fail fast.
 - Phase 10 completed 2026-04-26. It added structured runtime/model binding receipts to SDK and legacy init surfaces, mirrored SDK/CJS receipt projection, and updated `/gsd-plan-phase` plus `/gsd-execute-phase` transcript instructions to display conservative receipt status before dispatch.
 - Phase 10 receipt semantics intentionally remain conservative: `runtime_enforced=unknown` is not runtime proof; actual Hermes binding propagation/proof remains Phase 11/12 scope.
-- Phase 11 plan-phase completed 2026-04-26. Research selected the canonical Hermes seam as direct `delegate_task(model=...)` plus batch `tasks[].model`, with `delegation.model` remaining a global fallback. The plan set preserves the proof boundary: child `AIAgent(model=...)` construction is Phase 11 proof; provider wire-level `model=` proof remains Phase 12 unless explicitly instrumented.
+- Phase 11 plan-phase completed 2026-04-26. Research selected the canonical Hermes seam as direct `delegate_task(model=...)` plus batch `tasks[].model`, with `delegation.model` remaining a global fallback. The plan set preserved the proof boundary: child `AIAgent(model=...)` construction is Phase 11 proof; provider wire-level `model=` proof remains Phase 12 unless explicitly instrumented.
+- Phase 11 execution completed 2026-04-26. Local Hermes Agent now supports `delegate_task(model=...)` and batch `tasks[].model` with precedence `tasks[i].model > top-level model > delegation.model > parent inheritance`; tests prove child `AIAgent(model=...)` construction. GSD receipts now include `runtime_binding_channel` with Hermes child-construction metadata and fail-fast validation for unavailable explicit binding channels. Full GSD suite passed `5593/5593`.
 
 ## Blockers
 
-None currently. Phase 11 execution should coordinate the sibling Hermes Agent patch and the GSD fail-fast/capability updates, then run focused Hermes Agent and GSD verification gates.
+None currently. Phase 12 should add provider/request diagnostics and invalid-model no-silent-fallback proof while keeping credentials redacted and `runtime_enforced` conservative until provider proof exists.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,32 +2,32 @@
 gsd_state_version: 1.0
 milestone: v1.4
 milestone_name: Hermes Runtime Model Binding Receipts
-status: executing
-last_updated: "2026-04-25T16:02:09.543Z"
-last_activity: 2026-04-25 -- Phase 10 planning complete
+status: active
+last_updated: "2026-04-25T17:27:32.863Z"
+last_activity: 2026-04-26 -- Phase 10 complete
 progress:
   total_phases: 4
-  completed_phases: 0
+  completed_phases: 1
   total_plans: 3
-  completed_plans: 0
-  percent: 0
+  completed_plans: 3
+  percent: 25
 ---
 
 # State: GSD Hermes
 
 ## Current Position
 
-Phase: Not started (defining requirements complete)
-Plan: —
-Status: Ready to execute
-Last activity: 2026-04-25 -- Phase 10 planning complete
+Phase: 10 (Runtime Binding Receipt Surface) — COMPLETE
+Plan: 3 of 3
+Status: Ready for Phase 11
+Last activity: 2026-04-26 -- Phase 10 complete
 
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-04-25)
 
 **Core value:** A user running Hermes Agent can `npx gsd-hermes --hermes --global` and immediately use the standard GSD workflow with Hermes-native runtime/model semantics, while the fork tracks closely behind upstream GSD.
-**Current focus:** v1.4 Hermes Runtime Model Binding Receipts — prove and enforce per-agent model bindings in Hermes.
+**Current focus:** Phase 11 — Hermes Per-Agent Binding Channel
 
 ## Current Milestone
 
@@ -39,8 +39,8 @@ Goal: Make GSD/Hermes per-agent model overrides observable, enforceable, and imp
 
 Run one of:
 
-- `/gsd-discuss-phase 10` — gather implementation context before planning.
-- `/gsd-plan-phase 10` — plan Phase 10 directly.
+- `/gsd-discuss-phase 11` — gather implementation context before planning.
+- `/gsd-plan-phase 11` — plan Phase 11 directly.
 
 ## Accumulated Context
 
@@ -48,7 +48,9 @@ Run one of:
 - Manual investigation on 2026-04-25 confirmed `.planning/config.json` model overrides resolve correctly in GSD (`source=override`, `binding=explicit`) and workflow init payloads expose flat `*_model` strings.
 - Manual investigation also found current Hermes `delegate_task` schema has no per-call `model` field; with `delegation.model` unset, child agents inherit the parent model.
 - v1.4 treats this as runtime truthfulness/correctness work: resolver success is not enough; spawned Hermes subagents must prove the effective model or GSD must fail fast.
+- Phase 10 completed 2026-04-26. It added structured runtime/model binding receipts to SDK and legacy init surfaces, mirrored SDK/CJS receipt projection, and updated `/gsd-plan-phase` plus `/gsd-execute-phase` transcript instructions to display conservative receipt status before dispatch.
+- Phase 10 receipt semantics intentionally remain conservative: `runtime_enforced=unknown` is not runtime proof; actual Hermes binding propagation/proof remains Phase 11/12 scope.
 
 ## Blockers
 
-None currently. Phase 10 should begin by preserving backward compatibility for existing flat `*_model` init fields while adding structured receipts.
+None currently. Phase 11 should identify the smallest upstream-syncable Hermes binding channel or fail fast before spawn when a configured model cannot be enforced.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,11 +1,26 @@
+---
+gsd_state_version: 1.0
+milestone: v1.4
+milestone_name: Hermes Runtime Model Binding Receipts
+status: executing
+last_updated: "2026-04-25T16:02:09.543Z"
+last_activity: 2026-04-25 -- Phase 10 planning complete
+progress:
+  total_phases: 4
+  completed_phases: 0
+  total_plans: 3
+  completed_plans: 0
+  percent: 0
+---
+
 # State: GSD Hermes
 
 ## Current Position
 
 Phase: Not started (defining requirements complete)
 Plan: —
-Status: Ready to start milestone v1.4
-Last activity: 2026-04-25 — Milestone v1.4 started for Hermes runtime model binding receipts
+Status: Ready to execute
+Last activity: 2026-04-25 -- Phase 10 planning complete
 
 ## Project Reference
 

--- a/.planning/phases/10-runtime-binding-receipt-surface/10-01-PLAN.md
+++ b/.planning/phases/10-runtime-binding-receipt-surface/10-01-PLAN.md
@@ -1,0 +1,174 @@
+---
+phase: 10-runtime-binding-receipt-surface
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - sdk/src/query/runtime-model-contract.ts
+  - get-shit-done/bin/lib/model-profiles.cjs
+  - sdk/src/query/config-query.test.ts
+  - tests/runtime-model-parity.test.cjs
+autonomous: true
+requirements:
+  - RCPT-01
+  - RCPT-02
+  - RCPT-04
+must_haves:
+  truths:
+    - "Runtime/model receipts are additive projections over the existing runtime-model contract; flat model token behavior remains unchanged."
+    - "Receipt fields explicitly distinguish resolved_by_gsd, passed_to_runtime, and runtime_enforced."
+    - "Phase 10 does not claim Hermes child-agent enforcement; runtime_enforced defaults to unknown unless real proof is supplied."
+    - "SDK and legacy CJS expose equivalent receipt projection semantics for shared resolver cases."
+  artifacts:
+    - path: "sdk/src/query/runtime-model-contract.ts"
+      provides: "canonical TypeScript receipt projection helper and exported receipt types"
+      contains: "runtime_enforced"
+    - path: "get-shit-done/bin/lib/model-profiles.cjs"
+      provides: "legacy CJS receipt projection helper mirroring SDK semantics"
+      contains: "toBindingReceipt"
+    - path: "sdk/src/query/config-query.test.ts"
+      provides: "unit coverage for receipt shape and truth-field separation"
+      contains: "resolved_by_gsd"
+    - path: "tests/runtime-model-parity.test.cjs"
+      provides: "SDK/CJS receipt projection parity coverage"
+      contains: "runtime_enforced"
+---
+
+<objective>
+Create the shared model-binding receipt projection used by Phase 10 init surfaces. The projection must wrap the existing runtime-model resolver output without changing legacy flat model-token behavior.
+
+Purpose: closes the contract portion of RCPT-01/RCPT-02 and the truth-separation requirement in RCPT-04.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/REQUIREMENTS.md
+@.planning/ROADMAP.md
+@.planning/phases/10-runtime-binding-receipt-surface/10-CONTEXT.md
+@.planning/phases/10-runtime-binding-receipt-surface/10-RESEARCH.md
+@sdk/src/query/runtime-model-contract.ts
+@get-shit-done/bin/lib/model-profiles.cjs
+@sdk/src/query/config-query.test.ts
+@tests/runtime-model-parity.test.cjs
+
+<interfaces>
+Existing SDK resolver:
+- `resolveAgentBinding(config, agent)` returns `RuntimeModelResolution`.
+- `serializeRuntimeModelResolution(resolution)` returns resolver metadata.
+- `detectModelFamily(model)` is already exported and suitable for provider family detection.
+- `toInitModelToken(resolution)` must remain unchanged.
+
+Existing CJS resolver:
+- `resolveAgentBinding(config, agent)` exists in `get-shit-done/bin/lib/model-profiles.cjs`.
+- `toInitModelToken(resolution)` must remain unchanged.
+
+Target receipt semantics:
+```json
+{
+  "agent": "gsd-planner",
+  "role": "planner",
+  "runtime": "hermes",
+  "profile": "inherit",
+  "binding_kind": "explicit",
+  "source": "override",
+  "configured_model": "claude-opus-4-7",
+  "resolved_model": "claude-opus-4-7",
+  "model_token": "claude-opus-4-7",
+  "provider_family": "anthropic",
+  "known_agent": true,
+  "resolved_by_gsd": true,
+  "passed_to_runtime": true,
+  "runtime_enforced": "unknown",
+  "enforceability": "explicit-token-needs-runtime-proof",
+  "suggested_fix": "Adjust model_overrides for this agent or remove the override to use profile/runtime defaults."
+}
+```
+
+Allowed `runtime_enforced` values for this phase: `"unknown"`, `false`, `true`. In this plan, use `"unknown"` for resolved bindings because Phase 11/12 own runtime proof.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add SDK receipt type and failing unit coverage</name>
+  <files>sdk/src/query/runtime-model-contract.ts, sdk/src/query/config-query.test.ts</files>
+  <action>
+  Add failing tests in `sdk/src/query/config-query.test.ts` before implementation:
+  - explicit override receipt has `resolved_by_gsd: true`, `passed_to_runtime: true`, `runtime_enforced: "unknown"`, `provider_family: "openai"` for `openai/gpt-5.4`.
+  - runtime-default/omit receipt has `resolved_by_gsd: true`, `passed_to_runtime: false`, `runtime_enforced: "unknown"`.
+  - unsupported unknown-agent receipt has `resolved_by_gsd: false`, `passed_to_runtime: false`, `enforceability: "unsupported"`, and preserves `message`/`suggested_fix`.
+  </action>
+  <verify>
+    <automated>npm run build:sdk && (cd sdk && npx vitest run src/query/config-query.test.ts)</automated>
+    <expected>Tests fail before implementation because the receipt helper does not exist.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Implement SDK receipt projection helper</name>
+  <files>sdk/src/query/runtime-model-contract.ts</files>
+  <action>
+  In `sdk/src/query/runtime-model-contract.ts`:
+  - Export a `RuntimeModelReceipt` interface.
+  - Export `toRuntimeModelReceipt(resolution: RuntimeModelResolution, role: string): RuntimeModelReceipt`.
+  - Base fields on `serializeRuntimeModelResolution(resolution)` to avoid semantic drift.
+  - Derive `provider_family` from `resolution.modelToken ?? resolution.resolvedModel ?? resolution.configuredModel` using `detectModelFamily`.
+  - Set `resolved_by_gsd = resolution.kind === 'resolved'`.
+  - Set `passed_to_runtime = resolution.kind === 'resolved' && !!resolution.modelToken`.
+  - Set `runtime_enforced = 'unknown'` by default.
+  - Set `enforceability`:
+    - unsupported → `unsupported`
+    - explicit with model token → `explicit-token-needs-runtime-proof`
+    - otherwise → `inherits-or-runtime-default`
+  - Preserve `message`, `rejection_reason`, and `suggested_fix` for unsupported bindings.
+  Do not change `toLegacyResolveModelResult`, `toLegacyModelToken`, or `toInitModelToken` behavior.
+  </action>
+  <verify>
+    <automated>npm run build:sdk && (cd sdk && npx vitest run src/query/config-query.test.ts)</automated>
+    <expected>SDK receipt tests pass; existing runtime-model config tests continue to pass.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Add CJS receipt projection parity</name>
+  <files>get-shit-done/bin/lib/model-profiles.cjs, tests/runtime-model-parity.test.cjs</files>
+  <action>
+  Mirror the SDK projection in CJS:
+  - Add local `detectModelFamily(model)` helper matching the SDK regex behavior for anthropic/openai/google/unknown.
+  - Add `toBindingReceipt(resolution, role)` with the same public field names as SDK `toRuntimeModelReceipt`.
+  - Export `toBindingReceipt`.
+  Extend `tests/runtime-model-parity.test.cjs` so each matrix row compares SDK and CJS receipts after normalizing optional unsupported fields. Keep existing token assertions unchanged.
+  </action>
+  <verify>
+    <automated>npm run build:sdk && node --test tests/runtime-model-parity.test.cjs</automated>
+    <expected>Runtime-model parity remains green and includes receipt parity.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 4: Run focused receipt contract checks</name>
+  <files>sdk/src/query/runtime-model-contract.ts, get-shit-done/bin/lib/model-profiles.cjs, sdk/src/query/config-query.test.ts, tests/runtime-model-parity.test.cjs</files>
+  <action>
+  Run the focused test/build commands and inspect diffs for accidental behavior changes.
+  </action>
+  <verify>
+    <automated>npm run build:sdk && (cd sdk && npx vitest run src/query/config-query.test.ts) && node --test tests/runtime-model-parity.test.cjs</automated>
+    <expected>All focused checks pass. `git diff` shows additive receipt helpers/tests and no flat-token projection changes.</expected>
+  </verify>
+</task>
+
+</tasks>
+
+<done>
+- SDK and CJS both expose receipt projection helpers.
+- Receipt truth fields separate GSD resolution, runtime handoff intent, and runtime proof status.
+- `runtime_enforced` remains conservative (`unknown`) for Phase 10.
+- Existing flat model-token projection behavior is unchanged.
+</done>

--- a/.planning/phases/10-runtime-binding-receipt-surface/10-02-PLAN.md
+++ b/.planning/phases/10-runtime-binding-receipt-surface/10-02-PLAN.md
@@ -1,0 +1,194 @@
+---
+phase: 10-runtime-binding-receipt-surface
+plan: 02
+type: execute
+wave: 2
+depends_on:
+  - 10-01
+files_modified:
+  - sdk/src/query/init.ts
+  - get-shit-done/bin/lib/init.cjs
+  - sdk/src/query/init.test.ts
+  - tests/init.test.cjs
+  - sdk/src/golden/golden.integration.test.ts
+autonomous: true
+requirements:
+  - RCPT-01
+  - RCPT-02
+  - RCPT-04
+must_haves:
+  truths:
+    - "init.plan-phase returns receipts for researcher, planner, checker."
+    - "init.execute-phase returns receipts for executor, verifier."
+    - "Flat fields researcher_model/planner_model/checker_model/executor_model/verifier_model remain present and unchanged."
+    - "SDK init output and legacy CJS init output remain golden-parity compatible."
+  artifacts:
+    - path: "sdk/src/query/init.ts"
+      provides: "SDK init receipt payloads"
+      contains: "model_binding_receipts"
+    - path: "get-shit-done/bin/lib/init.cjs"
+      provides: "legacy CJS init receipt payloads"
+      contains: "model_binding_receipts"
+    - path: "sdk/src/query/init.test.ts"
+      provides: "SDK init receipt shape tests"
+      contains: "runtime_enforced"
+    - path: "tests/init.test.cjs"
+      provides: "legacy init receipt tests"
+      contains: "model_binding_receipts"
+    - path: "sdk/src/golden/golden.integration.test.ts"
+      provides: "unchanged parity harness proving SDK/CJS outputs match"
+      contains: "init.plan-phase"
+---
+
+<objective>
+Add structured binding receipt payloads to `init.plan-phase` and `init.execute-phase` while preserving existing flat model fields and SDK/CJS golden parity.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/REQUIREMENTS.md
+@.planning/phases/10-runtime-binding-receipt-surface/10-CONTEXT.md
+@.planning/phases/10-runtime-binding-receipt-surface/10-RESEARCH.md
+@sdk/src/query/init.ts
+@get-shit-done/bin/lib/init.cjs
+@sdk/src/query/init.test.ts
+@tests/init.test.cjs
+@sdk/src/golden/golden.integration.test.ts
+
+<interfaces>
+Plan 01 provides:
+- SDK `toRuntimeModelReceipt(resolution, role)`.
+- CJS `toBindingReceipt(resolution, role)`.
+
+Target `init.plan-phase` addition:
+```json
+"model_binding_receipts": {
+  "workflow": "plan-phase",
+  "runtime": "hermes",
+  "agents": {
+    "researcher": { "role": "researcher", "agent": "gsd-phase-researcher", "runtime_enforced": "unknown" },
+    "planner": { "role": "planner", "agent": "gsd-planner", "runtime_enforced": "unknown" },
+    "checker": { "role": "checker", "agent": "gsd-plan-checker", "runtime_enforced": "unknown" }
+  }
+}
+```
+
+Target `init.execute-phase` addition:
+```json
+"model_binding_receipts": {
+  "workflow": "execute-phase",
+  "runtime": "hermes",
+  "agents": {
+    "executor": { "role": "executor", "agent": "gsd-executor", "runtime_enforced": "unknown" },
+    "verifier": { "role": "verifier", "agent": "gsd-verifier", "runtime_enforced": "unknown" }
+  }
+}
+```
+
+For this repo's config, expected plan-phase agent source/family examples:
+- researcher: override / anthropic / passed_to_runtime true
+- planner: override / anthropic / passed_to_runtime true
+- checker: override / openai / passed_to_runtime true
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add failing SDK init receipt tests</name>
+  <files>sdk/src/query/init.test.ts</files>
+  <action>
+  Extend `initPlanPhase` tests:
+  - Assert `data.model_binding_receipts.workflow === 'plan-phase'`.
+  - Assert `agents.researcher.agent === 'gsd-phase-researcher'`.
+  - Assert planner/checker roles exist.
+  - Assert every plan agent has `resolved_by_gsd`, `passed_to_runtime`, `runtime_enforced` keys.
+  Extend `initExecutePhase` tests similarly for `executor` and `verifier`.
+  Also assert existing flat fields are still defined.
+  </action>
+  <verify>
+    <automated>npm run build:sdk && (cd sdk && npx vitest run src/query/init.test.ts)</automated>
+    <expected>Fails before implementation because `model_binding_receipts` is absent.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add SDK init receipt payloads</name>
+  <files>sdk/src/query/init.ts</files>
+  <action>
+  In `sdk/src/query/init.ts`:
+  - Import `resolveAgentBinding` and `toRuntimeModelReceipt` from `runtime-model-contract.ts` if not already imported.
+  - In `initPlanPhase`, compute receipts from the loaded `config` for:
+    - `researcher`: `gsd-phase-researcher`
+    - `planner`: `gsd-planner`
+    - `checker`: `gsd-plan-checker`
+  - In `initExecutePhase`, compute receipts for:
+    - `executor`: `gsd-executor`
+    - `verifier`: `gsd-verifier`
+  - Add `model_binding_receipts` to the result object.
+  - Set top-level `workflow` to the init command name and `runtime` from the receipt/runtime; do not add a separate detector if receipts already carry runtime.
+  - Do not remove or rename any existing result fields.
+  </action>
+  <verify>
+    <automated>npm run build:sdk && (cd sdk && npx vitest run src/query/init.test.ts)</automated>
+    <expected>SDK init tests pass.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Add legacy CJS init receipt payloads and tests</name>
+  <files>get-shit-done/bin/lib/init.cjs, tests/init.test.cjs</files>
+  <action>
+  In `get-shit-done/bin/lib/init.cjs`:
+  - Import/use `resolveAgentBinding` and `toBindingReceipt` from `model-profiles.cjs`.
+  - Add `model_binding_receipts` to `cmdInitPlanPhase` and `cmdInitExecutePhase` using the same workflow/role/agent mapping as SDK.
+  - Keep existing `resolveModelInternal(...)` flat-field calls unchanged.
+  In `tests/init.test.cjs`, add assertions that the legacy JSON includes plan and execute receipts and preserves flat fields.
+  </action>
+  <verify>
+    <automated>node --test tests/init.test.cjs</automated>
+    <expected>Legacy init tests pass and receipt fields are present.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 4: Prove SDK/CJS init parity still holds</name>
+  <files>sdk/src/golden/golden.integration.test.ts</files>
+  <action>
+  Run existing golden tests. Do not change `golden.integration.test.ts` unless a normalization helper is genuinely needed for deterministic fields; receipt fields should be deterministic and should not need normalization.
+  </action>
+  <verify>
+    <automated>npm run build:sdk && (cd sdk && npx vitest run src/golden/golden.integration.test.ts)</automated>
+    <expected>Golden init tests pass for `init.plan-phase` and `init.execute-phase`.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 5: Inspect live init output in this repo</name>
+  <files>none</files>
+  <action>
+  Run live queries from the repo root:
+  ```bash
+  gsd-sdk query init.plan-phase 10
+  gsd-sdk query init.execute-phase 10
+  ```
+  Confirm the JSON includes `model_binding_receipts` and that this repo's Hermes/openai+anthropic overrides appear exactly as configured.
+  </action>
+  <verify>
+    <automated>gsd-sdk query init.plan-phase 10 | grep -q 'model_binding_receipts' && gsd-sdk query init.execute-phase 10 | grep -q 'model_binding_receipts'</automated>
+    <expected>Both live init queries expose binding receipts.</expected>
+  </verify>
+</task>
+
+</tasks>
+
+<done>
+- `init.plan-phase` and `init.execute-phase` expose structured receipts.
+- Flat model fields remain available for older workflow consumers.
+- SDK and CJS init JSON remain aligned.
+- Live Hermes project init output visibly separates resolver truth from runtime proof status.
+</done>

--- a/.planning/phases/10-runtime-binding-receipt-surface/10-03-PLAN.md
+++ b/.planning/phases/10-runtime-binding-receipt-surface/10-03-PLAN.md
@@ -1,0 +1,165 @@
+---
+phase: 10-runtime-binding-receipt-surface
+plan: 03
+type: execute
+wave: 3
+depends_on:
+  - 10-02
+files_modified:
+  - get-shit-done/workflows/plan-phase.md
+  - get-shit-done/workflows/execute-phase.md
+  - tests/runtime-model-parity.test.cjs
+  - docs/hermes-compatibility.md
+autonomous: true
+requirements:
+  - RCPT-03
+  - RCPT-04
+must_haves:
+  truths:
+    - "plan-phase workflow parses and displays binding receipts before researcher/planner/checker Task dispatch."
+    - "execute-phase workflow parses and displays binding receipts before executor/verifier Task dispatch."
+    - "Workflow receipt text states runtime_enforced=unknown when Hermes proof is absent."
+    - "Docs/tests prevent future wording from conflating resolver truth with runtime proof."
+  artifacts:
+    - path: "get-shit-done/workflows/plan-phase.md"
+      provides: "plan workflow receipt rendering instructions"
+      contains: "model_binding_receipts"
+    - path: "get-shit-done/workflows/execute-phase.md"
+      provides: "execute workflow receipt rendering instructions"
+      contains: "runtime_enforced"
+    - path: "docs/hermes-compatibility.md"
+      provides: "user-facing explanation of resolver/workflow/runtime proof layers"
+      contains: "resolved_by_gsd"
+    - path: "tests/runtime-model-parity.test.cjs"
+      provides: "workflow/doc guard assertions for receipt wording"
+      contains: "resolved_by_gsd"
+---
+
+<objective>
+Surface binding receipts in `/gsd-plan-phase` and `/gsd-execute-phase` transcript instructions so users see model intent and runtime proof status before subagents spawn.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/REQUIREMENTS.md
+@.planning/phases/10-runtime-binding-receipt-surface/10-CONTEXT.md
+@.planning/phases/10-runtime-binding-receipt-surface/10-RESEARCH.md
+@get-shit-done/workflows/plan-phase.md
+@get-shit-done/workflows/execute-phase.md
+@docs/hermes-compatibility.md
+@tests/runtime-model-parity.test.cjs
+
+<interfaces>
+Plan 02 provides `INIT.model_binding_receipts` for both workflows.
+
+Concise transcript target:
+```text
+## Runtime/model binding receipt
+Workflow: plan-phase
+Runtime: hermes
+- researcher / gsd-phase-researcher: configured=claude-opus-4-7 resolved=claude-opus-4-7 source=override binding=explicit passed_to_runtime=true runtime_enforced=unknown
+- planner / gsd-planner: configured=claude-opus-4-7 resolved=claude-opus-4-7 source=override binding=explicit passed_to_runtime=true runtime_enforced=unknown
+- checker / gsd-plan-checker: configured=openai/gpt-5.4 resolved=openai/gpt-5.4 source=override binding=explicit passed_to_runtime=true runtime_enforced=unknown
+
+Note: `runtime_enforced=unknown` means the GSD resolver produced an explicit token, but Hermes child-agent/provider proof is handled by later enforcement phases.
+```
+
+This is display guidance only. It must not alter Task dispatch semantics in Phase 10.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add workflow/doc guard tests for receipt truth wording</name>
+  <files>tests/runtime-model-parity.test.cjs</files>
+  <action>
+  Extend the existing workflow-doc guard test to assert:
+  - `plan-phase.md` mentions `model_binding_receipts`.
+  - `execute-phase.md` mentions `model_binding_receipts`.
+  - Both workflows mention `runtime_enforced`.
+  - At least one workflow/doc guard asserts `resolved_by_gsd` and `passed_to_runtime` exist in documentation text.
+  - The workflow docs include a warning that `runtime_enforced=unknown` is not proof of child model enforcement.
+  </action>
+  <verify>
+    <automated>node --test tests/runtime-model-parity.test.cjs</automated>
+    <expected>Fails before workflow docs are updated.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 2: Update plan-phase receipt display instructions</name>
+  <files>get-shit-done/workflows/plan-phase.md</files>
+  <action>
+  In the Initialize/parsing section:
+  - Add `model_binding_receipts` to the parsed JSON fields.
+  - Add a required display step after init validation and before any researcher/planner/checker Task dispatch.
+  - The display step must show role, agent, configured_model, resolved_model, source, binding_kind, provider_family, passed_to_runtime, runtime_enforced.
+  - Include explicit text: `runtime_enforced=unknown is not runtime proof; it means GSD has not yet observed Hermes child/provider enforcement`.
+  - Keep the existing flat `researcher_model`, `planner_model`, and `checker_model` parsing and model resolution guidance intact.
+  </action>
+  <verify>
+    <automated>grep -q 'model_binding_receipts' get-shit-done/workflows/plan-phase.md && grep -q 'runtime_enforced' get-shit-done/workflows/plan-phase.md</automated>
+    <expected>plan-phase workflow contains receipt parsing and display guidance.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 3: Update execute-phase receipt display instructions</name>
+  <files>get-shit-done/workflows/execute-phase.md</files>
+  <action>
+  In the initialize step:
+  - Add `model_binding_receipts` to parsed JSON fields.
+  - Display receipts before executor/verifier spawning and before cross-AI fallback decisions.
+  - Preserve existing `executor_model === "inherit"` guidance exactly: omit `model=` when inherit/empty.
+  - State that `passed_to_runtime=true` means GSD has an explicit token ready to pass, not that Hermes has proven enforcement.
+  - State that `runtime_enforced=unknown` remains expected until Phase 11/12 proof is implemented.
+  </action>
+  <verify>
+    <automated>grep -q 'model_binding_receipts' get-shit-done/workflows/execute-phase.md && grep -q 'passed_to_runtime' get-shit-done/workflows/execute-phase.md</automated>
+    <expected>execute-phase workflow contains receipt parsing and display guidance.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 4: Document Hermes receipt layers</name>
+  <files>docs/hermes-compatibility.md</files>
+  <action>
+  Add or update a concise subsection under the runtime/model compatibility area explaining:
+  - Resolver layer: `resolved_by_gsd`.
+  - Workflow handoff layer: `passed_to_runtime`.
+  - Runtime proof layer: `runtime_enforced`.
+  - Phase 10 receipts are observability, not enforcement.
+  - Provider request model metadata is the preferred proof in later phases; subagent self-report is not proof.
+  Ensure no credentials or request secrets are documented or logged.
+  </action>
+  <verify>
+    <automated>grep -q 'resolved_by_gsd' docs/hermes-compatibility.md && grep -q 'runtime_enforced' docs/hermes-compatibility.md</automated>
+    <expected>Hermes compatibility docs explain the three receipt layers.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 5: Run focused workflow/doc guards and full tests</name>
+  <files>all modified files</files>
+  <action>
+  Run focused guards first, then full project tests.
+  </action>
+  <verify>
+    <automated>node --test tests/runtime-model-parity.test.cjs && npm test</automated>
+    <expected>Focused guards and full suite pass. If full suite is too slow or fails for unrelated reasons, record exact output and run all relevant focused tests from Plans 01–03.</expected>
+  </verify>
+</task>
+
+</tasks>
+
+<done>
+- `/gsd-plan-phase` and `/gsd-execute-phase` display binding receipts before subagent work.
+- Receipt display uses conservative runtime proof language.
+- Documentation explains resolver/workflow/runtime-proof separation.
+- Guard tests make future conflation harder.
+</done>

--- a/.planning/phases/10-runtime-binding-receipt-surface/10-CONTEXT.md
+++ b/.planning/phases/10-runtime-binding-receipt-surface/10-CONTEXT.md
@@ -1,0 +1,63 @@
+# Phase 10 Context — Runtime Binding Receipt Surface
+
+**Phase:** 10 — Runtime Binding Receipt Surface
+**Milestone:** v1.4 Hermes Runtime Model Binding Receipts
+**Mode:** Hermes text/sequential planning fallback; do not rely on per-agent Task(model) correctness while planning this milestone.
+
+## Goal
+
+Add structured model binding receipts to `init.plan-phase`, `init.execute-phase`, and the corresponding workflow transcript surfaces so users can see GSD resolver intent and runtime proof status before subagents spawn.
+
+## Requirements Covered
+
+- RCPT-01: `gsd-sdk query init.plan-phase <phase>` shows structured binding metadata for researcher, planner, checker.
+- RCPT-02: `gsd-sdk query init.execute-phase <phase>` shows structured binding metadata for executor, verifier.
+- RCPT-03: `/gsd-plan-phase` and `/gsd-execute-phase` show concise binding receipt before subagents spawn.
+- RCPT-04: Receipt output distinguishes `resolved_by_gsd`, `passed_to_runtime`, and `runtime_enforced`.
+
+## Locked Decisions
+
+1. Preserve flat model fields (`planner_model`, `executor_model`, etc.) for compatibility.
+2. Add structured receipts as additive JSON fields.
+3. Receipts must be present in both SDK and legacy CJS init surfaces to keep golden parity.
+4. `runtime_enforced` must be conservative in Phase 10: default to `unknown` unless real runtime proof exists.
+5. Do not use subagent self-reporting as model proof.
+6. Do not print credentials, API keys, tokens, passwords, or connection strings.
+7. Keep changes narrow and upstream-sync friendly: helper functions and small workflow-doc rendering changes, not broad workflow rewrites.
+
+## Implementation Areas
+
+- `sdk/src/query/runtime-model-contract.ts`
+  - Add receipt builder/serializer helper or extend existing serializer with receipt projection.
+- `sdk/src/query/init.ts`
+  - Add plan-phase and execute-phase receipt payloads.
+- `get-shit-done/bin/lib/model-profiles.cjs`
+  - Mirror receipt projection helper for legacy CJS.
+- `get-shit-done/bin/lib/init.cjs`
+  - Add receipt payloads to legacy init output.
+- `get-shit-done/workflows/plan-phase.md`
+  - Parse/render receipt before researcher/planner/checker spawning.
+- `get-shit-done/workflows/execute-phase.md`
+  - Parse/render receipt before executor/verifier spawning.
+- Tests:
+  - `sdk/src/query/config-query.test.ts`
+  - `sdk/src/query/init.test.ts`
+  - `sdk/src/golden/golden.integration.test.ts`
+  - `tests/runtime-model-parity.test.cjs`
+  - `tests/init.test.cjs`
+
+## Validation Commands
+
+Use these commands during execution:
+
+```bash
+npm run build:sdk
+node --test tests/runtime-model-parity.test.cjs tests/init.test.cjs
+npm test
+```
+
+Use SDK Vitest commands from `sdk/package.json` by running `(cd sdk && npx vitest run <relative-test-path>)`; do not pass Jest-only serial-run flags.
+
+## Acceptance Notes
+
+This phase is complete when receipts are visible and tested. It is not complete by proving Hermes runtime enforcement; that is Phase 11/12 scope.

--- a/.planning/phases/10-runtime-binding-receipt-surface/10-RESEARCH.md
+++ b/.planning/phases/10-runtime-binding-receipt-surface/10-RESEARCH.md
@@ -1,0 +1,203 @@
+# Phase 10 Research — Runtime Binding Receipt Surface
+
+**Date:** 2026-04-25
+**Phase:** 10 — Runtime Binding Receipt Surface
+**Milestone:** v1.4 Hermes Runtime Model Binding Receipts
+**Requirements:** RCPT-01, RCPT-02, RCPT-03, RCPT-04
+
+## Scope
+
+Phase 10 is the receipt-surface phase. It must make GSD's model-binding intent observable at SDK init and workflow boundaries without claiming Hermes child-agent enforcement is solved yet. The runtime enforcement channel itself belongs to Phase 11, and fail-fast enforcement/proof belongs to Phase 12.
+
+## Problem Statement
+
+The current project can resolve model overrides through `.planning/config.json`, and flat fields such as `planner_model` or `executor_model` can show the configured model token. That is not enough evidence that Hermes spawned subagents actually run with that model. Phase 10 must expose structured receipts that separate:
+
+1. `resolved_by_gsd` — GSD config/runtime resolver outcome.
+2. `passed_to_runtime` — whether the workflow has a concrete runtime token it intends to pass to subagent creation.
+3. `runtime_enforced` — whether the runtime has provided proof that the child agent actually used the requested model.
+
+For Phase 10, `runtime_enforced` should be `unknown` unless there is real runtime proof. Do not infer enforcement from `planner_model` strings or subagent self-reporting.
+
+## Current Config Evidence
+
+Project config currently uses Hermes runtime with explicit per-agent overrides:
+
+- `runtime: hermes`
+- `model_profile: inherit`
+- `resolve_model_ids: omit`
+- explicit overrides include:
+  - `gsd-phase-researcher: claude-opus-4-7`
+  - `gsd-planner: claude-opus-4-7`
+  - `gsd-plan-checker: openai/gpt-5.4`
+  - `gsd-executor: openai/gpt-5.4`
+  - `gsd-verifier: openai/gpt-5.4`
+
+This means Phase 10 must handle mixed provider families under Hermes and preserve configured tokens exactly in receipts.
+
+## Codebase Findings
+
+### SDK init queries
+
+Relevant file: `sdk/src/query/init.ts`
+
+- `initExecutePhase` currently returns flat model fields:
+  - `executor_model`
+  - `verifier_model`
+- `initPlanPhase` currently returns flat model fields:
+  - `researcher_model`
+  - `planner_model`
+  - `checker_model`
+- These fields are produced through `getModelAlias(...)` and projected as strings.
+- Existing workflow JSON consumers parse those flat keys, so Phase 10 must retain them for backwards compatibility.
+
+### Runtime model contract
+
+Relevant file: `sdk/src/query/runtime-model-contract.ts`
+
+Existing useful pieces:
+
+- `resolveAgentBinding(config, agent)` returns structured `RuntimeModelResolution`.
+- `serializeRuntimeModelResolution(resolution)` returns serialized fields including:
+  - `agent`
+  - `status`
+  - `known_agent`
+  - `runtime`
+  - `profile`
+  - `binding_kind`
+  - `source`
+  - `configured_model`
+  - `resolved_model`
+  - `model_token`
+  - `resolve_model_ids`
+  - `cross_ai`
+  - `runtime_capability`
+  - rejection fields for unsupported bindings
+- This is the right foundation for binding receipts.
+
+Gap: current serialized contract is resolver-centric. It does not explicitly surface receipt truth fields such as `resolved_by_gsd`, `passed_to_runtime`, `runtime_enforced`, or user-facing enforcement status.
+
+### Legacy CJS parity
+
+Relevant files:
+
+- `get-shit-done/bin/lib/init.cjs`
+- `get-shit-done/bin/lib/model-profiles.cjs`
+- `sdk/src/golden/golden.integration.test.ts`
+
+Important constraint: golden tests compare SDK init output to legacy `gsd-tools.cjs` output for `init.plan-phase` and `init.execute-phase`. Any new receipt fields added to SDK init output must also be added to legacy CJS output or golden parity will fail.
+
+### Existing tests
+
+Relevant files:
+
+- `sdk/src/query/init.test.ts`
+- `sdk/src/query/config-query.test.ts`
+- `tests/runtime-model-parity.test.cjs`
+- `tests/init.test.cjs`
+- `sdk/src/golden/golden.integration.test.ts`
+
+Current tests cover:
+
+- flat model fields exist
+- model overrides win over profile and `resolve_model_ids: omit`
+- inherit and runtime-default token projection
+- SDK/CJS semantic parity
+- SDK/CJS init JSON golden parity
+
+Needed Phase 10 coverage:
+
+- `init.plan-phase` includes structured binding receipts for researcher/planner/checker.
+- `init.execute-phase` includes structured binding receipts for executor/verifier.
+- flat fields remain unchanged.
+- receipts distinguish resolver truth from runtime proof.
+- SDK and CJS init outputs remain parity-compatible.
+
+### Workflow surface
+
+Relevant files:
+
+- `get-shit-done/workflows/plan-phase.md`
+- `get-shit-done/workflows/execute-phase.md`
+
+Current workflow init parsing lists only flat model fields. Phase 10 should update workflow docs/prompts so Hermes users see a concise binding receipt before subagents spawn. Because Phase 11 will implement/enforce the real Hermes channel, Phase 10 should print the receipt and mark runtime proof conservatively.
+
+## Recommended Receipt Shape
+
+Add a new init field that is structured but compact, for example:
+
+```json
+{
+  "model_binding_receipts": {
+    "workflow": "plan-phase",
+    "runtime": "hermes",
+    "agents": {
+      "researcher": {
+        "agent": "gsd-phase-researcher",
+        "configured_model": "claude-opus-4-7",
+        "resolved_model": "claude-opus-4-7",
+        "model_token": "claude-opus-4-7",
+        "source": "override",
+        "binding_kind": "explicit",
+        "provider_family": "anthropic",
+        "enforceability": "explicit-token-needs-runtime-proof",
+        "resolved_by_gsd": true,
+        "passed_to_runtime": true,
+        "runtime_enforced": "unknown"
+      }
+    }
+  }
+}
+```
+
+Also consider role-specific convenience keys to reduce workflow parsing complexity:
+
+- `researcher_binding_receipt`
+- `planner_binding_receipt`
+- `checker_binding_receipt`
+- `executor_binding_receipt`
+- `verifier_binding_receipt`
+
+However, avoid duplicated data if possible. A single `model_binding_receipts.agents` object plus role mapping is likely enough.
+
+## Receipt Semantics
+
+Proposed fields:
+
+- `agent`: canonical GSD agent name.
+- `role`: workflow role (`researcher`, `planner`, `checker`, `executor`, `verifier`).
+- `runtime`: detected runtime.
+- `profile`: resolved profile input.
+- `binding_kind`: `explicit`, `profile`, `inherit`, or `runtime-default`.
+- `source`: `override`, `profile`, `inherit-profile`, or `resolve-model-omit`.
+- `configured_model`: model token from config override, or null.
+- `resolved_model`: resolver output, or null.
+- `model_token`: token intended for runtime, or null.
+- `provider_family`: detected family (`anthropic`, `openai`, `google`, `unknown`).
+- `known_agent`: whether contract covers this agent.
+- `resolved_by_gsd`: true only when the GSD resolver returned `status: resolved`.
+- `passed_to_runtime`: true only when `model_token` is non-empty and intended to be passed through the workflow/runtime boundary.
+- `runtime_enforced`: `unknown` in Phase 10 unless runtime proof is provided by a later phase.
+- `enforceability`: short string suitable for CLI/transcript display:
+  - `explicit-token-needs-runtime-proof`
+  - `inherits-or-runtime-default`
+  - `unsupported`
+- `message` / `suggested_fix`: for unsupported cases.
+
+## Boundary With Later Phases
+
+Phase 10 must not attempt to solve the Hermes per-agent binding channel. It should make the missing proof visible. Phase 11 will identify and implement the actual channel. Phase 12 will add fail-fast validation and invalid-model/no-silent-fallback proof tests.
+
+## Risk Notes
+
+- Do not remove or rename flat model fields; existing workflows and tests depend on them.
+- Do not silently treat explicit override as runtime-enforced.
+- Do not use subagent self-reporting as proof.
+- Keep CJS and SDK output aligned to preserve golden tests.
+- Avoid leaking credentials in diagnostics; receipts should include model names, not API keys or request headers.
+
+## Open Implementation Questions
+
+1. Should receipts live only under `model_binding_receipts`, or also expose role-specific shortcut keys? Recommendation: one structured object first; add shortcuts only if workflow rendering becomes awkward.
+2. Should `runtime_enforced` be boolean or enum? Recommendation: enum/string (`unknown`, `false`, `true`) because Phase 10 has resolver truth but not runtime proof.
+3. Should provider family be derived from `configured_model`, `resolved_model`, or `model_token`? Recommendation: use the intended runtime token when present, otherwise `resolved_model`, otherwise `configured_model`.

--- a/.planning/phases/10-runtime-binding-receipt-surface/10-SUMMARY.md
+++ b/.planning/phases/10-runtime-binding-receipt-surface/10-SUMMARY.md
@@ -1,0 +1,119 @@
+# Phase 10 Summary: Runtime Binding Receipt Surface
+
+**Date:** 2026-04-26
+**Milestone:** v1.4 Hermes Runtime Model Binding Receipts
+**Status:** Complete
+
+## Objective
+
+Make model binding intent visible at GSD entry points before spawning agents, with structured metadata that separates GSD resolver truth from runtime enforcement proof.
+
+Phase 10 intentionally does **not** claim Hermes provider/wire-level enforcement. It creates the receipt surface and conservative proof vocabulary that Phase 11/12 will use to implement and verify actual runtime binding.
+
+## Completed Plans
+
+### 10-01 — Shared receipt projection
+
+Implemented a shared runtime/model receipt projection while preserving legacy flat model-token behavior.
+
+Key outcomes:
+- SDK `runtime-model-contract.ts` now serializes structured runtime model receipts.
+- Legacy CJS `model-profiles.cjs` mirrors the SDK receipt shape via `toBindingReceipt` / `serializeRuntimeModelResolution`.
+- Existing `*_model` / init token behavior remains backward compatible.
+- Receipt fields distinguish resolver intent from proof:
+  - `configured_model`
+  - `resolved_model`
+  - `model_token`
+  - `source`
+  - `binding_kind`
+  - `provider_family`
+  - `resolved_by_gsd`
+  - `passed_to_runtime`
+  - `runtime_enforced`
+  - `suggested_fix`
+
+### 10-02 — Init payload receipts + parity
+
+Added structured receipt payloads to both SDK and legacy CJS init surfaces.
+
+Key outcomes:
+- `init.plan-phase` exposes `model_binding_receipts` for:
+  - `researcher / gsd-phase-researcher`
+  - `planner / gsd-planner`
+  - `checker / gsd-plan-checker`
+- `init.execute-phase` exposes `model_binding_receipts` for:
+  - `executor / gsd-executor`
+  - `verifier / gsd-verifier`
+- Flat fields remain intact:
+  - `researcher_model`, `planner_model`, `checker_model`
+  - `executor_model`, `verifier_model`
+- SDK/CJS parity is covered by focused init tests and runtime-model parity tests.
+
+### 10-03 — Workflow transcript surface + docs
+
+Updated Hermes-visible workflow instructions so receipts are displayed before Task dispatch / fallback decisions.
+
+Key outcomes:
+- `/gsd-plan-phase` workflow now parses and displays `model_binding_receipts` before researcher/planner/checker Task dispatch.
+- `/gsd-execute-phase` workflow now parses and displays `model_binding_receipts` before executor/verifier Task dispatch and cross-AI fallback decisions.
+- `docs/hermes-compatibility.md` documents the conservative proof boundary.
+- Guard tests ensure workflows/docs keep the receipt wording and do not imply runtime proof.
+
+## Conservative Runtime Proof Boundary
+
+Phase 10 receipts are deliberately conservative:
+
+- `resolved_by_gsd=true` means the GSD resolver selected a model/binding.
+- `passed_to_runtime=true` means GSD has an explicit model token ready to pass.
+- `runtime_enforced=unknown` is **not** runtime proof.
+
+Actual Hermes child-agent/provider enforcement remains Phase 11/12 scope.
+
+## Validation
+
+Commands run successfully:
+
+```bash
+npm run build:sdk
+(cd sdk && npx vitest run src/query/config-query.test.ts -t 'runtime/model receipts|runtime-default bindings|unknown-agent bindings')
+(cd sdk && npx vitest run src/query/init.test.ts -t 'initExecutePhase|initPlanPhase')
+node --test tests/runtime-model-parity.test.cjs
+node --test tests/init.test.cjs
+npm run test:hermes
+node --test tests/workflow-size-budget.test.cjs
+npm test
+```
+
+Final full-suite result:
+
+```text
+npm test → PASS
+# tests 5593
+# suites 1002
+# pass 5593
+# fail 0
+```
+
+Notes:
+- `npm run build:sdk` emits the existing Node engine warning because the local runtime is Node v20 while SDK package metadata requests Node >=22.
+- `npm ci` reports existing audit findings; no dependency changes were introduced for Phase 10.
+
+## Commits
+
+- `710878b1 test(10-01): add failing runtime binding receipt SDK tests`
+- `5a542cfd feat(10-01): add runtime model receipt projection`
+- `0a1d1d11 feat(10-01): mirror binding receipts in legacy runtime contract`
+- `f762ed30 test(10-02): require SDK init binding receipts`
+- `5c3f80f0 feat(10-02): emit SDK init binding receipts`
+- `09c45e03 test(10-02): require legacy init binding receipts`
+- `88b1f198 feat(10-02): emit legacy init binding receipts`
+- `f4172755 test(10-03): guard runtime binding receipt wording`
+- `0ba811a0 docs(10-03): surface runtime binding receipt status`
+- `d6da40c0 fix(test): accept gsd-hermes 1.4 version line`
+- `02c93dcc fix(10-03): keep execute workflow under size budget`
+
+## Next Route
+
+Proceed to Phase 11: Hermes Per-Agent Binding Channel.
+
+Phase 11 should identify and implement/prove the real Hermes runtime binding path, or fail fast before spawn when a configured model cannot be enforced.

--- a/.planning/phases/10-runtime-binding-receipt-surface/10-VALIDATION.md
+++ b/.planning/phases/10-runtime-binding-receipt-surface/10-VALIDATION.md
@@ -1,0 +1,79 @@
+---
+phase: 10
+slug: runtime-binding-receipt-surface
+status: draft
+nyquist_compliant: true
+wave_0_complete: true
+created: 2026-04-25
+---
+
+# Phase 10 — Validation Strategy
+
+> Per-phase validation contract for runtime binding receipt observability.
+
+---
+
+## Test Infrastructure
+
+**Node engine note:** `package.json` and `sdk/package.json` declare `node >=22.0.0`. Before executing this phase, run `node --version`; if the local shell is below 22, record the engine mismatch in SUMMARY and use the project-approved Node 22 toolchain before treating test failures as product failures.
+
+| Property | Value |
+|----------|-------|
+| **Framework** | node:test + vitest |
+| **Config file** | `package.json`, `sdk/package.json`, `sdk/tsconfig.json` |
+| **Quick run command** | `npm run build:sdk && node --test tests/runtime-model-parity.test.cjs tests/init.test.cjs` |
+| **Full suite command** | `npm test` |
+| **Estimated runtime** | focused: ~30-90s; full: project-dependent |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run the task's focused automated command.
+- **After every plan wave:** Run `npm run build:sdk && node --test tests/runtime-model-parity.test.cjs tests/init.test.cjs`.
+- **Before `/gsd-verify-work`:** Run `npm test` or record exact unrelated blockers if full suite fails.
+- **Max feedback latency:** one task.
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 10-01-01 | 01 | 1 | RCPT-04 | credential-leak / false-proof | Receipt helper separates resolver truth from runtime proof without secrets | unit | `npm run build:sdk && (cd sdk && npx vitest run src/query/config-query.test.ts)` | ✅ | ⬜ pending |
+| 10-01-02 | 01 | 1 | RCPT-04 | semantic-drift | SDK receipt projection is additive and does not alter flat token projection | unit | `npm run build:sdk && (cd sdk && npx vitest run src/query/config-query.test.ts)` | ✅ | ⬜ pending |
+| 10-01-03 | 01 | 1 | RCPT-04 | sdk-cjs-drift | CJS receipt projection mirrors SDK receipt semantics | parity | `npm run build:sdk && node --test tests/runtime-model-parity.test.cjs` | ✅ | ⬜ pending |
+| 10-02-01 | 02 | 2 | RCPT-01 | missing-plan-receipts | plan init has researcher/planner/checker receipts | unit | `npm run build:sdk && (cd sdk && npx vitest run src/query/init.test.ts)` | ✅ | ⬜ pending |
+| 10-02-02 | 02 | 2 | RCPT-02 | missing-execute-receipts | execute init has executor/verifier receipts | unit | `npm run build:sdk && (cd sdk && npx vitest run src/query/init.test.ts)` | ✅ | ⬜ pending |
+| 10-02-03 | 02 | 2 | RCPT-01/02 | sdk-cjs-init-drift | SDK and legacy CJS init outputs remain aligned | golden | `npm run build:sdk && (cd sdk && npx vitest run src/golden/golden.integration.test.ts)` | ✅ | ⬜ pending |
+| 10-03-01 | 03 | 3 | RCPT-03 | invisible-receipts | plan/execute workflows instruct visible receipt display | doc guard | `node --test tests/runtime-model-parity.test.cjs` | ✅ | ⬜ pending |
+| 10-03-02 | 03 | 3 | RCPT-04 | false-runtime-proof | docs explain runtime_enforced=unknown is not proof | doc guard | `grep -q 'runtime_enforced' docs/hermes-compatibility.md` | ✅ | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+Existing infrastructure covers all phase requirements. No new framework installation is required.
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Transcript wording is concise and not misleading | RCPT-03/RCPT-04 | Workflow transcript readability is partly qualitative | Run `gsd-sdk query init.plan-phase 10`; inspect workflow display instructions and ensure they would show configured/resolved/source/binding/passed/runtime proof fields without claiming enforcement |
+
+---
+
+## Validation Sign-Off
+
+- [x] All tasks have `<automated>` verify or Wave 0 dependencies
+- [x] Sampling continuity: no 3 consecutive tasks without automated verify
+- [x] Wave 0 covers all MISSING references
+- [x] No watch-mode flags
+- [x] Feedback latency < one task
+- [x] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** draft 2026-04-25

--- a/.planning/phases/11-hermes-per-agent-binding-channel/11-01-PLAN.md
+++ b/.planning/phases/11-hermes-per-agent-binding-channel/11-01-PLAN.md
@@ -1,0 +1,138 @@
+---
+phase: 11-hermes-per-agent-binding-channel
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - /home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py
+  - /home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py
+  - docs/hermes-compatibility.md
+autonomous: true
+requirements:
+  - BIND-01
+  - BIND-02
+  - BIND-03
+must_haves:
+  truths:
+    - "GSD resolver receipts are not runtime proof; Phase 11 must identify a real Hermes child-agent binding channel."
+    - "The canonical seam is Hermes delegate_task top-level model plus tasks[].model, not subagent self-report."
+    - "ACP --model may remain a transport-specific option, but it is not the general GSD per-agent binding channel."
+    - "Child-construction proof is a Phase 11 proof boundary; provider wire-level proof remains Phase 12 unless explicitly instrumented."
+  artifacts:
+    - path: "/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py"
+      provides: "failing/then-passing schema contract tests for delegate_task model fields"
+      contains: "tasks[].model"
+    - path: "/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py"
+      provides: "authoritative delegate_task schema surface for top-level and per-task model"
+      contains: "model"
+    - path: "docs/hermes-compatibility.md"
+      provides: "documented Phase 11 binding-channel decision and proof boundary"
+      contains: "delegate_task model"
+---
+
+<objective>
+Trace Hermes delegation entry points and lock the smallest upstream-syncable binding seam in tests and docs: direct `delegate_task(model=...)` and `tasks[].model` feeding Hermes child `AIAgent(model=...)` construction.
+
+This plan closes the discovery/contract part of BIND-01 and creates the executable contract that Plan 11-02 implements fully.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/REQUIREMENTS.md
+@.planning/ROADMAP.md
+@.planning/phases/11-hermes-per-agent-binding-channel/11-CONTEXT.md
+@.planning/phases/11-hermes-per-agent-binding-channel/11-RESEARCH.md
+@docs/hermes-compatibility.md
+@/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py
+@/home/whiskey/.hermes/hermes-agent/run_agent.py
+@/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py
+
+<current_findings>
+- Current Hermes source has `_build_child_agent(..., model, ...)` and constructs `AIAgent(model=effective_model)`.
+- Current `DELEGATE_TASK_SCHEMA` has no top-level `model` and no `tasks[].model`.
+- Current registry handler and `run_agent._dispatch_delegate_task(...)` do not pass `model`.
+- Current `delegate_task(...)` passes `model=creds["model"]`, where `creds["model"]` comes from global Hermes `delegation.model` rather than GSD per-agent overrides.
+</current_findings>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add failing schema tests for the chosen model-binding seam</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py</files>
+  <action>
+  Add tests near existing `DELEGATE_TASK_SCHEMA` coverage that assert:
+  - `DELEGATE_TASK_SCHEMA["parameters"]["properties"]["model"]` exists, is a string, and documents that it overrides child model for this delegate call.
+  - `DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]["model"]` exists, is a string, and documents per-task override behavior.
+  - Schema descriptions explicitly state precedence: task model > top-level model > `delegation.model` > parent model inheritance.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/tools/test_delegate.py -q -k "schema and model"</automated>
+    <expected>Fails before schema implementation because `model` is absent.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 2: Add the schema fields without changing runtime behavior yet</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py</files>
+  <action>
+  In `DELEGATE_TASK_SCHEMA`:
+  - Add top-level `model` property.
+  - Add per-task `model` property inside `tasks.items.properties`.
+  - Include precise descriptions:
+    - model is optional.
+    - model is the child model requested by the caller.
+    - model supports exact configured runtime model IDs.
+    - `inherit`, empty, or absent should preserve inheritance.
+    - per-task value overrides top-level value in batch mode.
+  Do not yet alter function signatures in this task; that is Plan 11-02.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/tools/test_delegate.py -q -k "schema and model"</automated>
+    <expected>Schema tests pass; runtime propagation tests are still absent/pending for Plan 11-02.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 3: Document the Phase 11 seam and proof boundary in GSD docs</name>
+  <files>docs/hermes-compatibility.md</files>
+  <action>
+  Add a concise section under Runtime-Model Composition or Runtime Binding Receipt Layers:
+  - State that Phase 11's canonical direct Hermes seam is `delegate_task(model=...)` plus `tasks[].model`.
+  - State that `delegation.model` remains a global default, not a per-agent GSD override channel.
+  - State that ACP `--model` is transport-specific and may be used only when ACP subprocess routing is selected.
+  - State the proof boundary: child `AIAgent(model=...)` construction is Phase 11 proof; provider request/wire-level `model=` is Phase 12 proof.
+  - Reiterate that subagent self-report is not proof.
+  Keep the doc additive and avoid claiming full provider enforcement.
+  </action>
+  <verify>
+    <automated>node --test tests/hermes-docs.test.cjs || true</automated>
+    <expected>If docs test suite has unrelated assumptions, record the failure and continue; this task's required check is that the new section is present and does not contradict Phase 10 wording.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 4: Run focused syntax and schema checks</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py, /home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py, docs/hermes-compatibility.md</files>
+  <action>
+  Run focused checks and inspect diff for scope creep.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py && .venv/bin/python -m pytest tests/tools/test_delegate.py -q -k "schema and model"</automated>
+    <expected>Schema tests and py_compile pass. Git diff shows only schema tests, schema fields, and docs contract text.</expected>
+  </verify>
+</task>
+
+</tasks>
+
+<done>
+- Hermes binding seam is explicitly selected and documented.
+- `delegate_task` schema exposes top-level `model` and `tasks[].model`.
+- Plan 11-02 can implement runtime propagation against a committed schema contract.
+</done>

--- a/.planning/phases/11-hermes-per-agent-binding-channel/11-02-PLAN.md
+++ b/.planning/phases/11-hermes-per-agent-binding-channel/11-02-PLAN.md
@@ -1,0 +1,206 @@
+---
+phase: 11-hermes-per-agent-binding-channel
+plan: 02
+type: execute
+wave: 2
+depends_on:
+  - 11-01-PLAN.md
+files_modified:
+  - /home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py
+  - /home/whiskey/.hermes/hermes-agent/run_agent.py
+  - /home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py
+autonomous: true
+requirements:
+  - BIND-02
+  - BIND-03
+must_haves:
+  truths:
+    - "A GSD-originated explicit model must reach Hermes child AIAgent construction exactly, not only the GSD receipt surface."
+    - "Per-task model in batch mode must override top-level model and allow heterogeneous child models."
+    - "Absent, empty, or inherit model preserves existing parent/delegation inheritance behavior."
+    - "Existing delegation.model global default behavior remains backward compatible when no per-call or per-task model is supplied."
+  artifacts:
+    - path: "/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py"
+      provides: "delegate_task model signature, normalization, precedence, registry pass-through, and child build propagation"
+      contains: "task_model"
+    - path: "/home/whiskey/.hermes/hermes-agent/run_agent.py"
+      provides: "single dispatch pass-through for new model field"
+      contains: "function_args.get(\"model\")"
+    - path: "/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py"
+      provides: "child construction proof for top-level, per-task, delegation default, and inherit behavior"
+      contains: "AIAgent"
+---
+
+<objective>
+Implement actual Hermes model propagation so direct `delegate_task(model=...)` and batch `tasks[].model` construct child `AIAgent` instances with the requested model. Preserve current behavior when no explicit model is supplied.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/11-hermes-per-agent-binding-channel/11-CONTEXT.md
+@.planning/phases/11-hermes-per-agent-binding-channel/11-RESEARCH.md
+@.planning/phases/11-hermes-per-agent-binding-channel/11-01-PLAN.md
+@/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py
+@/home/whiskey/.hermes/hermes-agent/run_agent.py
+@/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py
+
+<binding_precedence>
+For every child task, resolve the model in this order:
+1. `tasks[i].model` when present and non-empty and not `inherit`.
+2. top-level `model` when present and non-empty and not `inherit`.
+3. Hermes global `delegation.model` from `_resolve_delegation_credentials(...)`.
+4. parent model inheritance in `_build_child_agent`.
+
+Normalize string values by trimming whitespace. Treat `"inherit"` case-insensitively as no explicit child model.
+</binding_precedence>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add failing child construction tests for top-level model</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py</files>
+  <action>
+  Add a test using existing delegate test patterns/mocks that calls:
+
+  ```python
+  delegate_task(goal="use direct model", model="openai/gpt-5.4", parent_agent=parent)
+  ```
+
+  Assert the mocked `AIAgent(...)` constructor receives `model="openai/gpt-5.4"`, even when `parent.model` is a different value and `delegation.model` is unset.
+
+  Also assert the final JSON result or active registry/progress metadata includes the child model if existing test utilities make that observable without relying on subagent self-report.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/tools/test_delegate.py -q -k "top_level_model"</automated>
+    <expected>Fails before implementation because delegate_task does not accept/pass `model`.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add failing batch tests for per-task heterogeneous models</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py</files>
+  <action>
+  Add a test with two tasks:
+
+  ```python
+  delegate_task(
+      tasks=[
+          {"goal": "planner", "model": "claude-opus-4-7"},
+          {"goal": "checker", "model": "openai/gpt-5.4"},
+      ],
+      model="fallback-model-should-not-win",
+      parent_agent=parent,
+  )
+  ```
+
+  Assert two child `AIAgent(...)` constructor calls use `claude-opus-4-7` and `openai/gpt-5.4` respectively. Assert the top-level fallback does not override per-task model.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/tools/test_delegate.py -q -k "per_task_model or heterogeneous"</automated>
+    <expected>Fails before implementation because tasks[].model is ignored.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Add inheritance/default regression tests</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py</files>
+  <action>
+  Add tests proving existing behavior remains:
+  - No top-level/per-task model + `delegation.model="configured-child-model"` constructs child with `configured-child-model`.
+  - Top-level `model="inherit"` with parent model `parent-model` and no `delegation.model` constructs child with `parent-model` through `_build_child_agent` fallback.
+  - Per-task `model="inherit"` does not override a valid top-level model if the intended semantics choose explicit inherit to mean parent inheritance; choose and document the behavior. Preferred strict behavior: per-task `inherit` means no explicit per-task model, so top-level model may still apply unless GSD deliberately omits top-level model for that task. If this is surprising, document it in schema and tests.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/tools/test_delegate.py -q -k "delegation_model or inherit_model"</automated>
+    <expected>Fails only where new normalization is missing; existing delegation.model behavior should pass after implementation.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 4: Implement model argument plumbing in delegate_tool.py</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py</files>
+  <action>
+  Implement the minimal propagation:
+
+  1. Add helper:
+  ```python
+  def _normalize_requested_model(value: Any) -> Optional[str]:
+      if not isinstance(value, str):
+          return None
+      model = value.strip()
+      if not model or model.lower() == "inherit":
+          return None
+      return model
+  ```
+
+  2. Add `model: Optional[str] = None` to `delegate_task(...)` signature.
+  3. Normalize top-level model once: `top_model = _normalize_requested_model(model)`.
+  4. For each task, compute:
+  ```python
+  task_model = _normalize_requested_model(t.get("model")) or top_model or creds["model"]
+  ```
+  5. Pass `model=task_model` to `_build_child_agent(...)`.
+  6. Update registry handler to pass `args.get("model")`.
+  7. Keep credential/provider resolution unchanged; do not log API keys or secrets.
+  8. Keep `delegation.model` fallback unchanged when per-call/per-task model is absent.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/tools/test_delegate.py -q -k "model"</automated>
+    <expected>All new model propagation tests pass.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 5: Pass model through run_agent delegate dispatch</name>
+  <files>/home/whiskey/.hermes/hermes-agent/run_agent.py</files>
+  <action>
+  Update `AIAgent._dispatch_delegate_task(function_args)`:
+
+  ```python
+  return _delegate_task(
+      goal=function_args.get("goal"),
+      context=function_args.get("context"),
+      toolsets=function_args.get("toolsets"),
+      tasks=function_args.get("tasks"),
+      max_iterations=function_args.get("max_iterations"),
+      model=function_args.get("model"),
+      acp_command=function_args.get("acp_command"),
+      acp_args=function_args.get("acp_args"),
+      role=function_args.get("role"),
+      parent_agent=self,
+  )
+  ```
+
+  Add or extend a unit test if there is existing `_dispatch_delegate_task` coverage; otherwise rely on delegate schema/handler tests and document the dispatch change in the plan summary.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m py_compile run_agent.py tools/delegate_tool.py</automated>
+    <expected>py_compile passes.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 6: Run Hermes focused delegation verification</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py, /home/whiskey/.hermes/hermes-agent/run_agent.py, /home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py</files>
+  <action>
+  Run focused tests and inspect diffs.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/tools/test_delegate.py -q && .venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py tests/tools/test_delegate.py</automated>
+    <expected>Delegation test file passes and Python sources compile. Any pre-existing unrelated lint failures are recorded, not silently fixed.</expected>
+  </verify>
+</task>
+
+</tasks>
+
+<done>
+- Direct `delegate_task(model=...)` constructs child `AIAgent` with the requested model.
+- Batch `tasks[].model` can construct heterogeneous children.
+- `delegation.model` and parent inheritance remain backward compatible.
+- No subagent self-report is used as proof.
+</done>

--- a/.planning/phases/11-hermes-per-agent-binding-channel/11-03-PLAN.md
+++ b/.planning/phases/11-hermes-per-agent-binding-channel/11-03-PLAN.md
@@ -1,0 +1,203 @@
+---
+phase: 11-hermes-per-agent-binding-channel
+plan: 03
+type: execute
+wave: 3
+depends_on:
+  - 11-02-PLAN.md
+files_modified:
+  - sdk/src/query/runtime-model-contract.ts
+  - sdk/src/query/runtime-model-validation.ts
+  - sdk/src/query/init.test.ts
+  - get-shit-done/bin/lib/init.cjs
+  - tests/init.test.cjs
+  - get-shit-done/workflows/plan-phase.md
+  - get-shit-done/workflows/execute-phase.md
+  - docs/hermes-compatibility.md
+autonomous: true
+requirements:
+  - BIND-01
+  - BIND-02
+  - BIND-03
+  - BIND-04
+must_haves:
+  truths:
+    - "Hermes explicit model support must be tied to an actual binding channel, not assumed from resolver success."
+    - "When an explicit model is configured and the Hermes binding channel is unavailable, GSD must fail before spawning agents."
+    - "Receipts must distinguish child-construction proof from provider wire-level proof."
+    - "Flat legacy model fields must remain backward compatible while structured metadata gains stricter diagnostics."
+  artifacts:
+    - path: "sdk/src/query/runtime-model-validation.ts"
+      provides: "pre-spawn validation/capability diagnostics for Hermes binding channel availability"
+      contains: "Hermes delegate_task model binding"
+    - path: "sdk/src/query/runtime-model-contract.ts"
+      provides: "receipt/capability metadata that does not overclaim provider enforcement"
+      contains: "runtime_enforced"
+    - path: "get-shit-done/bin/lib/init.cjs"
+      provides: "legacy init parity for pre-spawn fail-fast diagnostics or binding metadata"
+      contains: "model_binding_receipts"
+    - path: "get-shit-done/workflows/plan-phase.md"
+      provides: "Hermes runtime instruction to pass model tokens through delegate_task model field or fail"
+      contains: "delegate_task"
+    - path: "get-shit-done/workflows/execute-phase.md"
+      provides: "same execution-time guidance for executor/verifier spawns"
+      contains: "delegate_task"
+---
+
+<objective>
+Connect the new Hermes binding channel back to GSD so explicit per-agent overrides are either passed to Hermes through an enforceable child-construction seam or rejected pre-spawn with actionable diagnostics.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/11-hermes-per-agent-binding-channel/11-CONTEXT.md
+@.planning/phases/11-hermes-per-agent-binding-channel/11-RESEARCH.md
+@.planning/phases/11-hermes-per-agent-binding-channel/11-01-PLAN.md
+@.planning/phases/11-hermes-per-agent-binding-channel/11-02-PLAN.md
+@sdk/src/query/runtime-model-contract.ts
+@sdk/src/query/runtime-model-validation.ts
+@sdk/src/query/init.test.ts
+@get-shit-done/bin/lib/init.cjs
+@tests/init.test.cjs
+@get-shit-done/workflows/plan-phase.md
+@get-shit-done/workflows/execute-phase.md
+@docs/hermes-compatibility.md
+
+<policy>
+- Keep `runtime_enforced` conservative unless provider request proof exists.
+- If adding a child-construction proof field, name it so it cannot be confused with wire-level provider proof.
+- Do not remove flat fields (`planner_model`, `checker_model`, `executor_model`, etc.).
+- Fail-fast diagnostics must name: runtime, agent, configured model, missing/unsupported channel, and suggested fix.
+</policy>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add failing SDK init tests for Hermes binding-channel metadata</name>
+  <files>sdk/src/query/init.test.ts, sdk/src/query/runtime-model-contract.ts</files>
+  <action>
+  Add or extend `initPlanPhase`/`initExecutePhase` tests for `runtime: "hermes"` with explicit `model_overrides`.
+
+  Assert each explicit receipt includes enough metadata to decide whether Hermes can enforce child construction, for example one of these shapes:
+
+  Option A, if adding a new field:
+  ```json
+  {
+    "runtime_binding_channel": {
+      "kind": "hermes-delegate-task-model",
+      "available": true,
+      "proof_level": "child-construction"
+    }
+  }
+  ```
+
+  Option B, if keeping existing fields only:
+  - `runtime_capability.supports_explicit_model === true`
+  - `passed_to_runtime === true`
+  - `runtime_enforced === "unknown"`
+  - `enforceability === "explicit-token-needs-runtime-proof"`
+  - a new validation summary separately states the Hermes delegate model channel is available.
+
+  Prefer Option A if the schema change remains additive and small.
+  </action>
+  <verify>
+    <automated>npm run build:sdk && (cd sdk && npx vitest run src/query/init.test.ts -t "initPlanPhase|initExecutePhase|Hermes")</automated>
+    <expected>Fails before metadata/capability implementation if the new field or summary is absent.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add failing fail-fast diagnostics tests for missing Hermes binding channel</name>
+  <files>sdk/src/query/runtime-model-validation.ts, sdk/src/query/init.test.ts, tests/init.test.cjs</files>
+  <action>
+  Introduce a test hook or pure helper input that simulates `runtime: "hermes"` with explicit model overrides but no Hermes delegate model channel.
+
+  Assert validation fails before spawn with an actionable issue:
+  - `agent`: the affected agent, e.g. `gsd-planner`.
+  - `runtime`: `hermes`.
+  - `configuredModel`: exact configured model.
+  - `rejectionReason` or equivalent: `runtime-model-unsupported` or a new `missing-runtime-binding-channel` if the type is extended.
+  - `reason`: names missing Hermes `delegate_task.model` / `tasks[].model` channel.
+  - `suggestedFix`: upgrade/restart Hermes Agent with delegate model support, use `inherit`, remove override, or use explicit cross-AI execution where appropriate.
+
+  The helper should be pure/deterministic; do not shell out to the live Hermes checkout inside unit tests unless already supported by test fixtures.
+  </action>
+  <verify>
+    <automated>npm run build:sdk && (cd sdk && npx vitest run src/query/init.test.ts -t "binding channel|fail fast") && node --test tests/init.test.cjs</automated>
+    <expected>Fails before fail-fast helper/diagnostic implementation.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 3: Implement channel-aware validation without broad workflow rewrites</name>
+  <files>sdk/src/query/runtime-model-validation.ts, sdk/src/query/runtime-model-contract.ts, get-shit-done/bin/lib/init.cjs</files>
+  <action>
+  Implement the smallest additive contract:
+
+  1. Add a `HermesBindingChannelCapability` / `RuntimeBindingChannel` type or equivalent helper that can represent:
+     - kind: `hermes-delegate-task-model`
+     - available: boolean
+     - proof_level: `child-construction`
+     - reason/suggested_fix when unavailable
+
+  2. Default Hermes capability to available only when the planned/runtime environment declares `delegate_task.model` support. If no dynamic schema detection exists in GSD, make the init helper accept an injected capability for tests and default to conservative unavailable for explicit overrides unless the packaged/runtime marker is present.
+
+  3. Ensure explicit Hermes model overrides call this capability gate before any workflow spawn. If unavailable, return/throw the same validation issue shape used by existing runtime-model validation.
+
+  4. Keep SDK and CJS init outputs aligned enough for `tests/runtime-model-parity.test.cjs` and `tests/init.test.cjs`.
+
+  5. Do not set provider-level `runtime_enforced` to true from this change. If a child-construction field is added, keep it semantically separate.
+  </action>
+  <verify>
+    <automated>npm run build:sdk && (cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts) && node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs</automated>
+    <expected>SDK/CJS init surfaces pass; explicit missing-channel case fails fast; normal available-channel case remains backward compatible.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 4: Update Hermes workflow instructions to use delegate_task model channel</name>
+  <files>get-shit-done/workflows/plan-phase.md, get-shit-done/workflows/execute-phase.md</files>
+  <action>
+  Add compact Hermes-specific guidance near existing receipt output/spawn instructions:
+
+  - For Hermes runtime, when `model_binding_receipts.<role>.model_token` is non-empty and channel is available, pass that token into the Hermes delegate call as `model` for single-task spawn or `tasks[].model` for batch spawn.
+  - If channel unavailable and binding is explicit, stop with the pre-spawn validation error; do not spawn and hope the child uses the right model.
+  - Do not claim wire-level provider proof from the transcript.
+
+  Keep wording concise to preserve workflow size budgets.
+  </action>
+  <verify>
+    <automated>node --test tests/workflow-size-budget.test.cjs</automated>
+    <expected>Workflow files stay under configured size budgets.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 5: Update compatibility docs and run focused gates</name>
+  <files>docs/hermes-compatibility.md</files>
+  <action>
+  Update docs with:
+  - how to interpret the new binding-channel metadata;
+  - fail-fast behavior when the channel is absent;
+  - child-construction proof vs provider proof distinction;
+  - restart note if a running Hermes CLI/gateway has not loaded the patched delegate tool.
+  </action>
+  <verify>
+    <automated>npm run build:sdk && (cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts) && node --test tests/runtime-model-parity.test.cjs tests/init.test.cjs tests/workflow-size-budget.test.cjs && npm run test:hermes</automated>
+    <expected>Focused SDK, CJS, workflow-size, and Hermes compatibility gates pass.</expected>
+  </verify>
+</task>
+
+</tasks>
+
+<done>
+- GSD no longer overclaims Hermes explicit binding support without an actual delegate model channel.
+- Explicit Hermes overrides either route into `delegate_task.model` / `tasks[].model` or fail before spawn.
+- Diagnostics name the runtime, agent, configured model, missing channel, and suggested fix.
+- Receipt/proof wording remains conservative about provider wire-level enforcement.
+</done>

--- a/.planning/phases/11-hermes-per-agent-binding-channel/11-CONTEXT.md
+++ b/.planning/phases/11-hermes-per-agent-binding-channel/11-CONTEXT.md
@@ -1,0 +1,120 @@
+# Phase 11 Context — Hermes Per-Agent Binding Channel
+
+## Mission
+
+Implement or prove the real Hermes child-agent model binding path for GSD-originated per-agent model overrides. If a configured explicit model cannot be carried into Hermes child construction, fail before spawning any subagent.
+
+Phase 11 is not about adding more resolver receipts; Phase 10 already did that. Phase 11 is about the runtime binding channel between GSD workflow intent and Hermes child `AIAgent(model=...)` construction.
+
+## Requirement mapping
+
+| Requirement | Phase 11 responsibility |
+| --- | --- |
+| BIND-01 | Identify and document the authoritative Hermes binding path. |
+| BIND-02 | Ensure explicit GSD overrides construct Hermes child `AIAgent` with the expected model instead of inheriting `parent_agent.model`. |
+| BIND-03 | Preserve per-task model bindings in batch/multi-agent spawns. |
+| BIND-04 | Emit a clear pre-spawn validation error when the binding path is unavailable or unsupported. |
+
+## Current repo state
+
+- Runtime config: `.planning/config.json` has `runtime: "hermes"`, `model_profile: "inherit"`, `resolve_model_ids: "omit"`, and explicit `model_overrides`.
+- Phase 10 closeout is committed at `f20a5a52 docs(10): close runtime binding receipt phase`.
+- Live `gsd-sdk query init.plan-phase 11` output shows explicit binding receipts for researcher/planner/checker with `passed_to_runtime=true` and `runtime_enforced=unknown`.
+- `.planning/phases/11-hermes-per-agent-binding-channel/` is the Phase 11 directory.
+
+## Current Hermes source truth
+
+Checked source: `/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py`
+
+Important current behavior:
+
+- `DELEGATE_TASK_SCHEMA` does not expose `model` at top-level or per-task.
+- `delegate_task(...)` signature does not accept `model`.
+- Registry handler does not pass `model`.
+- `run_agent.py::_dispatch_delegate_task(...)` does not pass `model`.
+- `_resolve_delegation_credentials(...)` reads global `delegation.model` from Hermes config.
+- `_build_child_agent(..., model, ...)` already constructs `AIAgent(model=effective_model)` with `effective_model = model or parent_agent.model`.
+- Batch construction passes the same `creds["model"]` to every child today.
+
+Therefore the smallest binding seam is to add a model argument before `_build_child_agent`, not to redesign child construction.
+
+## Implementation posture
+
+Prefer this order:
+
+1. Patch Hermes Agent's `delegate_task` schema/signature/dispatch to support `model` and `tasks[].model`.
+2. Add Hermes Agent unit tests that prove child construction receives top-level and per-task model tokens.
+3. Update GSD/Hermes workflows or generated skill adapter guidance so Hermes runtime uses `delegate_task(..., model=receipt.model_token)` instead of relying on Claude-style `Task(model=...)` semantics.
+4. Add pre-spawn capability validation in GSD so explicit Hermes model overrides fail fast if the active Hermes delegate schema lacks the model field.
+
+## Binding semantics to preserve
+
+- Explicit model token:
+  - non-empty model string should reach Hermes child construction exactly as configured/resolved.
+- Inherit binding:
+  - empty, null, absent, or literal `inherit` from GSD should omit the child model and preserve parent inheritance.
+- Runtime-default binding:
+  - no explicit model token should not fabricate a model; it may remain runtime default/inherit depending on the runtime path.
+- Batch binding:
+  - per-task `model` beats top-level `model`.
+  - top-level `model` beats global `delegation.model`.
+  - `delegation.model` remains the global default when no per-call/per-task model is specified.
+  - parent model inheritance remains the fallback.
+
+## Files likely to change during execution
+
+Hermes Agent sibling repo:
+
+- `/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py`
+- `/home/whiskey/.hermes/hermes-agent/run_agent.py`
+- `/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py`
+
+GSD Hermes repo:
+
+- `sdk/src/query/runtime-model-contract.ts`
+- `sdk/src/query/runtime-model-validation.ts`
+- `get-shit-done/bin/lib/model-profiles.cjs`
+- `get-shit-done/bin/lib/init.cjs`
+- `get-shit-done/workflows/plan-phase.md`
+- `get-shit-done/workflows/execute-phase.md`
+- `tests/runtime-model-parity.test.cjs`
+- `tests/init.test.cjs`
+- possibly new focused tests under `tests/` for Hermes binding-channel/pre-spawn diagnostics
+- `docs/hermes-compatibility.md`
+
+## Verification commands
+
+Hermes Agent focused verification:
+
+```bash
+cd /home/whiskey/.hermes/hermes-agent
+.venv/bin/python -m pytest tests/tools/test_delegate.py -q
+.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py
+```
+
+GSD Hermes focused verification:
+
+```bash
+cd /home/whiskey/workspace/project/central/v2/gsd-hermes
+npm run build:sdk
+cd sdk && npx vitest run src/query/config-query.test.ts src/query/init.test.ts
+cd .. && node --test tests/runtime-model-parity.test.cjs tests/init.test.cjs
+npm run test:hermes
+```
+
+Full gate when feasible:
+
+```bash
+npm test
+```
+
+## Proof boundary
+
+Phase 11 acceptance should require child-construction proof:
+
+- static schema includes `model` and `tasks[].model`;
+- dispatch pass-through includes `model`;
+- mocked `AIAgent` constructor receives expected model values for single and batch calls;
+- GSD pre-spawn validation rejects explicit overrides when that seam is absent.
+
+Provider wire-level proof remains Phase 12 unless Phase 11 intentionally adds sanitized provider request instrumentation. Do not treat subagent self-report as proof.

--- a/.planning/phases/11-hermes-per-agent-binding-channel/11-RESEARCH.md
+++ b/.planning/phases/11-hermes-per-agent-binding-channel/11-RESEARCH.md
@@ -1,0 +1,187 @@
+# Phase 11 Research — Hermes Per-Agent Binding Channel
+
+## Research question
+
+Phase 10 made GSD runtime/model binding receipts visible, but left `runtime_enforced` conservative (`unknown`). Phase 11 must identify the actual Hermes channel that can bind a spawned child agent to a per-agent model, or define a pre-spawn failure path when that channel is absent.
+
+Requirements covered: BIND-01, BIND-02, BIND-03, BIND-04.
+
+## Inputs inspected
+
+- `.planning/REQUIREMENTS.md` — Phase 11 owns BIND-01..BIND-04.
+- `.planning/ROADMAP.md` — Phase 11 success criteria and planned 11-01..11-03 plan split.
+- `.planning/config.json` — current Hermes runtime config uses explicit per-agent `model_overrides`:
+  - researcher/planner: `claude-opus-4-7`
+  - checker/executor/verifier and several auditors: `openai/gpt-5.4`
+- Phase 10 artifacts:
+  - `10-RESEARCH.md`
+  - `10-CONTEXT.md`
+  - `10-SUMMARY.md`
+  - `docs/hermes-compatibility.md`
+- GSD runtime/model code:
+  - `sdk/src/query/runtime-model-contract.ts`
+  - `sdk/src/query/runtime-model-validation.ts`
+  - `get-shit-done/bin/lib/model-profiles.cjs`
+  - `get-shit-done/bin/lib/init.cjs`
+  - `tests/runtime-model-parity.test.cjs`
+  - `tests/init.test.cjs`
+- GSD workflow surfaces:
+  - `get-shit-done/workflows/plan-phase.md`
+  - `get-shit-done/workflows/execute-phase.md`
+- Existing regression context:
+  - `tests/bug-2256-model-overrides-transport.test.cjs`
+  - `tests/bug-2516-inherit-model-execute-phase.test.cjs`
+  - `tests/issue-2517-runtime-aware-profiles.test.cjs`
+- Hermes runtime source checked out at `/home/whiskey/.hermes/hermes-agent`:
+  - `tools/delegate_tool.py`
+  - `run_agent.py`
+  - `tests/tools/test_delegate.py`
+
+## Key findings
+
+### F-01 — GSD resolver and receipts are already producing explicit model intent
+
+Live init output for Phase 11 shows structured receipts:
+
+- `researcher` / `gsd-phase-researcher`: configured/resolved/model_token = `claude-opus-4-7`, source `override`, binding `explicit`, provider family `anthropic`, `passed_to_runtime=true`, `runtime_enforced=unknown`.
+- `planner` / `gsd-planner`: configured/resolved/model_token = `claude-opus-4-7`, source `override`, binding `explicit`, provider family `anthropic`, `passed_to_runtime=true`, `runtime_enforced=unknown`.
+- `checker` / `gsd-plan-checker`: configured/resolved/model_token = `openai/gpt-5.4`, source `override`, binding `explicit`, provider family `openai`, `passed_to_runtime=true`, `runtime_enforced=unknown`.
+
+This proves resolver intent and workflow-handoff intent only. It does not prove Hermes child construction or provider request behavior.
+
+### F-02 — Current Hermes delegate_task source has no per-call `model` schema field
+
+In `/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py`, `DELEGATE_TASK_SCHEMA` exposes:
+
+- top-level: `goal`, `context`, `toolsets`, `tasks`, `role`, `acp_command`, `acp_args`
+- per-task: `goal`, `context`, `toolsets`, `acp_command`, `acp_args`, `role`
+
+It does not expose a top-level or per-task `model` field in the checked source. The registry handler similarly passes `goal`, `context`, `toolsets`, `tasks`, `max_iterations`, `acp_command`, `acp_args`, `role`, and `parent_agent`, but no `model`.
+
+Impact: a GSD workflow can display `model="{planner_model}"` in Claude-style `Task(...)` examples, but Hermes `delegate_task` cannot currently receive that model token as a first-class per-call argument.
+
+### F-03 — Current Hermes child construction can bind a model, but only if a model reaches `_build_child_agent`
+
+`tools/delegate_tool.py::_build_child_agent(...)` already has a `model: Optional[str]` parameter and constructs children with:
+
+```python
+effective_model = model or parent_agent.model
+child = AIAgent(..., model=effective_model, ...)
+```
+
+So the child-construction seam exists. The missing channel is upstream of it: `delegate_task(...)` currently passes `model=creds["model"]`, where `creds` comes from `_resolve_delegation_credentials(cfg, parent_agent)`.
+
+### F-04 — Existing `delegation.model` is global, not per-agent or per-task
+
+`_resolve_delegation_credentials(...)` reads `cfg.get("model")`, i.e. `delegation.model` from Hermes config. That value applies to every child spawned by a `delegate_task` call.
+
+Consequences:
+
+- Single child can use a configured global delegation model.
+- Batch children all receive the same `creds["model"]`.
+- Different GSD agents in the same workflow cannot receive different configured models through this path.
+- If `delegation.model` is unset, the child inherits `parent_agent.model`.
+
+This matches the milestone root cause: explicit per-agent overrides can resolve in GSD but still not affect Hermes child construction.
+
+### F-05 — ACP args are a possible transport-specific escape hatch, but not sufficient as the canonical GSD binding seam
+
+Hermes delegate_task already supports `acp_command` and `acp_args` at both top-level and per-task levels. In `_build_child_agent`, `override_acp_args` becomes `effective_acp_args`, and when `override_acp_command` is provided the provider is forced to `copilot-acp`.
+
+This can carry a CLI-specific `--model` argument for an ACP subprocess, but it is not a general Hermes direct-provider binding path:
+
+- It depends on a subprocess ACP transport being selected.
+- It does not bind direct Hermes `AIAgent(..., provider=..., model=...)` children unless translated back into `model`.
+- It is awkward for mixed-provider batches where each task needs a different GSD model token.
+
+ACP `--model` remains a useful compatibility path, but Phase 11 should use a direct `delegate_task.model` / `tasks[].model` field as the canonical seam and keep ACP args as optional transport details.
+
+### F-06 — `run_agent.py` has a single delegate dispatch pass-through that must be updated
+
+`run_agent.py::_dispatch_delegate_task(function_args)` is the single call site for delegate tool dispatch. Its docstring says new `DELEGATE_TASK_SCHEMA` fields only need to be added there to reach all invocation paths.
+
+Current pass-through includes no `model`. Therefore Phase 11 implementation must update this function, not just `tools/delegate_tool.py`.
+
+### F-07 — Hermes already surfaces child model metadata in runtime-visible places once construction is correct
+
+`tools/delegate_tool.py` records child model in several runtime-observable structures:
+
+- `effective_model_for_cb = model or getattr(parent_agent, "model", None)` feeds progress callbacks.
+- active subagent registry entries include `"model": getattr(child, "model", None)`.
+- final result entries include `"model": child.model` when string.
+
+These are useful child-construction proof surfaces after the model binding reaches `_build_child_agent`. They are not provider wire-level proof, but they are stronger than subagent self-report.
+
+### F-08 — Provider request proof remains Phase 12 territory
+
+Phase 11 can prove that Hermes constructs `AIAgent(model=expected_model)` for each child. It should not overclaim wire-level proof unless tests inspect the provider request path directly.
+
+Preferred proof hierarchy remains:
+
+1. Provider request / wire-level `model=...`
+2. Hermes child agent construction / runtime registry model metadata
+3. Static schema/code checks
+4. Subagent self-report — not proof
+
+Phase 11 should set the stage for Phase 12 no-silent-fallback and provider diagnostics tests. Provider wire-level proof remains Phase 12 unless Phase 11 deliberately adds sanitized request instrumentation.
+
+### F-09 — Current GSD runtime capability semantics overclaim unless tied to actual Hermes channel availability
+
+`runtime-model-contract.ts` currently marks Hermes `supportsExplicitModel: true`, and receipts show `runtime_capability.supports_explicit_model=true`, but `runtime_enforced=unknown`.
+
+After Phase 11, this should become conditional:
+
+- If the installed/target Hermes delegate schema supports `model`, explicit model binding can be considered handoff-enforceable at child-construction level.
+- If not, explicit overrides must fail before spawn rather than silently continuing with `parent_agent.model`.
+
+A safe implementation should provide a runtime capability/seam check instead of a blanket Hermes true.
+
+### F-10 — Existing tests provide useful guardrails but not the Phase 11 proof
+
+Existing tests cover:
+
+- Config resolver and receipt parity (`runtime-model-parity.test.cjs`, SDK init tests).
+- Codex/OpenCode install-time model override transport (`bug-2256-model-overrides-transport.test.cjs`).
+- Claude-style `inherit` omission guidance (`bug-2516-inherit-model-execute-phase.test.cjs`).
+- Runtime-aware profile resolution (`issue-2517-runtime-aware-profiles.test.cjs`).
+
+Missing tests for Phase 11:
+
+- Hermes `DELEGATE_TASK_SCHEMA` exposes `model` at top-level and `tasks[].model`.
+- `run_agent._dispatch_delegate_task` passes `model` through.
+- `delegate_task(goal=..., model=...)` constructs child `AIAgent(model=expected)`.
+- `delegate_task(tasks=[...model A..., ...model B...])` constructs different children with different models.
+- GSD workflow/init receipts either map explicit model tokens into Hermes delegate_task model fields or fail before spawn if the field is unavailable.
+
+## Decision
+
+Use a direct Hermes `delegate_task` model field as Phase 11's canonical binding channel:
+
+- Add `model` to top-level `delegate_task` schema and function signature.
+- Add `model` to `tasks[].model` for batch/multi-agent spawns.
+- Plumb `model` through `run_agent._dispatch_delegate_task` and registry handler.
+- Resolve effective per-task child model as:
+  1. `tasks[i].model` if provided and non-empty.
+  2. top-level `model` if provided and non-empty.
+  3. `delegation.model` from Hermes config.
+  4. `parent_agent.model` inheritance.
+- Keep `inherit` as an omission/null behavior; do not pass literal `"inherit"` into `AIAgent(model=...)`.
+- Add tests in Hermes Agent proving child construction uses the requested model.
+- Update GSD/Hermes workflow guidance and receipt semantics so explicit Hermes overrides are either passed via `delegate_task(..., model=...)` or rejected pre-spawn if the runtime seam is absent.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Broad workflow rewrites increase upstream-sync cost. | Keep GSD changes in runtime receipt/capability helpers and concise Hermes-specific dispatch guidance. Avoid rewriting core workflow structure. |
+| Provider wire-level proof is conflated with child construction proof. | Use receipt/proof terms carefully: Phase 11 proves child construction; Phase 12 owns provider request diagnostics. |
+| Literal `"inherit"` reaches Hermes `AIAgent(model=...)`. | Normalize `inherit` and empty strings to `None` before child construction; preserve prior inheritance behavior. |
+| Batch calls accidentally use top-level/global model for every task. | Add batch tests with two different task models and assert two different `AIAgent(model=...)` calls. |
+| Hermes runtime source and packaged runtime differ. | Add static/version or schema detection guard in GSD so absence of `delegate_task.model` causes pre-spawn actionable failure. |
+| Secrets leak in diagnostics. | Tests and docs must assert/request metadata excludes API keys, tokens, cookies, passwords, and connection strings. |
+
+## Open questions for execution
+
+1. Should the Hermes Agent patch be carried as a sibling repo change first, then copied into any packaged dependency/reference? Plan 11-01 should keep this explicit.
+2. Should GSD detect the Hermes delegate schema dynamically, or should it gate by documented minimum Hermes Agent version? Prefer schema/capability detection when available; version gating is acceptable only if schema detection is impractical.
+3. Should Phase 11 update `runtime_enforced` from `unknown` to a new child-construction value, or leave `runtime_enforced` reserved for provider proof? Preferred: keep `runtime_enforced=unknown` until provider proof, and add/consume a narrower `child_constructed_model` / `runtime_binding_channel` proof field if needed. If schema must remain small, document that Phase 11 proof is construction-level only and Phase 12 changes enforcement status.

--- a/.planning/phases/11-hermes-per-agent-binding-channel/11-SUMMARY.md
+++ b/.planning/phases/11-hermes-per-agent-binding-channel/11-SUMMARY.md
@@ -1,0 +1,104 @@
+# Phase 11 Summary: Hermes Per-Agent Binding Channel
+
+**Status:** Complete  
+**Completed:** 2026-04-26  
+**Route:** `/gsd-execute-phase 11`  
+**Execution mode:** Hermes inline/degraded orchestration, with direct repository edits and verification.
+
+## What changed
+
+Phase 11 implemented the child-agent binding channel needed for GSD/Hermes per-agent model overrides to reach Hermes spawned agents instead of silently inheriting the parent model.
+
+### 1. Hermes Agent binding channel
+
+Updated the local Hermes Agent checkout at `/home/whiskey/.hermes/hermes-agent` so `delegate_task` exposes and propagates explicit child model overrides:
+
+- Direct single-child calls can pass `delegate_task(model=...)`.
+- Batch calls can pass heterogeneous `tasks[].model` values.
+- Model precedence is now:
+  1. `tasks[i].model`
+  2. top-level `model`
+  3. `delegation.model`
+  4. parent-agent inheritance
+- Empty strings and `inherit` mean no explicit override at that level, preserving existing inheritance behavior.
+- `run_agent.py` forwards the tool argument into `delegate_task(...)`.
+- Delegate tests assert child `AIAgent(model=...)` construction receives the expected model for direct and batch cases.
+
+This is Phase 11 child-construction proof. Provider wire-level request proof remains Phase 12 scope.
+
+### 2. GSD runtime binding channel receipts and validation
+
+Updated GSD runtime-model contract/validation surfaces so Hermes receipts and validation distinguish child-construction channel availability from provider-level enforcement:
+
+- Added `runtime_binding_channel` metadata to structured model binding receipts.
+- Hermes explicit override receipts now expose:
+  - `kind: hermes-delegate-task-model`
+  - `available: true`
+  - `proof_level: child-construction`
+- `runtime_enforced` remains `unknown`; Phase 11 does not claim provider wire-level proof.
+- Added fail-fast validation support for explicit Hermes overrides when the delegate model channel is unavailable, returning actionable diagnostics with agent, runtime, configured model, rejection reason, and suggested fix.
+- Preserved existing flat fields such as `planner_model`, `executor_model`, etc.
+- Kept SDK and legacy CJS parity.
+
+### 3. Workflow and compatibility docs
+
+Updated Hermes compatibility and workflow wording to make the proof boundary explicit:
+
+- `runtime_enforced=unknown` is not provider proof.
+- Hermes child-construction binding is represented by `runtime_binding_channel.kind=hermes-delegate-task-model` and `proof_level=child-construction`.
+- Explicit model tokens should flow through `delegate_task(model=...)` or `tasks[].model`.
+- If that channel is unavailable, GSD should stop on a pre-spawn validation error instead of spawning and silently falling back.
+
+## Verification
+
+### Hermes Agent
+
+Ran in `/home/whiskey/.hermes/hermes-agent`:
+
+```bash
+.venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py -q && \
+.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py tests/tools/test_delegate.py agent/auxiliary_client.py tests/agent/test_auxiliary_codex_responses_conversion.py
+```
+
+Result: `121 passed, 24 warnings`.
+
+### GSD targeted gates
+
+Ran in `/home/whiskey/workspace/project/central/v2/gsd-hermes`:
+
+```bash
+npm run build:sdk
+cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts
+node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs
+```
+
+Results:
+
+- SDK build passed.
+- Vitest passed: `63 passed`.
+- Node targeted tests passed: `216 passed`.
+
+### Full suite
+
+Ran:
+
+```bash
+npm test
+```
+
+Result:
+
+- `5593` tests passed.
+- `1002` suites passed.
+- `0` failures.
+
+## Important boundaries
+
+- Phase 11 proves the Hermes child `AIAgent(model=...)` construction path, not the provider request payload.
+- Provider wire-level `model=...` diagnostics and invalid-model no-silent-fallback smoke tests remain Phase 12 scope.
+- The local Hermes Agent patch may require restarting Hermes CLI/gateway processes before an already-running process loads it.
+- Existing unrelated Hermes Agent dirty file `web/package-lock.json` was not touched or staged.
+
+## Outcome
+
+Phase 11 is complete. The next route is `/gsd-plan-phase 12` to plan fail-fast validation and provider-proof tests.

--- a/.planning/phases/11-hermes-per-agent-binding-channel/11-VALIDATION.md
+++ b/.planning/phases/11-hermes-per-agent-binding-channel/11-VALIDATION.md
@@ -1,0 +1,101 @@
+# Phase 11 Plan Validation — Hermes Per-Agent Binding Channel
+
+**Validated at:** 2026-04-25T18:05:47.235Z
+**Local date:** 2026-04-26
+**Mode:** `/gsd-plan-phase 11 --auto` with Hermes degraded inline planning path
+
+## Artifacts checked
+
+- `.planning/phases/11-hermes-per-agent-binding-channel/11-RESEARCH.md`
+- `.planning/phases/11-hermes-per-agent-binding-channel/11-CONTEXT.md`
+- `.planning/phases/11-hermes-per-agent-binding-channel/11-01-PLAN.md`
+- `.planning/phases/11-hermes-per-agent-binding-channel/11-02-PLAN.md`
+- `.planning/phases/11-hermes-per-agent-binding-channel/11-03-PLAN.md`
+
+## Automated validation
+
+A local validation script checked:
+
+- all required Phase 11 research/context/plan files exist;
+- every plan has frontmatter with `phase`, `requirements`, `must_haves`, objective/tasks/done sections;
+- plans reference BIND requirements;
+- Wave dependencies are explicit:
+  - 11-02 depends on 11-01;
+  - 11-03 depends on 11-02;
+- research includes the key Hermes facts:
+  - `DELEGATE_TASK_SCHEMA` currently lacks per-call model fields;
+  - canonical seam is `model` / `tasks[].model`;
+  - current fallback uses global `delegation.model` or parent inheritance;
+  - child-construction proof targets `AIAgent(model=expected_model)`;
+  - provider wire-level proof remains Phase 12 unless explicitly instrumented;
+- plans do not claim provider-level `runtime_enforced=true`.
+
+Validation result:
+
+```json
+{
+  "ok": true,
+  "issues": [],
+  "files": [
+    "11-RESEARCH.md",
+    "11-CONTEXT.md",
+    "11-01-PLAN.md",
+    "11-02-PLAN.md",
+    "11-03-PLAN.md"
+  ]
+}
+```
+
+## Manual plan review
+
+### 11-01 — Binding seam contract
+
+Pass.
+
+The plan selects the smallest upstream-syncable Hermes seam:
+
+- top-level `delegate_task(model=...)`;
+- per-task `tasks[].model`;
+- `delegation.model` remains global default;
+- ACP `--model` is documented as transport-specific, not the general GSD binding channel.
+
+It also preserves the proof boundary: schema/static proof and child construction are Phase 11; provider request proof remains Phase 12.
+
+### 11-02 — Runtime propagation
+
+Pass.
+
+The plan implements test-first propagation through Hermes Agent:
+
+- schema → `delegate_task(...)` signature → registry handler → `_build_child_agent(...)`;
+- `run_agent._dispatch_delegate_task(...)` pass-through;
+- top-level model tests;
+- heterogeneous batch `tasks[].model` tests;
+- inheritance/default regression tests.
+
+It explicitly avoids using subagent self-report as proof.
+
+### 11-03 — GSD fail-fast/capability semantics
+
+Pass.
+
+The plan connects Hermes Agent support back to GSD:
+
+- capability/channel metadata is additive;
+- explicit Hermes overrides fail before spawn if the channel is unavailable;
+- diagnostics name runtime, agent, configured model, missing channel, and suggested fix;
+- flat fields remain backward compatible;
+- `runtime_enforced` remains conservative unless provider request proof exists.
+
+## Remaining execution risks
+
+- Hermes Agent and GSD are separate working directories; execution must coordinate commits or clearly record sibling-repo patch requirements.
+- A currently running Hermes process may need restart to load delegate tool changes.
+- Dynamic schema/capability detection may not be available from GSD; if unavailable, execution should use an injected pure helper for tests and a conservative runtime marker/version gate.
+- Provider wire-level proof is intentionally deferred to Phase 12.
+
+## Verdict
+
+Phase 11 plan set is executable and aligned with BIND-01 through BIND-04.
+
+Next route: `/gsd-execute-phase 11`.

--- a/.planning/phases/12-fail-fast-validation-and-proof-tests/12-01-PLAN.md
+++ b/.planning/phases/12-fail-fast-validation-and-proof-tests/12-01-PLAN.md
@@ -1,0 +1,122 @@
+---
+phase: 12-fail-fast-validation-and-proof-tests
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - sdk/src/query/runtime-model-validation.ts
+  - sdk/src/query/init.test.ts
+  - tests/init.test.cjs
+  - tests/runtime-model-parity.test.cjs
+  - get-shit-done/bin/lib/model-profiles.cjs
+autonomous: true
+requirements:
+  - ENF-01
+  - ENF-03
+  - TEST-01
+must_haves:
+  truths:
+    - "Explicit per-agent overrides must fail fast if Hermes cannot bind them before spawn."
+    - "Override, inherit, and runtime-default receipt cases must remain distinguishable."
+    - "SDK and legacy CJS must expose equivalent semantics."
+  artifacts:
+    - path: "sdk/src/query/init.test.ts"
+      provides: "SDK validation/receipt matrix tests"
+      contains: "hermesDelegateModelChannelAvailable"
+    - path: "tests/init.test.cjs"
+      provides: "legacy CJS receipt assertions"
+      contains: "runtime_binding_channel"
+    - path: "tests/runtime-model-parity.test.cjs"
+      provides: "SDK/CJS parity guard"
+      contains: "runtime_binding_channel"
+---
+
+<objective>
+Expand GSD validation and receipt tests so Phase 12 proves enforceability behavior for explicit override, inherit, runtime-default, unavailable-channel, invalid-model, and explicit cross-AI execution modes.
+</objective>
+
+<execution_context>
+@$HOME/.hermes/get-shit-done/workflows/execute-plan.md
+@$HOME/.hermes/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/REQUIREMENTS.md
+@.planning/ROADMAP.md
+@.planning/phases/12-fail-fast-validation-and-proof-tests/12-CONTEXT.md
+@.planning/phases/12-fail-fast-validation-and-proof-tests/12-RESEARCH.md
+@sdk/src/query/runtime-model-validation.ts
+@sdk/src/query/runtime-model-contract.ts
+@sdk/src/query/init.ts
+@sdk/src/query/init.test.ts
+@get-shit-done/bin/lib/model-profiles.cjs
+@get-shit-done/bin/lib/init.cjs
+@tests/init.test.cjs
+@tests/runtime-model-parity.test.cjs
+
+<starting_point>
+Phase 11 already added `runtime_binding_channel` metadata and one unavailable-channel validation test. This plan broadens the matrix and locks SDK/CJS parity.
+</starting_point>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add SDK validation matrix tests</name>
+  <files>sdk/src/query/init.test.ts, sdk/src/query/runtime-model-validation.ts</files>
+  <action>
+  Add focused tests that cover:
+  - explicit override with Hermes delegate channel available -> valid; receipt channel available; proof level child-construction; `runtime_enforced` remains `unknown`.
+  - explicit override with Hermes delegate channel unavailable -> invalid before spawn with actionable issue fields.
+  - inherited model/default model -> no explicit fail-fast error when channel is unavailable.
+  - intentionally invalid explicit model token `definitely-not-a-real-model-gsd-binding-test` remains the configured/resolved model and is not replaced by parent/default during validation.
+  - explicit `workflow.cross_ai_execution` remains represented as an explicit mode, not silent fallback.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/workspace/project/central/v2/gsd-hermes/sdk && npx vitest run src/query/init.test.ts</automated>
+    <expected>New tests fail before any missing validation/projection changes, then pass after implementation.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Mirror matrix in legacy CJS tests</name>
+  <files>tests/init.test.cjs, get-shit-done/bin/lib/model-profiles.cjs</files>
+  <action>
+  Add CJS tests for the same externally visible behaviors as SDK:
+  - `runtime_binding_channel` exists and matches Hermes child-construction semantics.
+  - invalid explicit model token is preserved in receipt output.
+  - unavailable Hermes delegate channel produces clear fail-fast issue metadata where CJS exposes validation.
+  Keep assertions focused on public command/query output.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/workspace/project/central/v2/gsd-hermes && node --test tests/init.test.cjs</automated>
+    <expected>CJS tests pass and remain behaviorally aligned with SDK tests.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 3: Update runtime model parity assertions</name>
+  <files>tests/runtime-model-parity.test.cjs</files>
+  <action>
+  Extend parity assertions to include any new receipt/validation fields used by Phase 12. Preserve existing flat model fields and avoid brittle full-object snapshots.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/workspace/project/central/v2/gsd-hermes && node --test tests/runtime-model-parity.test.cjs</automated>
+    <expected>SDK and CJS projections remain equivalent for Phase 12 fields.</expected>
+  </verify>
+</task>
+
+</tasks>
+
+<verification>
+Run:
+
+```bash
+cd /home/whiskey/workspace/project/central/v2/gsd-hermes
+npm run build:sdk
+cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts
+cd .. && node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs
+```
+</verification>

--- a/.planning/phases/12-fail-fast-validation-and-proof-tests/12-02-PLAN.md
+++ b/.planning/phases/12-fail-fast-validation-and-proof-tests/12-02-PLAN.md
@@ -1,0 +1,86 @@
+---
+phase: 12-fail-fast-validation-and-proof-tests
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - /home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py
+  - /home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py
+autonomous: true
+requirements:
+  - TEST-02
+  - ENF-02
+must_haves:
+  truths:
+    - "Subagent self-report is not proof; tests must inspect child AIAgent construction inputs."
+    - "Planner and executor style GSD roles must get their configured model tokens."
+    - "Invalid explicit model strings must reach child construction and not be replaced by parent inheritance."
+  artifacts:
+    - path: "/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py"
+      provides: "GSD-originated role binding tests"
+      contains: "gsd-planner"
+---
+
+<objective>
+Add Hermes Agent tests that prove GSD-originated planner/executor child agents are constructed with the configured model, including invalid-model strings used for no-silent-fallback proof.
+</objective>
+
+<execution_context>
+@$HOME/.hermes/get-shit-done/workflows/execute-plan.md
+@$HOME/.hermes/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/12-fail-fast-validation-and-proof-tests/12-CONTEXT.md
+@.planning/phases/12-fail-fast-validation-and-proof-tests/12-RESEARCH.md
+@/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py
+@/home/whiskey/.hermes/hermes-agent/run_agent.py
+@/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py
+
+<starting_point>
+Phase 11 tests prove generic direct `model` and batch `tasks[].model` propagation. Phase 12 should make the GSD role origin explicit in test names/data so the integration contract is clear.
+</starting_point>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add GSD planner/executor child construction tests</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py</files>
+  <action>
+  Add tests using the existing child-agent construction monkeypatch/fake factory pattern. Cover:
+  - a single planner-style delegate call with `model="openai/o4-mini"` constructs child `AIAgent(model="openai/o4-mini")`.
+  - a batch with planner and executor tasks uses heterogeneous `tasks[].model` values.
+  - top-level `model` applies to both planner/executor when task-specific model is absent.
+  Test names should mention GSD planner/executor or GSD-originated override.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/tools/test_delegate.py -q -k "gsd and model"</automated>
+    <expected>Fails before any missing test helpers/implementation changes, then passes.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add invalid-model no-inheritance construction test</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py</files>
+  <action>
+  Add a deterministic offline test with parent/default model set to a known safe value and explicit child model set to `definitely-not-a-real-model-gsd-binding-test`. Assert the child construction receives the invalid explicit token exactly. This proves Hermes does not replace explicit invalid values with parent/default inheritance before provider dispatch.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/tools/test_delegate.py -q -k "invalid and model"</automated>
+    <expected>The captured child constructor input equals the invalid explicit token.</expected>
+  </verify>
+</task>
+
+</tasks>
+
+<verification>
+Run:
+
+```bash
+cd /home/whiskey/.hermes/hermes-agent
+.venv/bin/python -m pytest tests/tools/test_delegate.py -q
+.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py tests/tools/test_delegate.py
+```
+</verification>

--- a/.planning/phases/12-fail-fast-validation-and-proof-tests/12-03-PLAN.md
+++ b/.planning/phases/12-fail-fast-validation-and-proof-tests/12-03-PLAN.md
@@ -1,0 +1,121 @@
+---
+phase: 12-fail-fast-validation-and-proof-tests
+plan: 03
+type: execute
+wave: 2
+depends_on:
+  - 12-01-PLAN.md
+  - 12-02-PLAN.md
+files_modified:
+  - /home/whiskey/.hermes/hermes-agent/agent/provider_diagnostics.py
+  - /home/whiskey/.hermes/hermes-agent/tests/agent/test_provider_diagnostics.py
+  - /home/whiskey/.hermes/hermes-agent/agent/redact.py
+  - docs/hermes-compatibility.md
+autonomous: true
+requirements:
+  - ENF-01
+  - ENF-02
+  - TEST-03
+  - TEST-04
+must_haves:
+  truths:
+    - "Provider diagnostics must be safe by default and must not require live API calls."
+    - "Request model metadata may be logged, but credentials and connection strings must be redacted."
+    - "Invalid model proof should be deterministic and offline unless an explicit opt-in live test flag is set."
+  artifacts:
+    - path: "/home/whiskey/.hermes/hermes-agent/tests/agent/test_provider_diagnostics.py"
+      provides: "offline redaction and invalid-model diagnostic tests"
+      contains: "definitely-not-a-real-model-gsd-binding-test"
+---
+
+<objective>
+Add opt-in/safe provider-request diagnostics that expose effective request model metadata and prove credential redaction, then use them for invalid-model no-silent-fallback coverage without requiring live provider credentials.
+</objective>
+
+<execution_context>
+@$HOME/.hermes/get-shit-done/workflows/execute-plan.md
+@$HOME/.hermes/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/12-fail-fast-validation-and-proof-tests/12-CONTEXT.md
+@.planning/phases/12-fail-fast-validation-and-proof-tests/12-RESEARCH.md
+@docs/hermes-compatibility.md
+@/home/whiskey/.hermes/hermes-agent/hermes_logging.py
+@/home/whiskey/.hermes/hermes-agent/agent/redact.py
+@/home/whiskey/.hermes/hermes-agent/agent/auxiliary_client.py
+@/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py
+
+<starting_point>
+Existing Hermes logging has redaction support. Do not log raw API requests. Add a small reusable diagnostic helper if needed, with tests proving redaction.
+</starting_point>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add redacted provider diagnostic helper tests</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tests/agent/test_provider_diagnostics.py</files>
+  <action>
+  Create failing tests for a helper that accepts request metadata and returns/logs only sanitized fields. Include fixtures containing fake API keys, bearer tokens, password-like values, Authorization headers, and URL connection strings. Assert output contains model/subagent/provider metadata but not secret values.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/agent/test_provider_diagnostics.py -q</automated>
+    <expected>Fails until helper exists; passes after implementation.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Implement minimal diagnostic helper using existing redaction</name>
+  <files>/home/whiskey/.hermes/hermes-agent/agent/provider_diagnostics.py, /home/whiskey/.hermes/hermes-agent/agent/redact.py</files>
+  <action>
+  Implement a small helper such as `sanitize_provider_request_metadata(...)` or equivalent. Prefer reuse of existing redaction utilities. The helper should keep only safe keys by default and redact values matching secret patterns. Avoid changing provider call behavior unless tests require an opt-in hook.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/agent/test_provider_diagnostics.py -q</automated>
+    <expected>Diagnostic helper tests pass.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Add invalid-model diagnostic fixture</name>
+  <files>/home/whiskey/.hermes/hermes-agent/tests/agent/test_provider_diagnostics.py</files>
+  <action>
+  Add an offline fixture using model `definitely-not-a-real-model-gsd-binding-test`. Assert sanitized diagnostics preserve that exact model string and associate it with a child/subagent identifier. This is the provider-request diagnostic proof boundary without making a live request.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/agent/test_provider_diagnostics.py -q</automated>
+    <expected>Invalid model metadata remains visible; secrets remain redacted.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 4: Update compatibility docs only if diagnostics are user-visible</name>
+  <files>docs/hermes-compatibility.md</files>
+  <action>
+  If a user-visible diagnostic flag/env var is introduced, document its safe metadata boundary and redaction guarantees. Do not turn this into Phase 13 release documentation.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/workspace/project/central/v2/gsd-hermes && node --test tests/hermes-docs.test.cjs</automated>
+    <expected>Docs tests pass.</expected>
+  </verify>
+</task>
+
+</tasks>
+
+<verification>
+Run:
+
+```bash
+cd /home/whiskey/.hermes/hermes-agent
+.venv/bin/python -m pytest tests/agent/test_provider_diagnostics.py tests/tools/test_delegate.py -q
+.venv/bin/python -m py_compile agent/provider_diagnostics.py agent/redact.py tests/agent/test_provider_diagnostics.py
+```
+
+If GSD docs changed, also run:
+
+```bash
+cd /home/whiskey/workspace/project/central/v2/gsd-hermes
+node --test tests/hermes-docs.test.cjs tests/runtime-model-parity.test.cjs
+```
+</verification>

--- a/.planning/phases/12-fail-fast-validation-and-proof-tests/12-04-PLAN.md
+++ b/.planning/phases/12-fail-fast-validation-and-proof-tests/12-04-PLAN.md
@@ -1,0 +1,127 @@
+---
+phase: 12-fail-fast-validation-and-proof-tests
+plan: 04
+type: execute
+wave: 3
+depends_on:
+  - 12-01-PLAN.md
+  - 12-02-PLAN.md
+  - 12-03-PLAN.md
+files_modified:
+  - .planning/phases/12-fail-fast-validation-and-proof-tests/12-SUMMARY.md
+  - .planning/ROADMAP.md
+  - .planning/STATE.md
+autonomous: true
+requirements:
+  - ENF-01
+  - ENF-02
+  - ENF-03
+  - TEST-01
+  - TEST-02
+  - TEST-03
+  - TEST-04
+must_haves:
+  truths:
+    - "Closeout must verify both GSD and Hermes Agent repositories."
+    - "Do not claim provider enforcement beyond the diagnostics actually proven."
+    - "Unrelated dirty files, especially Hermes Agent web/package-lock.json, must remain untouched."
+  artifacts:
+    - path: ".planning/phases/12-fail-fast-validation-and-proof-tests/12-SUMMARY.md"
+      provides: "Phase 12 validation evidence and proof boundary"
+      contains: "no silent fallback"
+---
+
+<objective>
+Run full regression gates, fix any compatibility drift discovered by Phase 12 changes, then close Phase 12 with summary evidence and route to Phase 13.
+</objective>
+
+<execution_context>
+@$HOME/.hermes/get-shit-done/workflows/execute-plan.md
+@$HOME/.hermes/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/REQUIREMENTS.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/12-fail-fast-validation-and-proof-tests/12-CONTEXT.md
+@.planning/phases/12-fail-fast-validation-and-proof-tests/12-RESEARCH.md
+@.planning/phases/12-fail-fast-validation-and-proof-tests/12-01-PLAN.md
+@.planning/phases/12-fail-fast-validation-and-proof-tests/12-02-PLAN.md
+@.planning/phases/12-fail-fast-validation-and-proof-tests/12-03-PLAN.md
+</context>
+
+<tasks>
+
+<task type="auto" tdd="false">
+  <name>Task 1: Run targeted GSD gates</name>
+  <files>GSD repo</files>
+  <action>
+  Run the targeted GSD gates relevant to runtime model binding, receipts, docs, and workflow budgets.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/workspace/project/central/v2/gsd-hermes && npm run build:sdk && cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts && cd .. && node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs</automated>
+    <expected>All targeted GSD gates pass.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 2: Run targeted Hermes Agent gates</name>
+  <files>Hermes Agent repo</files>
+  <action>
+  Run delegate, auxiliary, and provider diagnostic tests plus py_compile for touched files.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/.hermes/hermes-agent && .venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py tests/agent/test_provider_diagnostics.py -q && .venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py agent/provider_diagnostics.py agent/redact.py tests/tools/test_delegate.py tests/agent/test_provider_diagnostics.py</automated>
+    <expected>All targeted Hermes Agent gates pass.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 3: Run full GSD suite</name>
+  <files>GSD repo</files>
+  <action>
+  Run `npm test`. If failures occur, use systematic debugging: isolate failing command, inspect error, identify root cause, add/update tests before fixes, and rerun.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/workspace/project/central/v2/gsd-hermes && npm test</automated>
+    <expected>Full suite passes with zero failures.</expected>
+  </verify>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 4: Close Phase 12</name>
+  <files>.planning/phases/12-fail-fast-validation-and-proof-tests/12-SUMMARY.md, .planning/ROADMAP.md, .planning/STATE.md</files>
+  <action>
+  Create `12-SUMMARY.md` with:
+  - implementation summary;
+  - tests run and exact results;
+  - proof boundaries for child construction vs provider diagnostics;
+  - redaction guarantees;
+  - remaining Phase 13 release/tracker/docs route.
+  Update ROADMAP/STATE to mark Phase 12 complete and route to Phase 13. Commit GSD changes. Commit Hermes Agent changes separately if touched, excluding unrelated dirty files.
+  </action>
+  <verify>
+    <automated>cd /home/whiskey/workspace/project/central/v2/gsd-hermes && gsd-sdk query state.validate && git status --short</automated>
+    <expected>State validates. GSD repo clean after commit. Hermes Agent only retains unrelated `web/package-lock.json` if it was already dirty.</expected>
+  </verify>
+</task>
+
+</tasks>
+
+<verification>
+Final Phase 12 closeout requires:
+
+```bash
+cd /home/whiskey/workspace/project/central/v2/gsd-hermes
+npm test
+gsd-sdk query state.validate
+git status --short
+
+cd /home/whiskey/.hermes/hermes-agent
+.venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py tests/agent/test_provider_diagnostics.py -q
+.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py agent/provider_diagnostics.py agent/redact.py tests/tools/test_delegate.py tests/agent/test_provider_diagnostics.py
+git status --short
+```
+</verification>

--- a/.planning/phases/12-fail-fast-validation-and-proof-tests/12-CONTEXT.md
+++ b/.planning/phases/12-fail-fast-validation-and-proof-tests/12-CONTEXT.md
@@ -1,0 +1,60 @@
+# Phase 12 Context: Fail-Fast Validation and Proof Tests
+
+**Phase:** 12 — Fail-Fast Validation and Proof Tests
+**Route:** `/gsd-plan-phase 12`
+**Date:** 2026-04-26
+**Execution mode:** Hermes inline planning path.
+
+## Why this phase exists
+
+Phase 10 made runtime/model binding intent visible. Phase 11 added the Hermes child-agent binding channel and receipts for the child-construction proof boundary. Phase 12 must prove that strict semantics actually hold under failure and diagnostic scenarios:
+
+- explicit per-agent overrides do not silently fall back to parent/default models;
+- unsupported Hermes binding paths fail before spawning work;
+- invalid explicit model names are observable at the child/provider boundary instead of being replaced;
+- diagnostics reveal model metadata without leaking credentials.
+
+## Requirements covered
+
+- ENF-01 — Unsupported/unknown/not enforceable explicit `model_overrides` fail with clear actionable errors before subagents begin.
+- ENF-02 — `definitely-not-a-real-model-gsd-binding-test` cannot complete successfully through parent/default inheritance.
+- ENF-03 — `workflow.cross_ai_execution` remains explicit and observable; no silent routing/fallback.
+- TEST-01 — SDK tests cover binding metadata for override, inherit, runtime-default cases.
+- TEST-02 — Hermes tests prove child agent receives expected model from GSD-originated override.
+- TEST-03 — No-silent-fallback tests cover invalid explicit model behavior.
+- TEST-04 — Diagnostics expose provider request model metadata safely with redaction.
+
+## Implementation boundaries
+
+- Keep `runtime_enforced` conservative unless provider request metadata is actually proven.
+- Child-construction proof can remain separate from provider wire-level proof.
+- Do not add live provider tests that require paid/network credentials by default.
+- If provider diagnostics are introduced, they must be opt-in/testable offline and must redact API keys, tokens, passwords, Authorization headers, and connection strings.
+- Preserve SDK and legacy CJS parity.
+- Preserve flat receipt fields for backward compatibility.
+- Keep GSD-first architecture; avoid broad workflow rewrites.
+- Do not stage or touch unrelated Hermes Agent dirty file `web/package-lock.json`.
+
+## Repositories involved
+
+- GSD repo: `/home/whiskey/workspace/project/central/v2/gsd-hermes`
+- Hermes Agent repo: `/home/whiskey/.hermes/hermes-agent`
+
+## Starting evidence
+
+Phase 11 closeout evidence:
+
+- GSD commit: `faa79371 feat(11): add Hermes per-agent binding channel receipts`
+- Hermes Agent commit: `c0f4b05e fix: propagate delegated child model overrides`
+- GSD full suite: `npm test` passed `5593/5593`
+- Hermes Agent targeted suite: `121 passed, 24 warnings`
+
+## Expected end state
+
+By the end of Phase 12:
+
+1. SDK/CJS tests prove validation/receipt behavior for explicit override, inherit, runtime default, unsupported channel, invalid override, and explicit cross-AI mode visibility.
+2. Hermes Agent tests prove GSD-style planner/executor child construction receives configured models.
+3. Provider/request diagnostic code and tests expose sanitized model metadata and prove redaction.
+4. Full relevant test gates pass.
+5. Phase 12 SUMMARY records commands, results, proof boundaries, and any remaining Phase 13 release/tracker tasks.

--- a/.planning/phases/12-fail-fast-validation-and-proof-tests/12-RESEARCH.md
+++ b/.planning/phases/12-fail-fast-validation-and-proof-tests/12-RESEARCH.md
@@ -1,0 +1,107 @@
+# Phase 12 Research: Fail-Fast Validation and Proof Tests
+
+**Phase:** 12 — Fail-Fast Validation and Proof Tests  
+**Date:** 2026-04-26  
+**Route:** `/gsd-plan-phase 12`  
+**Execution mode:** Hermes inline planning path.
+
+## Mission
+
+Phase 12 must prove the v1.4 runtime/model binding fix cannot silently fall back. Phase 11 created the Hermes child-construction binding channel and conservative GSD receipt metadata. Phase 12 turns that into regression proof:
+
+- unsupported explicit bindings fail fast before spawn;
+- invalid explicit model names cannot succeed by inheriting the parent/default model;
+- child construction tests cover GSD-originated planner and executor roles;
+- provider-request diagnostics expose only safe request metadata, never credentials.
+
+## Inputs reviewed
+
+- `.planning/REQUIREMENTS.md`
+- `.planning/ROADMAP.md`
+- `.planning/STATE.md`
+- `.planning/phases/11-hermes-per-agent-binding-channel/11-SUMMARY.md`
+- GSD SDK/CJS runtime-model surfaces:
+  - `sdk/src/query/runtime-model-contract.ts`
+  - `sdk/src/query/runtime-model-validation.ts`
+  - `sdk/src/query/init.ts`
+  - `get-shit-done/bin/lib/model-profiles.cjs`
+  - `get-shit-done/bin/lib/init.cjs`
+- Current tests:
+  - `sdk/src/query/init.test.ts`
+  - `tests/init.test.cjs`
+  - `tests/runtime-model-parity.test.cjs`
+  - `tests/hermes-docs.test.cjs`
+- Hermes Agent surfaces:
+  - `/home/whiskey/.hermes/hermes-agent/tools/delegate_tool.py`
+  - `/home/whiskey/.hermes/hermes-agent/run_agent.py`
+  - `/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py`
+  - `/home/whiskey/.hermes/hermes-agent/hermes_logging.py`
+  - `/home/whiskey/.hermes/hermes-agent/agent/redact.py`
+
+## Phase 11 baseline
+
+Phase 11 completed these relevant changes:
+
+- `delegate_task(model=...)` is accepted and reaches child `AIAgent(model=...)` construction.
+- `tasks[].model` allows heterogeneous child model bindings.
+- Precedence is `tasks[i].model > top-level model > delegation.model > parent inheritance`.
+- GSD receipts include `runtime_binding_channel`.
+- Hermes explicit override receipts use `kind=hermes-delegate-task-model`, `available=true`, `proof_level=child-construction`.
+- `runtime_enforced` remains `unknown` because Phase 11 does not prove provider wire-level request payloads.
+- Full GSD test suite passed `5593/5593`.
+- Hermes Agent delegate/auxiliary tests passed `121` tests.
+
+## Gaps Phase 12 must close
+
+### 1. Validation matrix coverage
+
+Current tests assert receipt presence and one unavailable-channel fail-fast path. Phase 12 should expand tests to cover override, inherit, and runtime-default cases across both plan-phase and execute-phase roles, and should cover SDK and legacy CJS projections.
+
+Target requirements: ENF-01, TEST-01.
+
+### 2. GSD-originated child-construction proof
+
+Phase 11 Hermes tests prove raw `delegate_task(model=...)` and `tasks[].model`. Phase 12 should add a higher-level test fixture that mirrors GSD-originated roles: planner and executor at minimum, ideally including role labels/subagent metadata in the prompt or test name. This protects the integration seam from later schema or dispatch drift.
+
+Target requirements: TEST-02, ENF-02.
+
+### 3. Invalid model no-silent-fallback
+
+An invalid explicit override such as `definitely-not-a-real-model-gsd-binding-test` must not complete by inheriting parent/default model. Testing can be staged:
+
+- deterministic unit-level proof: assert the invalid string reaches `AIAgent(model=...)` construction and does not get replaced by parent model;
+- provider/transport-level proof: in diagnostic/test mode, capture the outbound request `model` metadata or error metadata with credentials redacted;
+- no live paid/provider test is required unless an opt-in environment flag is present.
+
+Target requirements: ENF-02, TEST-03.
+
+### 4. Redacted provider-request diagnostics
+
+Provider proof must be safe by default. Diagnostics should expose minimal metadata such as:
+
+- child/subagent id or task index;
+- configured/effective model string;
+- provider/api mode name;
+- request path/category (Responses vs chat completions, if known);
+- sanitized error category.
+
+Diagnostics must never log API keys, tokens, passwords, Authorization headers, connection strings, or raw request bodies containing secrets. Existing Hermes redaction infrastructure (`agent.redact.RedactingFormatter`) should be reused rather than inventing a parallel sanitizer.
+
+Target requirements: TEST-04, ENF-01.
+
+### 5. `workflow.cross_ai_execution` remains explicit
+
+No Phase 12 fix should silently route a failed binding to cross-AI execution. If cross-AI fallback is allowed, tests/docs must require it to remain user/config explicit and visible in receipts or workflow output.
+
+Target requirement: ENF-03.
+
+## Planning conclusion
+
+Use four plans matching the roadmap:
+
+1. Expand SDK/CJS validation and receipt tests.
+2. Add Hermes GSD-role child-construction proof tests.
+3. Add invalid-model no-silent-fallback plus redacted provider diagnostic coverage.
+4. Run full regression gates, update closeout state, and fix any drift found by the suite.
+
+Phase 12 should remain test/diagnostic focused. Do not broaden into Phase 13 release/tracker/docs except where minimal docs/test wording is required to verify diagnostics.

--- a/.planning/phases/12-fail-fast-validation-and-proof-tests/12-SUMMARY.md
+++ b/.planning/phases/12-fail-fast-validation-and-proof-tests/12-SUMMARY.md
@@ -1,0 +1,108 @@
+# Phase 12 Summary — Fail-Fast Validation and Proof Tests
+
+Status: Complete
+Completed: 2026-04-26
+Route: `/gsd-execute-phase 12`
+Execution mode: sequential inline under Hermes runtime compatibility fallback
+
+## What changed
+
+Phase 12 closed the runtime-model proof gap left after Phase 11 by adding regression coverage and safe diagnostics around strict model binding semantics.
+
+### GSD SDK / legacy CJS validation matrix
+
+Files changed:
+
+- `sdk/src/query/init.test.ts`
+- `tests/init.test.cjs`
+- `tests/runtime-model-parity.test.cjs`
+- `get-shit-done/bin/lib/model-profiles.cjs`
+
+Added/locked behavior:
+
+- Explicit Hermes overrides fail validation when the Hermes delegate model channel is unavailable.
+- Inherit and runtime-default bindings do not fail solely because the delegate model channel is unavailable.
+- Invalid explicit model tokens such as `definitely-not-a-real-model-gsd-binding-test` remain the configured/resolved model token instead of being replaced by a parent/default model.
+- `workflow.cross_ai_execution` remains explicit metadata and is not treated as silent fallback.
+- Legacy CJS exports now include validation helpers that mirror SDK behavior for the Phase 12 public validation surface.
+
+### Hermes child-construction proof tests
+
+Files changed:
+
+- `/home/whiskey/.hermes/hermes-agent/tests/tools/test_delegate.py`
+
+Added GSD-originated role tests proving:
+
+- planner-style `delegate_task(model="openai/o4-mini")` constructs child `AIAgent(model="openai/o4-mini")`;
+- planner/executor batch tasks can use heterogeneous `tasks[].model` values;
+- top-level `model` applies to all batch children without task-specific models;
+- invalid explicit model strings reach child construction unchanged and do not inherit parent or `delegation.model` defaults.
+
+### Safe provider-request diagnostic helper
+
+Files changed:
+
+- `/home/whiskey/.hermes/hermes-agent/agent/provider_diagnostics.py`
+- `/home/whiskey/.hermes/hermes-agent/tests/agent/test_provider_diagnostics.py`
+
+Added an offline diagnostic helper for sanitized provider-request metadata. It preserves the diagnostic subject fields (`model`, `provider`, `subagent_id`, `agent_role`, etc.) while redacting API keys, bearer tokens, Authorization headers, passwords, client secrets, and credential-bearing URLs.
+
+This is not a live provider wire-level assertion. It is an offline, safe diagnostic boundary proving that model metadata can be exposed without leaking credentials.
+
+## Proof boundaries
+
+- GSD resolver proof: covered by SDK/CJS validation and parity tests.
+- Hermes child-construction proof: covered by `AIAgent(model=...)` constructor assertions in Hermes Agent tests.
+- Provider/request diagnostic boundary: covered by offline sanitized metadata tests.
+- Provider wire-level enforcement: still not overclaimed. `runtime_enforced` remains conservative unless future live/sanitized provider request instrumentation proves exact provider-side `model=` dispatch.
+
+## Verification
+
+GSD targeted gates:
+
+```bash
+cd /home/whiskey/workspace/project/central/v2/gsd-hermes
+npm run build:sdk
+cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts
+cd .. && node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs
+```
+
+Result: PASS — SDK build passed, Vitest `66 passed`, Node targeted group `220 passed`.
+
+Hermes Agent targeted gates:
+
+```bash
+cd /home/whiskey/.hermes/hermes-agent
+.venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py tests/agent/test_provider_diagnostics.py -q
+.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py agent/provider_diagnostics.py agent/redact.py tests/tools/test_delegate.py tests/agent/test_provider_diagnostics.py
+```
+
+Result: PASS — `128 passed`; py_compile passed.
+
+GSD full suite:
+
+```bash
+cd /home/whiskey/workspace/project/central/v2/gsd-hermes
+npm test
+```
+
+Result: PASS — `5597/5597` tests passed.
+
+## Redaction guarantees
+
+The new diagnostic tests use fake secrets and assert they do not appear in sanitized output:
+
+- API keys / token-like values
+- bearer tokens / Authorization headers
+- password-like values
+- client secrets
+- URL userinfo / credential-bearing connection strings
+
+No real credentials were added to artifacts or test fixtures.
+
+## Remaining route
+
+Proceed to Phase 13: Tracker, Documentation, Release.
+
+Phase 13 should open/update the GitHub tracker issue, prepare PR/release acceptance evidence, update README/COMMANDS/CONFIGURATION/release notes, and then run PR/CI/release/publish flow for `gsd-hermes@1.4.0`.

--- a/.planning/phases/12-fail-fast-validation-and-proof-tests/12-VALIDATION.md
+++ b/.planning/phases/12-fail-fast-validation-and-proof-tests/12-VALIDATION.md
@@ -1,0 +1,30 @@
+# Phase 12 Plan Validation
+
+**Phase:** 12 — Fail-Fast Validation and Proof Tests
+**Validated:** 2026-04-26T03:11:15+08:00
+**Route:** `/gsd-plan-phase 12`
+**Execution mode:** Hermes inline/degraded planning path.
+
+## Artifacts created
+
+- `12-RESEARCH.md`
+- `12-CONTEXT.md`
+- `12-01-PLAN.md`
+- `12-02-PLAN.md`
+- `12-03-PLAN.md`
+- `12-04-PLAN.md`
+
+## Validation checks
+
+- Phase 12 requirements mapped: ENF-01, ENF-02, ENF-03, TEST-01, TEST-02, TEST-03, TEST-04.
+- Plans preserve Phase 11 proof boundary: child-construction proof remains distinct from provider wire-level proof.
+- Plans require TDD for new behavior and tests.
+- Plans include SDK and legacy CJS parity checks.
+- Plans include Hermes Agent child-construction proof for planner/executor style GSD roles.
+- Plans include invalid-model no-silent-fallback coverage.
+- Plans include provider diagnostic redaction tests and explicitly avoid live provider credentials by default.
+- Closeout plan requires full GSD suite and targeted Hermes Agent gates.
+
+## Routing
+
+Phase 12 is ready for `/gsd-execute-phase 12`.

--- a/.planning/phases/13-tracker-documentation-release/13-01-PLAN.md
+++ b/.planning/phases/13-tracker-documentation-release/13-01-PLAN.md
@@ -1,0 +1,78 @@
+# Plan 13-01 — Open/update GitHub tracker issue and prepare PR body acceptance checklist
+
+## Requirement coverage
+
+- REL-01: GitHub tracker issue exists for root cause and acceptance criteria.
+- Supports REL-04 by recording release-version constraints before PR/release.
+
+## Goal
+
+Create one canonical tracker issue for the v1.4 runtime model binding receipts work and produce a PR acceptance checklist that reviewers can use to verify the fix without reading all Phase 10–12 planning artifacts.
+
+## Files to read before implementation
+
+- `.planning/phases/13-tracker-documentation-release/13-TRACKER-ISSUE-DRAFT.md`
+- `.planning/phases/12-fail-fast-validation-and-proof-tests/12-SUMMARY.md`
+- `.planning/REQUIREMENTS.md`
+- `CHANGELOG.md`
+- `docs/hermes-compatibility.md`
+
+## Implementation steps
+
+1. Re-check for existing tracker issues.
+
+   ```bash
+   gh issue list --state all --search "Hermes runtime model binding receipts model_overrides delegate_task" --limit 20 --json number,title,state,url,labels
+   ```
+
+2. If no matching open tracker exists, create one from the draft:
+
+   ```bash
+   gh issue create \
+     --title "Track v1.4 Hermes runtime model binding receipts and fail-fast enforcement" \
+     --body-file .planning/phases/13-tracker-documentation-release/13-TRACKER-ISSUE-DRAFT.md \
+     --label needs-triage
+   ```
+
+   If labels differ, list labels first and use the nearest existing label:
+
+   ```bash
+   gh label list --limit 100
+   ```
+
+3. If a matching issue exists, update it instead of duplicating it:
+
+   ```bash
+   gh issue edit <number> --body-file .planning/phases/13-tracker-documentation-release/13-TRACKER-ISSUE-DRAFT.md
+   ```
+
+4. Create a PR body draft artifact at `.planning/phases/13-tracker-documentation-release/13-PR-BODY-DRAFT.md` with:
+   - tracker issue URL;
+   - root cause;
+   - change summary by phase;
+   - proof boundary;
+   - validation commands and actual results;
+   - release target (`1.4.1` recommended because `1.4.0` already exists);
+   - rollback notes.
+
+5. Record the tracker URL in the Phase 13 summary during closeout.
+
+## Acceptance criteria
+
+- [ ] A GitHub tracker issue exists or an existing matching issue is updated.
+- [ ] Tracker issue includes root cause, static evidence, runtime evidence, proof boundary, acceptance checklist, validation commands, and release-version constraint.
+- [ ] `.planning/phases/13-tracker-documentation-release/13-PR-BODY-DRAFT.md` exists and is ready for PR creation.
+- [ ] No credentials, tokens, request bodies, or provider secrets appear in issue/PR text.
+
+## Verification commands
+
+```bash
+gh issue list --state open --search "Hermes runtime model binding receipts" --limit 5 --json number,title,url,state
+rg -n "Authorization|api[_-]?key|token|password|client_secret|BEGIN .*KEY" .planning/phases/13-tracker-documentation-release/13-TRACKER-ISSUE-DRAFT.md .planning/phases/13-tracker-documentation-release/13-PR-BODY-DRAFT.md
+```
+
+Expected result: issue exists; secret scan returns no real credentials. Placeholder terms in prose are acceptable when describing redaction guarantees.
+
+## Rollback
+
+If the issue is created with incorrect content, edit the issue body with the corrected draft. Do not delete the issue unless it contains sensitive data; in that case, redact immediately and notify the maintainer.

--- a/.planning/phases/13-tracker-documentation-release/13-01-PLAN.md
+++ b/.planning/phases/13-tracker-documentation-release/13-01-PLAN.md
@@ -52,7 +52,7 @@ Create one canonical tracker issue for the v1.4 runtime model binding receipts w
    - change summary by phase;
    - proof boundary;
    - validation commands and actual results;
-   - release target (`1.4.1` recommended because `1.4.0` already exists);
+   - release target (`1.4.30` selected because `1.4.0` already exists and local `v1.4.1`–`v1.4.29` tags are present);
    - rollback notes.
 
 5. Record the tracker URL in the Phase 13 summary during closeout.

--- a/.planning/phases/13-tracker-documentation-release/13-02-PLAN.md
+++ b/.planning/phases/13-tracker-documentation-release/13-02-PLAN.md
@@ -1,0 +1,92 @@
+# Plan 13-02 — Update README, COMMANDS.md, CONFIGURATION.md, CHANGELOG, and release notes
+
+## Requirement coverage
+
+- REL-02: Documentation explains resolver output, workflow receipt output, Hermes child construction, and provider request model metadata.
+- REL-03: README, COMMANDS.md, CONFIGURATION.md, and release notes describe strict per-agent model binding semantics for Hermes.
+- Supports REL-04 with publishable version metadata.
+
+## Goal
+
+Update user-facing docs and release metadata so users understand strict Hermes model binding semantics and the maintainer can ship a publishable v1.4 patch release.
+
+## Files to read before implementation
+
+- `README.md`
+- `docs/COMMANDS.md`
+- `docs/CONFIGURATION.md`
+- `docs/hermes-compatibility.md`
+- `CHANGELOG.md`
+- `docs/releases/v1.4.0-upstream-sync-cd057255.md`
+- `package.json`
+- `package-lock.json`
+
+## Implementation steps
+
+1. Version decision and metadata:
+   - Because `gsd-hermes@1.4.0` already exists on npm, bump package metadata to `1.4.1` unless the maintainer explicitly selects a different version.
+   - Update `package.json` and `package-lock.json` together.
+   - Add a new `CHANGELOG.md` section for `1.4.1` dated with the release date.
+   - Keep the existing `1.4.0` upstream-sync section intact.
+
+2. Add long-form release notes:
+   - Create `docs/releases/v1.4.1-runtime-model-binding-receipts.md`.
+   - Include:
+     - root cause;
+     - Phase 10 receipt surface;
+     - Phase 11 Hermes child binding channel;
+     - Phase 12 fail-fast validation and diagnostics;
+     - proof boundary;
+     - validation commands/results;
+     - upgrade notes.
+
+3. Update `README.md`:
+   - Mention the latest publishable package version.
+   - Add a concise “Hermes strict model binding” section.
+   - Link to `docs/hermes-compatibility.md` and the new release note.
+
+4. Update `docs/COMMANDS.md`:
+   - Update the v1.4 release note at the top to include runtime model binding receipts.
+   - In `/gsd-plan-phase` and `/gsd-execute-phase` sections, add how binding receipts appear and how to interpret `runtime_enforced=unknown`.
+
+5. Update `docs/CONFIGURATION.md`:
+   - Add a concrete `model_overrides` example for Hermes.
+   - Explain strict behavior: explicit overrides must run as configured or fail fast.
+   - Explain `workflow.cross_ai_execution` as explicit alternative routing, not silent fallback.
+   - Explain invalid override diagnostic expectations.
+
+6. Update `docs/hermes-compatibility.md`:
+   - Add Phase 12 section for fail-fast validation and safe provider diagnostics.
+   - State that provider wire-level enforcement remains unclaimed unless live sanitized request instrumentation proves exact provider-side model dispatch.
+
+7. Update docs index if useful:
+   - Ensure `docs/README.md` or top-level README links the new release note if release-note links are listed.
+
+## Acceptance criteria
+
+- [ ] `package.json` and `package-lock.json` have the same publishable version.
+- [ ] `CHANGELOG.md` has a new `1.4.1` section while preserving `1.4.0` upstream-sync notes.
+- [ ] A new release note file exists under `docs/releases/`.
+- [ ] README, COMMANDS, CONFIGURATION, and Hermes compatibility docs explain strict model binding semantics.
+- [ ] Docs preserve the proof boundary and do not claim provider wire-level enforcement.
+- [ ] Docs include verification commands for resolver receipts, workflow receipts, child construction proof, and provider diagnostics.
+
+## Verification commands
+
+```bash
+node -e "const p=require('./package.json'); const l=require('./package-lock.json'); if (p.version !== l.version) throw new Error(`${p.version} !== ${l.version}`); console.log(p.version)"
+npm run test:hermes
+node --test tests/hermes-docs.test.cjs tests/runtime-model-parity.test.cjs
+```
+
+Also scan for overclaims:
+
+```bash
+rg -n "provider wire-level.*(proved|enforced)|runtime_enforced=true|guaranteed provider" README.md docs CHANGELOG.md
+```
+
+Expected result: no wording that claims live provider wire-level enforcement unless a future implementation adds that proof.
+
+## Rollback
+
+If release version selection changes, update package files, changelog heading, release-note filename/title, README package badge/text, and PR body together in one commit.

--- a/.planning/phases/13-tracker-documentation-release/13-02-PLAN.md
+++ b/.planning/phases/13-tracker-documentation-release/13-02-PLAN.md
@@ -24,13 +24,13 @@ Update user-facing docs and release metadata so users understand strict Hermes m
 ## Implementation steps
 
 1. Version decision and metadata:
-   - Because `gsd-hermes@1.4.0` already exists on npm, bump package metadata to `1.4.1` unless the maintainer explicitly selects a different version.
+   - Because `gsd-hermes@1.4.0` already exists on npm, bump package metadata to `1.4.30` unless the maintainer explicitly selects a different version.
    - Update `package.json` and `package-lock.json` together.
-   - Add a new `CHANGELOG.md` section for `1.4.1` dated with the release date.
+   - Add a new `CHANGELOG.md` section for `1.4.30` dated with the release date.
    - Keep the existing `1.4.0` upstream-sync section intact.
 
 2. Add long-form release notes:
-   - Create `docs/releases/v1.4.1-runtime-model-binding-receipts.md`.
+   - Create `docs/releases/v1.4.30-runtime-model-binding-receipts.md`.
    - Include:
      - root cause;
      - Phase 10 receipt surface;
@@ -65,7 +65,7 @@ Update user-facing docs and release metadata so users understand strict Hermes m
 ## Acceptance criteria
 
 - [ ] `package.json` and `package-lock.json` have the same publishable version.
-- [ ] `CHANGELOG.md` has a new `1.4.1` section while preserving `1.4.0` upstream-sync notes.
+- [ ] `CHANGELOG.md` has a new `1.4.30` section while preserving `1.4.0` upstream-sync notes.
 - [ ] A new release note file exists under `docs/releases/`.
 - [ ] README, COMMANDS, CONFIGURATION, and Hermes compatibility docs explain strict model binding semantics.
 - [ ] Docs preserve the proof boundary and do not claim provider wire-level enforcement.

--- a/.planning/phases/13-tracker-documentation-release/13-03-PLAN.md
+++ b/.planning/phases/13-tracker-documentation-release/13-03-PLAN.md
@@ -15,7 +15,7 @@ Ship the completed runtime model binding receipt work through a reviewable PR, w
 - `.planning/phases/13-tracker-documentation-release/13-TRACKER-ISSUE-DRAFT.md`
 - `package.json`
 - `CHANGELOG.md`
-- `docs/releases/v1.4.1-runtime-model-binding-receipts.md`
+- `docs/releases/v1.4.30-runtime-model-binding-receipts.md`
 - `.planning/phases/10-runtime-binding-receipt-surface/10-SUMMARY.md`
 - `.planning/phases/11-hermes-per-agent-binding-channel/11-SUMMARY.md`
 - `.planning/phases/12-fail-fast-validation-and-proof-tests/12-SUMMARY.md`
@@ -26,7 +26,7 @@ Ship the completed runtime model binding receipt work through a reviewable PR, w
 
    ```bash
    npm view gsd-hermes versions --json
-   gh release view v1.4.1 --json tagName,url 2>/dev/null || true
+   gh release view v1.4.30 --json tagName,url 2>/dev/null || true
    git tag --list 'v1.4*'
    node -e "const p=require('./package.json'); const l=require('./package-lock.json'); if (p.version !== l.version) throw new Error(`${p.version} !== ${l.version}`); console.log(p.version)"
    ```
@@ -80,9 +80,9 @@ Ship the completed runtime model binding receipt work through a reviewable PR, w
    ```bash
    npm view gsd-hermes versions --json
    npm publish
-   git tag v1.4.1
-   git push origin v1.4.1
-   gh release create v1.4.1 --title "v1.4.1" --notes-file docs/releases/v1.4.1-runtime-model-binding-receipts.md
+   git tag v1.4.30
+   git push origin v1.4.30
+   gh release create v1.4.30 --title "v1.4.30" --notes-file docs/releases/v1.4.30-runtime-model-binding-receipts.md
    ```
 
 9. Record evidence in Phase 13 summary and state files:
@@ -113,7 +113,7 @@ Ship the completed runtime model binding receipt work through a reviewable PR, w
 gh pr status
 gh pr checks --watch
 npm view gsd-hermes version --json
-gh release view v1.4.1 --json tagName,name,url,isDraft,isPrerelease,publishedAt
+gh release view v1.4.30 --json tagName,name,url,isDraft,isPrerelease,publishedAt
 ```
 
 ## Rollback

--- a/.planning/phases/13-tracker-documentation-release/13-03-PLAN.md
+++ b/.planning/phases/13-tracker-documentation-release/13-03-PLAN.md
@@ -1,0 +1,123 @@
+# Plan 13-03 — Execute PR/CI/release flow and publish the v1.4 patch release
+
+## Requirement coverage
+
+- REL-04: npm package and GitHub Release evidence recorded after validation.
+- Also verifies REL-01–REL-03 before shipping.
+
+## Goal
+
+Ship the completed runtime model binding receipt work through a reviewable PR, wait for CI, then publish the next v1.4 patch release with evidence.
+
+## Files to read before implementation
+
+- `.planning/phases/13-tracker-documentation-release/13-PR-BODY-DRAFT.md`
+- `.planning/phases/13-tracker-documentation-release/13-TRACKER-ISSUE-DRAFT.md`
+- `package.json`
+- `CHANGELOG.md`
+- `docs/releases/v1.4.1-runtime-model-binding-receipts.md`
+- `.planning/phases/10-runtime-binding-receipt-surface/10-SUMMARY.md`
+- `.planning/phases/11-hermes-per-agent-binding-channel/11-SUMMARY.md`
+- `.planning/phases/12-fail-fast-validation-and-proof-tests/12-SUMMARY.md`
+
+## Implementation steps
+
+1. Preflight release target:
+
+   ```bash
+   npm view gsd-hermes versions --json
+   gh release view v1.4.1 --json tagName,url 2>/dev/null || true
+   git tag --list 'v1.4*'
+   node -e "const p=require('./package.json'); const l=require('./package-lock.json'); if (p.version !== l.version) throw new Error(`${p.version} !== ${l.version}`); console.log(p.version)"
+   ```
+
+   Abort if package version is still `1.4.0`; that version is already published. Also abort if the selected package version, git tag, or GitHub Release already exists.
+
+2. Run local validation:
+
+   ```bash
+   npm run build:sdk
+   npm run test:hermes
+   npm test
+   npm pack --dry-run
+   ```
+
+3. Verify Hermes Agent local proof tests if the PR/release notes cite local Hermes Agent proof:
+
+   ```bash
+   cd /home/whiskey/.hermes/hermes-agent
+   .venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py tests/agent/test_provider_diagnostics.py -q
+   .venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py agent/provider_diagnostics.py agent/redact.py tests/tools/test_delegate.py tests/agent/test_provider_diagnostics.py
+   ```
+
+4. Prepare PR branch:
+   - If `.planning/` should not enter PR, use the established clean PR branch workflow to exclude planning artifacts.
+   - Preserve local planning artifacts in the development branch/history.
+   - Ensure implementation/docs/package changes are included.
+
+5. Create PR:
+
+   ```bash
+   gh pr create --title "Ship Hermes runtime model binding receipts and fail-fast enforcement" --body-file .planning/phases/13-tracker-documentation-release/13-PR-BODY-DRAFT.md
+   ```
+
+6. Track CI until complete:
+
+   ```bash
+   gh pr checks --watch
+   ```
+
+7. Merge only after CI passes and review is acceptable.
+
+8. Publish release after merge:
+   - Pull/realign local main safely.
+   - Confirm version is publishable and not already on npm.
+   - Run `npm publish` only after credentials/scope are confirmed.
+   - Create GitHub Release for the same tag/version using the release-note file.
+
+   Example commands, adjusted for final version:
+
+   ```bash
+   npm view gsd-hermes versions --json
+   npm publish
+   git tag v1.4.1
+   git push origin v1.4.1
+   gh release create v1.4.1 --title "v1.4.1" --notes-file docs/releases/v1.4.1-runtime-model-binding-receipts.md
+   ```
+
+9. Record evidence in Phase 13 summary and state files:
+   - create `.planning/phases/13-tracker-documentation-release/13-SUMMARY.md`;
+   - update `.planning/ROADMAP.md` Phase 13 checkboxes/progress;
+   - update `.planning/STATE.md` milestone status;
+   - update `.planning/REQUIREMENTS.md` traceability/status if release is complete;
+   - record tracker issue URL;
+   - record PR URL;
+   - record CI pass link/status;
+   - record npm package URL/version;
+   - record GitHub Release URL;
+   - record validation command outputs.
+
+## Acceptance criteria
+
+- [ ] Local validation passes.
+- [ ] PR exists with tracker link and acceptance checklist.
+- [ ] PR CI passes before merge.
+- [ ] npm publish uses a version not already published.
+- [ ] GitHub Release tag matches package version.
+- [ ] Phase 13 summary records URLs/evidence.
+- [ ] No sensitive diagnostics or credentials are published.
+
+## Verification commands
+
+```bash
+gh pr status
+gh pr checks --watch
+npm view gsd-hermes version --json
+gh release view v1.4.1 --json tagName,name,url,isDraft,isPrerelease,publishedAt
+```
+
+## Rollback
+
+- Before publish: revert docs/version commits or close PR.
+- After GitHub Release but before npm publish: delete/recreate draft/release only if needed; prefer editing release notes.
+- After npm publish: do not unpublish except under npm security policy. Publish a follow-up patch release for corrections.

--- a/.planning/phases/13-tracker-documentation-release/13-CONTEXT.md
+++ b/.planning/phases/13-tracker-documentation-release/13-CONTEXT.md
@@ -1,0 +1,74 @@
+# Phase 13 Context — Tracker, Documentation, Release
+
+Generated: 2026-04-26
+Route: `/gsd-plan-phase 13 --auto`
+
+## Phase objective
+
+Make the v1.4 Hermes runtime model binding work reviewable, documented, and releasable.
+
+Phase 13 covers requirements:
+
+- REL-01 — GitHub tracker issue exists with root cause and acceptance criteria.
+- REL-02 — Documentation explains resolver output, workflow receipts, Hermes child construction, and provider request metadata diagnostics.
+- REL-03 — README, COMMANDS.md, CONFIGURATION.md, and release notes describe strict per-agent model binding semantics for Hermes.
+- REL-04 — The v1.4 release line is shipped with GitHub Release and npm evidence after tests/CI pass.
+
+## Completed technical foundation
+
+Phase 10:
+
+- Added structured plan/execute init model binding receipts.
+- Kept proof semantics conservative: resolver intent and workflow handoff are visible, but runtime enforcement is unknown unless proven.
+
+Phase 11:
+
+- Added Hermes Agent `delegate_task(model=...)` and batch `tasks[].model` support.
+- Precedence: `tasks[i].model > top-level model > delegation.model > parent inheritance`.
+- Added GSD `runtime_binding_channel` receipt metadata.
+- Proved Hermes child `AIAgent(model=...)` construction, not provider wire-level dispatch.
+
+Phase 12:
+
+- Added SDK/CJS validation tests for unavailable explicit channel fail-fast behavior.
+- Proved invalid explicit tokens are preserved rather than replaced by parent/default model.
+- Added Hermes tests for planner/executor child construction.
+- Added offline safe provider diagnostics that preserve model/provider metadata while redacting credentials.
+- Full GSD suite passed `5597/5597`; Hermes targeted suite passed `128/128`.
+
+## Release-version decision
+
+The original roadmap success criterion says `gsd-hermes@1.4.0`, but registry/release discovery found:
+
+- `npm view gsd-hermes version` returns `1.4.0`.
+- GitHub Release `v1.4.0` already exists.
+- Local HEAD contains runtime binding receipt commits after tag `v1.4.0`.
+
+Because npm versions are immutable, the executable default is to ship this as `1.4.1` in the v1.4 line. Execution should not publish until this is reflected in docs/release notes and confirmed in the PR body.
+
+## Proof wording to preserve
+
+Use this exact distinction in docs and release notes:
+
+- GSD resolver proof: `model_overrides` resolve to explicit configured/resolved model tokens.
+- Workflow receipt proof: `/gsd-plan-phase` and `/gsd-execute-phase` show structured `model_binding_receipts` before dispatch.
+- Hermes child-construction proof: delegated children are constructed with the intended `model` value.
+- Provider diagnostics: sanitized metadata can expose model/provider/request proof fields without credentials.
+- Provider wire-level enforcement: still not overclaimed unless future live provider instrumentation proves provider-side `model=` dispatch.
+
+## External side-effect gates
+
+Phase 13 execution may create GitHub issues/PRs and publish packages. Before publish:
+
+1. Confirm release target version (`1.4.1` recommended).
+2. Confirm npm auth and release scope are available.
+3. Confirm PR CI is green.
+4. Confirm no unintended `.planning/` artifacts are included in the PR branch unless explicitly desired.
+
+## Suggested tracker title
+
+`Track v1.4 Hermes runtime model binding receipts and fail-fast enforcement`
+
+## Suggested PR title
+
+`Ship Hermes runtime model binding receipts and fail-fast enforcement`

--- a/.planning/phases/13-tracker-documentation-release/13-CONTEXT.md
+++ b/.planning/phases/13-tracker-documentation-release/13-CONTEXT.md
@@ -44,7 +44,7 @@ The original roadmap success criterion says `gsd-hermes@1.4.0`, but registry/rel
 - GitHub Release `v1.4.0` already exists.
 - Local HEAD contains runtime binding receipt commits after tag `v1.4.0`.
 
-Because npm versions are immutable, the executable default is to ship this as `1.4.1` in the v1.4 line. Execution should not publish until this is reflected in docs/release notes and confirmed in the PR body.
+Because npm versions are immutable, the executable default is to ship this as `1.4.30` in the v1.4 line. Execution should not publish until this is reflected in docs/release notes and confirmed in the PR body.
 
 ## Proof wording to preserve
 
@@ -60,7 +60,7 @@ Use this exact distinction in docs and release notes:
 
 Phase 13 execution may create GitHub issues/PRs and publish packages. Before publish:
 
-1. Confirm release target version (`1.4.1` recommended).
+1. Confirm release target version (`1.4.30` recommended).
 2. Confirm npm auth and release scope are available.
 3. Confirm PR CI is green.
 4. Confirm no unintended `.planning/` artifacts are included in the PR branch unless explicitly desired.

--- a/.planning/phases/13-tracker-documentation-release/13-PATTERNS.md
+++ b/.planning/phases/13-tracker-documentation-release/13-PATTERNS.md
@@ -1,0 +1,43 @@
+# Phase 13 Patterns — Existing Release and Documentation Workflow
+
+Date: 2026-04-26
+
+## Existing docs/release locations
+
+| Purpose | Existing path |
+| --- | --- |
+| Top-level package overview | `README.md` |
+| Command reference | `docs/COMMANDS.md` |
+| Configuration reference | `docs/CONFIGURATION.md` |
+| Hermes compatibility and guardrails | `docs/hermes-compatibility.md` |
+| Release history | `CHANGELOG.md` |
+| Long-form release note | `docs/releases/` |
+| Package version | `package.json` / `package-lock.json` |
+
+## Existing release-note pattern
+
+- `CHANGELOG.md` has `[Unreleased]` followed by version sections.
+- `docs/releases/v1.4.0-upstream-sync-cd057255.md` is the current v1.4 release note.
+- README links individual release-note files under `docs/releases/`.
+- Existing package line records both downstream package version and upstream base.
+
+## Existing validation commands
+
+- Hermes compatibility: `npm run test:hermes`
+- SDK build: `npm run build:sdk`
+- Full test suite: `npm test`
+- Targeted Phase 12 GSD gates:
+  - `cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts`
+  - `node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs`
+- Hermes Agent targeted gates from Phase 12:
+  - `.venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py tests/agent/test_provider_diagnostics.py -q`
+  - `.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py agent/provider_diagnostics.py agent/redact.py tests/tools/test_delegate.py tests/agent/test_provider_diagnostics.py`
+
+## Patterns for Phase 13 execution
+
+1. Prefer small docs additions over broad rewrites.
+2. Keep Hermes-specific docs in existing Hermes files instead of upstream-owned docs where possible.
+3. Keep proof wording conservative and layered.
+4. Use exact verification commands in issue/PR/release notes.
+5. Treat npm publish as irreversible; do dry-run/pack checks first.
+6. If preparing a clean PR branch, filter `.planning/` according to established PR hygiene.

--- a/.planning/phases/13-tracker-documentation-release/13-PR-BODY-DRAFT.md
+++ b/.planning/phases/13-tracker-documentation-release/13-PR-BODY-DRAFT.md
@@ -1,0 +1,109 @@
+# Ship Hermes runtime model binding receipts and fail-fast enforcement
+
+Closes #32
+
+## Tracker
+
+- Issue: https://github.com/pingchesu/gsd-hermes/issues/32
+
+## Root cause
+
+GSD resolver/config surfaces could report explicit per-agent `model_overrides`, but the pre-fix Hermes delegation path did not expose a per-call child `model` binding. In Hermes, spawned child agents could therefore inherit the parent/default model even when GSD receipts showed `source=override` and `binding=explicit`.
+
+Resolver truth was not runtime truth.
+
+## Change summary
+
+### Phase 10 — Runtime Binding Receipt Surface
+
+- Added structured `model_binding_receipts` to plan-phase and execute-phase init payloads.
+- Preserved backward-compatible flat `*_model` fields.
+- Updated workflow transcript instructions to show resolver/runtime/proof boundaries conservatively.
+
+### Phase 11 — Hermes Per-Agent Binding Channel
+
+- Added Hermes Agent child binding support through direct `delegate_task(model=...)` and batch `tasks[].model`.
+- Added GSD receipt metadata for `runtime_binding_channel.kind=hermes-delegate-task-model` with `proof_level=child-construction`.
+- Documented that `delegation.model` is a global fallback, not a per-agent GSD override channel.
+
+### Phase 12 — Fail-Fast Validation and Proof Tests
+
+- Added SDK/CJS validation coverage so unsupported explicit Hermes bindings fail before spawn.
+- Added regression tests proving invalid explicit model tokens are preserved and cannot silently fall back to parent/default model.
+- Added Hermes Agent tests proving GSD planner/executor model tokens reach child `AIAgent(model=...)` construction.
+- Added safe provider diagnostics that preserve sanitized model/provider metadata while redacting credentials.
+
+### Phase 13 — Tracker, docs, release prep
+
+- Created tracker issue #32.
+- Updated README, COMMANDS, CONFIGURATION, Hermes compatibility docs, CHANGELOG, package metadata, and curated release notes for the selected patch release.
+- Selected `gsd-hermes@1.4.30` / GitHub Release `v1.4.30` because `1.4.0` is already published and local `v1.4.1`–`v1.4.29` tags are present.
+
+## Proof boundary
+
+This PR intentionally separates evidence layers:
+
+1. GSD resolver proof — config override resolves to the configured/resolved model token.
+2. Workflow receipt proof — init payload/transcript displays binding metadata before dispatch.
+3. Hermes child-construction proof — child `AIAgent(model=...)` receives the intended token.
+4. Provider diagnostics proof — sanitized metadata can expose provider/model fields without secrets.
+5. Provider wire-level enforcement — not claimed unless future live sanitized request instrumentation proves provider-side `model=` dispatch.
+
+`runtime_enforced=unknown` is conservative and must not be read as provider wire-level proof.
+
+## Validation
+
+Local validation to run before PR/release:
+
+```bash
+npm run build:sdk
+cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts
+cd .. && node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs
+npm run test:hermes
+npm test
+npm pack --dry-run
+```
+
+Hermes Agent proof tests:
+
+```bash
+cd /home/whiskey/.hermes/hermes-agent
+.venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py tests/agent/test_provider_diagnostics.py -q
+.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py agent/provider_diagnostics.py agent/redact.py tests/tools/test_delegate.py tests/agent/test_provider_diagnostics.py
+```
+
+Latest recorded Phase 12 results before Phase 13 docs/release updates:
+
+- GSD full suite: PASS — `5597/5597`.
+- GSD targeted gates: PASS.
+- Hermes Agent targeted gates: PASS — `128 passed` plus `py_compile`.
+
+Phase 13 final local/CI results will be recorded before merge/release.
+
+## Release target
+
+- npm package: `gsd-hermes@1.4.30`
+- GitHub Release: `v1.4.30`
+- Release notes: `docs/releases/v1.4.30-runtime-model-binding-receipts.md`
+
+Pre-publish gates:
+
+- [ ] `package.json` and `package-lock.json` both equal `1.4.30`.
+- [ ] `npm view gsd-hermes versions --json` does not include `1.4.30`.
+- [ ] `git tag --list v1.4.30` is empty before creating the release tag.
+- [ ] `gh release view v1.4.30` reports no existing release before creating it.
+- [ ] CI is green before publish.
+
+## Acceptance checklist
+
+- [ ] Structured plan/execute binding receipts are present and covered by SDK/CJS tests.
+- [ ] Hermes child binding channel supports direct `model` and batch `tasks[].model`.
+- [ ] Unsupported explicit bindings fail fast before spawn.
+- [ ] Invalid explicit model tokens cannot be hidden by fallback to parent/default model.
+- [ ] Provider diagnostics redact API keys, tokens, authorization headers, passwords, client secrets, and credential-bearing URLs.
+- [ ] README, COMMANDS.md, CONFIGURATION.md, Hermes compatibility docs, CHANGELOG, and release notes document strict semantics and proof boundaries.
+- [ ] npm/GitHub release evidence is recorded after publish.
+
+## Rollback notes
+
+Before publish, rollback is a normal PR revert/close. After npm publish, npm versions are immutable; corrections should ship as a follow-up patch release rather than unpublishing except under npm security policy.

--- a/.planning/phases/13-tracker-documentation-release/13-RESEARCH.md
+++ b/.planning/phases/13-tracker-documentation-release/13-RESEARCH.md
@@ -1,0 +1,99 @@
+# Phase 13 Research — Tracker, Documentation, Release
+
+Date: 2026-04-26
+Route: `/gsd-plan-phase 13 --auto`
+Mode: sequential inline planning under Hermes runtime compatibility fallback
+
+## Research question
+
+How should the v1.4 Hermes Runtime Model Binding Receipts milestone be made reviewable and shippable after Phases 10–12 landed resolver receipts, Hermes child model propagation, fail-fast validation tests, and safe provider diagnostics?
+
+## Inputs read
+
+- `.planning/REQUIREMENTS.md`
+- `.planning/ROADMAP.md`
+- `.planning/STATE.md`
+- `.planning/phases/12-fail-fast-validation-and-proof-tests/12-SUMMARY.md`
+- `README.md`
+- `docs/COMMANDS.md`
+- `docs/CONFIGURATION.md`
+- `docs/hermes-compatibility.md`
+- `CHANGELOG.md`
+- `package.json`
+- GitHub repository metadata via `gh repo view`
+- Existing issue search via `gh issue list`
+- Published package/release state via `npm view gsd-hermes version` and `gh release view v1.4.0`
+
+## Current release facts
+
+- Repository: `pingchesu/gsd-hermes`
+- Default branch: `main`
+- Current local branch: `main`
+- Package file version: `1.4.0`
+- npm registry already has `gsd-hermes@1.4.0`
+- GitHub Release `v1.4.0` already exists and was published on 2026-04-25 for the upstream-sync release.
+- Local HEAD is ahead of tag `v1.4.0` with the v1.4 runtime binding receipt work from Phase 10–12.
+
+## Important release constraint
+
+npm package versions are immutable. Because `gsd-hermes@1.4.0` already exists, Phase 13 execution must not attempt to publish `1.4.0` again. The default release plan is therefore:
+
+- Treat this milestone as the `v1.4` feature line.
+- Ship the new runtime binding receipt work as `gsd-hermes@1.4.1` / GitHub Release `v1.4.1`, unless the maintainer explicitly chooses a different semver.
+- Update docs/release notes to explain that `1.4.0` was the upstream-sync package and `1.4.1` is the Hermes runtime model binding receipt patch release.
+
+This reconciles REL-04 with the actual registry state without violating npm immutability.
+
+## Existing tracker issue search
+
+A search for `Hermes Runtime Model Binding Receipts OR model binding OR runtime model` found only unrelated closed issue #14 (`Ship v1.2 Cross-Provider Agent Execution milestone`). Phase 13 should create a new tracker issue instead of updating #14.
+
+## Documentation gaps to close
+
+1. `README.md`
+   - Currently mentions package `gsd-hermes@1.4.0` and links the existing v1.4 upstream-sync release note.
+   - Needs a short Hermes strict model binding section that points users to verification commands and proof boundaries.
+
+2. `docs/COMMANDS.md`
+   - Current v1.4 release note only describes upstream command-surface sync.
+   - Needs command-level explanation of `/gsd-plan-phase` and `/gsd-execute-phase` model binding receipts, plus how to interpret `runtime_enforced=unknown`.
+
+3. `docs/CONFIGURATION.md`
+   - Already says Hermes avoids silent model fallback.
+   - Needs concrete config examples for `model_overrides`, invalid override fail-fast behavior, and `workflow.cross_ai_execution` as an explicit alternative rather than silent fallback.
+
+4. `docs/hermes-compatibility.md`
+   - Already contains Phase 10–11 receipt layer wording.
+   - Needs Phase 12 update for fail-fast validation, safe provider diagnostics, and the remaining provider-wire proof boundary.
+
+5. `CHANGELOG.md` and `docs/releases/`
+   - Existing `1.4.0` section is an upstream-sync release.
+   - Needs a new `1.4.1` section/release note for runtime model binding receipts.
+
+## PR / CI / publish constraints
+
+- Keep `.planning/` artifacts out of clean PR branches unless intentionally shipping planning records. In this repo, planning artifacts may be committed locally, but PR preparation should use the established clean-branch workflow if security/CI rejects `.planning/`.
+- Before PR, run at minimum:
+  - `npm run build:sdk`
+  - `npm run test:hermes`
+  - `npm test`
+  - Hermes Agent targeted tests relevant to local patched runtime if release notes claim Hermes child construction proof.
+- PR body should include tracker issue link, root cause, proof boundary, validation output, and release-version decision (`1.4.1` because `1.4.0` already exists).
+- Publish should only occur after PR CI passes and the maintainer confirms release credentials/scope.
+
+## Recommended Phase 13 plan shape
+
+1. Tracker + PR acceptance artifact.
+2. Docs/release note/version metadata update.
+3. PR/CI/release/publish flow with explicit version-collision guard.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Duplicate issue | Search first, create only if no matching open issue exists. |
+| Attempting to republish `1.4.0` | Default to `1.4.1`; verify `npm view gsd-hermes version` before publish. |
+| Overclaiming provider proof | Docs must say child-construction proof exists; provider wire-level enforcement remains not overclaimed. |
+| Leaking secrets in diagnostics | Only mention sanitized metadata; never include headers/body/tokens/API keys. |
+| PR contaminated with planning artifacts | Use clean PR branch workflow if required by CI/security; planning artifacts can stay local/shared history. |
+| CI mismatch from Node version | Note local Node v20 emits `EBADENGINE` warnings for package `>=22`; release/CI should run on Node 22+. |

--- a/.planning/phases/13-tracker-documentation-release/13-RESEARCH.md
+++ b/.planning/phases/13-tracker-documentation-release/13-RESEARCH.md
@@ -39,8 +39,8 @@ How should the v1.4 Hermes Runtime Model Binding Receipts milestone be made revi
 npm package versions are immutable. Because `gsd-hermes@1.4.0` already exists, Phase 13 execution must not attempt to publish `1.4.0` again. The default release plan is therefore:
 
 - Treat this milestone as the `v1.4` feature line.
-- Ship the new runtime binding receipt work as `gsd-hermes@1.4.1` / GitHub Release `v1.4.1`, unless the maintainer explicitly chooses a different semver.
-- Update docs/release notes to explain that `1.4.0` was the upstream-sync package and `1.4.1` is the Hermes runtime model binding receipt patch release.
+- Ship the new runtime binding receipt work as `gsd-hermes@1.4.30` / GitHub Release `v1.4.30`, unless the maintainer explicitly chooses a different semver.
+- Update docs/release notes to explain that `1.4.0` was the upstream-sync package and `1.4.30` is the Hermes runtime model binding receipt patch release.
 
 This reconciles REL-04 with the actual registry state without violating npm immutability.
 
@@ -68,7 +68,7 @@ A search for `Hermes Runtime Model Binding Receipts OR model binding OR runtime 
 
 5. `CHANGELOG.md` and `docs/releases/`
    - Existing `1.4.0` section is an upstream-sync release.
-   - Needs a new `1.4.1` section/release note for runtime model binding receipts.
+   - Needs a new `1.4.30` section/release note for runtime model binding receipts.
 
 ## PR / CI / publish constraints
 
@@ -78,7 +78,7 @@ A search for `Hermes Runtime Model Binding Receipts OR model binding OR runtime 
   - `npm run test:hermes`
   - `npm test`
   - Hermes Agent targeted tests relevant to local patched runtime if release notes claim Hermes child construction proof.
-- PR body should include tracker issue link, root cause, proof boundary, validation output, and release-version decision (`1.4.1` because `1.4.0` already exists).
+- PR body should include tracker issue link, root cause, proof boundary, validation output, and release-version decision (`1.4.30` because `1.4.0` already exists).
 - Publish should only occur after PR CI passes and the maintainer confirms release credentials/scope.
 
 ## Recommended Phase 13 plan shape
@@ -92,7 +92,7 @@ A search for `Hermes Runtime Model Binding Receipts OR model binding OR runtime 
 | Risk | Mitigation |
 | --- | --- |
 | Duplicate issue | Search first, create only if no matching open issue exists. |
-| Attempting to republish `1.4.0` | Default to `1.4.1`; verify `npm view gsd-hermes version` before publish. |
+| Attempting to republish `1.4.0` | Default to `1.4.30`; verify `npm view gsd-hermes version` before publish. |
 | Overclaiming provider proof | Docs must say child-construction proof exists; provider wire-level enforcement remains not overclaimed. |
 | Leaking secrets in diagnostics | Only mention sanitized metadata; never include headers/body/tokens/API keys. |
 | PR contaminated with planning artifacts | Use clean PR branch workflow if required by CI/security; planning artifacts can stay local/shared history. |

--- a/.planning/phases/13-tracker-documentation-release/13-TRACKER-ISSUE-DRAFT.md
+++ b/.planning/phases/13-tracker-documentation-release/13-TRACKER-ISSUE-DRAFT.md
@@ -76,4 +76,4 @@ cd /home/whiskey/.hermes/hermes-agent
 
 ## Release note
 
-`gsd-hermes@1.4.0` already exists as the upstream-sync package. This tracker should ship as the next v1.4 patch release, recommended `gsd-hermes@1.4.1` / GitHub Release `v1.4.1`, unless the maintainer explicitly selects a different semver.
+`gsd-hermes@1.4.0` already exists as the upstream-sync package. Preflight also found local `v1.4.1`–`v1.4.29` tags, so this tracker should ship as the next local-safe v1.4 patch release, selected `gsd-hermes@1.4.30` / GitHub Release `v1.4.30`, unless the maintainer explicitly selects a different semver.

--- a/.planning/phases/13-tracker-documentation-release/13-TRACKER-ISSUE-DRAFT.md
+++ b/.planning/phases/13-tracker-documentation-release/13-TRACKER-ISSUE-DRAFT.md
@@ -1,0 +1,79 @@
+# Track v1.4 Hermes runtime model binding receipts and fail-fast enforcement
+
+## Root cause
+
+GSD resolver/config surfaces could show explicit per-agent `model_overrides`, but the pre-fix Hermes child delegation path did not expose a per-call child `model` binding. That meant Hermes-spawned subagents could inherit the parent/default model even when GSD showed `source=override` and `binding=explicit`.
+
+Resolver truth was therefore not the same as runtime truth.
+
+## Static evidence
+
+Pre-fix, Hermes `delegate_task` did not expose a per-call child model field for GSD to populate. `delegation.model` was only a global fallback/default, so a GSD-specific planner/executor override could not be proven at child construction.
+
+Fix evidence to cite in PR:
+
+- Hermes Agent schema/implementation now accepts direct `delegate_task(model=...)`.
+- Batch delegation now accepts per-task `tasks[].model`.
+- GSD receipts now expose `runtime_binding_channel.kind=hermes-delegate-task-model` and `proof_level=child-construction`.
+
+## Runtime evidence
+
+Runtime construction evidence to cite in PR:
+
+- Hermes tests assert planner-style `delegate_task(model="openai/o4-mini")` constructs child `AIAgent(model="openai/o4-mini")`.
+- Batch tests assert heterogeneous `tasks[].model` values reach their respective child `AIAgent` instances.
+- Invalid explicit model strings reach child construction unchanged and do not inherit parent/default model.
+- Provider diagnostics tests assert model/provider metadata can be exposed only after credential redaction.
+
+## Fix summary
+
+- Add structured plan/execute binding receipts so `/gsd-plan-phase` and `/gsd-execute-phase` show effective runtime/model intent before child dispatch.
+- Add Hermes child binding channel support through `delegate_task(model=...)` and batch `tasks[].model`.
+- Add fail-fast validation so unsupported explicit bindings fail before spawn instead of silently falling back.
+- Add regression tests proving invalid explicit model tokens are preserved and cannot be hidden by parent/default fallback.
+- Add safe provider diagnostics that preserve model/provider metadata while redacting credentials.
+
+## Proof boundary
+
+This tracker distinguishes evidence layers:
+
+1. GSD resolver proof — config override resolves to a configured/resolved model token.
+2. Workflow receipt proof — init payload/transcript displays binding receipt before dispatch.
+3. Hermes child-construction proof — child `AIAgent(model=...)` receives the intended token.
+4. Provider diagnostics — sanitized metadata can expose provider/model fields without secrets.
+5. Provider wire-level enforcement — not overclaimed unless future live provider request instrumentation proves provider-side `model=` dispatch.
+
+## Acceptance criteria
+
+- [ ] `gsd-sdk query init.plan-phase <phase>` emits structured binding metadata for researcher/planner/checker agents.
+- [ ] `gsd-sdk query init.execute-phase <phase>` emits structured binding metadata for executor/verifier agents.
+- [ ] Hermes `/gsd-plan-phase` and `/gsd-execute-phase` transcript instructions display concise binding receipts before dispatch.
+- [ ] Explicit Hermes model overrides reach child construction through `delegate_task(model=...)` or `tasks[].model`.
+- [ ] Unsupported explicit binding paths fail fast with actionable diagnostics before subagent spawn.
+- [ ] Invalid explicit model token tests prove no silent fallback to parent/default model.
+- [ ] Safe provider diagnostics redact API keys, tokens, passwords, authorization headers, and credential-bearing URLs.
+- [ ] README, COMMANDS.md, CONFIGURATION.md, Hermes compatibility docs, CHANGELOG, and release notes explain strict Hermes model binding semantics.
+- [ ] PR CI passes before release.
+- [ ] Release version uses the next publishable v1.4 patch version because `gsd-hermes@1.4.0` already exists.
+
+## Validation commands
+
+```bash
+npm run build:sdk
+cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts
+cd .. && node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs
+npm run test:hermes
+npm test
+```
+
+Hermes Agent targeted validation:
+
+```bash
+cd /home/whiskey/.hermes/hermes-agent
+.venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py tests/agent/test_provider_diagnostics.py -q
+.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py agent/provider_diagnostics.py agent/redact.py tests/tools/test_delegate.py tests/agent/test_provider_diagnostics.py
+```
+
+## Release note
+
+`gsd-hermes@1.4.0` already exists as the upstream-sync package. This tracker should ship as the next v1.4 patch release, recommended `gsd-hermes@1.4.1` / GitHub Release `v1.4.1`, unless the maintainer explicitly selects a different semver.

--- a/.planning/phases/13-tracker-documentation-release/13-VALIDATION.md
+++ b/.planning/phases/13-tracker-documentation-release/13-VALIDATION.md
@@ -1,0 +1,65 @@
+# Phase 13 Plan Validation — Tracker, Documentation, Release
+
+Date: 2026-04-26
+
+## Validation architecture
+
+Phase 13 is a release/documentation phase with external side effects. The plan therefore validates three layers:
+
+1. Tracker/review layer — issue and PR body must record root cause, acceptance criteria, proof boundary, and validation commands.
+2. Docs/release metadata layer — README, COMMANDS, CONFIGURATION, Hermes compatibility docs, changelog, release note, and package metadata must agree.
+3. Shipping layer — local tests, PR CI, npm publish, and GitHub Release evidence must be recorded.
+
+## Plan coverage
+
+| Plan | Requirements | Primary risk addressed |
+| --- | --- | --- |
+| 13-01 | REL-01 | Missing or duplicate tracker; weak acceptance criteria |
+| 13-02 | REL-02, REL-03 | Docs overclaiming provider proof or omitting strict fail-fast semantics |
+| 13-03 | REL-04 | Publishing wrong/duplicate version or releasing before CI passes |
+
+## Release-version validation
+
+Discovery found `gsd-hermes@1.4.0` already published and GitHub Release `v1.4.0` already present. The plans therefore require a publishable patch version, recommended `1.4.1`, before npm publish.
+
+This is a hard validation gate: execution must abort if `package.json` remains `1.4.0` at publish time.
+
+## Verification matrix
+
+| Gate | Command / evidence | Owner plan |
+| --- | --- | --- |
+| Tracker issue exists | `gh issue list --state open --search "Hermes runtime model binding receipts"` | 13-01 |
+| PR body draft exists | `.planning/phases/13-tracker-documentation-release/13-PR-BODY-DRAFT.md` | 13-01 |
+| Package version is publishable | `npm view gsd-hermes versions --json`; package version not already present | 13-02 / 13-03 |
+| Package metadata matches | `node -e "const p=require('./package.json'); const l=require('./package-lock.json'); if (p.version !== l.version) throw new Error(...)"` | 13-02 |
+| Hermes docs gate | `npm run test:hermes` | 13-02 / 13-03 |
+| Full regression | `npm test` | 13-03 |
+| Tarball sanity | `npm pack --dry-run` | 13-03 |
+| CI green | `gh pr checks --watch` | 13-03 |
+| Release evidence | npm version + GitHub Release URL in summary | 13-03 |
+
+## Plan-check result
+
+Automated artifact validation: PASS.
+
+Plan-checker review: PASS after revisions.
+
+Revisions applied after checker feedback:
+
+- Updated stale `1.4.0` release wording in ROADMAP validation matrix and REL-04 to the next publishable v1.4 patch release, default `1.4.1`.
+- Added explicit static evidence and runtime evidence sections to the tracker issue draft.
+- Strengthened Plan 13-01 acceptance criteria to require static/runtime evidence.
+- Strengthened Plan 13-03 publish preflight to require package-version, tag, and GitHub Release non-existence checks.
+- Made Phase 13 closeout artifacts and state updates explicit.
+
+Rationale:
+
+- Every Phase 13 success criterion maps to at least one plan.
+- The discovered `1.4.0` publication conflict is explicitly handled before publish.
+- External side effects are gated in the execution plans.
+- Proof boundaries remain conservative and layered.
+- Verification commands are concrete and measurable.
+
+## Known caveat
+
+`npx gsd-sdk query state.begin-phase` emitted local `EBADENGINE` warnings because the current Node is v20.19.5 while `package.json` requires Node >=22. The command still completed. Phase 13 release validation should run on Node 22+.

--- a/.planning/phases/13-tracker-documentation-release/13-VALIDATION.md
+++ b/.planning/phases/13-tracker-documentation-release/13-VALIDATION.md
@@ -20,7 +20,7 @@ Phase 13 is a release/documentation phase with external side effects. The plan t
 
 ## Release-version validation
 
-Discovery found `gsd-hermes@1.4.0` already published and GitHub Release `v1.4.0` already present. The plans therefore require a publishable patch version, recommended `1.4.1`, before npm publish.
+Discovery found `gsd-hermes@1.4.0` already published and GitHub Release `v1.4.0` already present. The plans therefore require a publishable patch version, selected `1.4.30`, before npm publish.
 
 This is a hard validation gate: execution must abort if `package.json` remains `1.4.0` at publish time.
 
@@ -46,7 +46,7 @@ Plan-checker review: PASS after revisions.
 
 Revisions applied after checker feedback:
 
-- Updated stale `1.4.0` release wording in ROADMAP validation matrix and REL-04 to the next publishable v1.4 patch release, default `1.4.1`.
+- Updated stale `1.4.0` release wording in ROADMAP validation matrix and REL-04 to the next publishable v1.4 patch release, default `1.4.30`.
 - Added explicit static evidence and runtime evidence sections to the tracker issue draft.
 - Strengthened Plan 13-01 acceptance criteria to require static/runtime evidence.
 - Strengthened Plan 13-03 publish preflight to require package-version, tag, and GitHub Release non-existence checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ syncs from.
 
 No unreleased changes yet.
 
+## [1.4.30] — 2026-04-26
+
+GSD Hermes package version: `1.4.30`
+Upstream GSD base: `upstream/main@cd057255`
+Tracker: https://github.com/pingchesu/gsd-hermes/issues/32
+
+### Added
+- **Hermes runtime model binding receipts** — plan-phase and execute-phase init payloads now include structured `model_binding_receipts` that show resolver decision, configured model, resolved token, binding source, runtime binding channel, and proof boundary for each participating GSD agent while preserving legacy flat `*_model` fields.
+- **Hermes child binding channel evidence** — direct `delegate_task(model=...)` and batch `tasks[].model` are the canonical Hermes per-agent binding seams; tests verify GSD planner/executor overrides reach child `AIAgent(model=...)` construction.
+- **Safe provider diagnostics** — sanitized provider metadata helpers can record model/provider/proof-source fields without retaining raw headers, request bodies, messages, credentials, API keys, tokens, passwords, client secrets, or credential-bearing URLs.
+
+### Fixed
+- **No silent fallback for explicit Hermes model overrides** — unsupported explicit bindings now fail before spawn with actionable diagnostics instead of allowing a child agent to inherit the parent/default model.
+- **Runtime/model proof boundaries documented** — README, command reference, configuration reference, Hermes compatibility docs, PR checklist, and release notes now distinguish resolver proof, workflow handoff, Hermes child-construction proof, provider diagnostics, and live provider wire-level proof.
+
+### Verification
+- `npm run build:sdk`
+- `cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts`
+- `node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs`
+- `npm run test:hermes`
+- `npm test`
+- Hermes Agent targeted pytest/py_compile gates recorded in the Phase 12/13 planning artifacts.
+
 ## [1.4.0] — 2026-04-25
 
 GSD Hermes package version: `1.4.0`
@@ -2218,6 +2241,7 @@ Upstream GSD base: `get-shit-done-cc@1.37.1`
 [1.5.2]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.5.2
 [1.5.1]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.5.1
 [1.5.0]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.5.0
+[1.4.30]: https://github.com/pingchesu/gsd-hermes/releases/tag/v1.4.30
 [1.4.29]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.4.29
 [1.4.28]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.4.28
 [1.4.27]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.4.27

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **GSD Hermes** is a downstream fork of [get-shit-done-cc](https://github.com/gsd-build/get-shit-done) that adds Hermes Agent runtime support while preserving upstream GSD workflows.
 
-- **Package:** `gsd-hermes@1.4.0`
+- **Package:** `gsd-hermes@1.4.30`
 - **Upstream base:** `upstream/main@cd057255` (25 commits after the v1.3.0 base `0a049149`)
 - **Install:** `npx gsd-hermes --hermes --global`
 
@@ -24,6 +24,19 @@ After install, GSD commands (`/gsd-new-project`, `/gsd-plan-phase`, `/gsd-execut
 
 Compatibility gate: `npm run test:hermes` validates Hermes install modes + SDK query behavior + runtime-model parity + slash command inventory. This gate is the single authoritative Hermes-specific regression signal.
 
+### Hermes runtime model binding receipts
+
+`gsd-hermes@1.4.30` makes per-agent model binding explicit in plan-phase and execute-phase init payloads through `model_binding_receipts`. These receipts show the resolver decision, configured model, resolved runtime token, binding source, Hermes runtime binding channel, and proof boundary for each spawned GSD agent.
+
+Hermes model override semantics are strict: if `.planning/config.json` configures a per-agent model, GSD must either pass that model to the Hermes child construction path or fail before spawn with an actionable diagnostic. Silent fallback to the parent/default model is not acceptable.
+
+Current proof boundary is conservative:
+
+- GSD resolver and workflow receipts prove the configured intent and handoff metadata.
+- Hermes Agent child-construction tests prove `delegate_task(model=...)` and batch `tasks[].model` reach `AIAgent(model=...)`.
+- Safe provider diagnostics expose sanitized model/provider metadata only.
+- Live provider wire-level `model=...` enforcement is not claimed unless captured through future sanitized provider instrumentation.
+
 ## Docs
 
 - [docs/hermes-install.md](docs/hermes-install.md) — Hermes install modes (global, external-dir, macOS canonicalization)
@@ -32,6 +45,7 @@ Compatibility gate: `npm run test:hermes` validates Hermes install modes + SDK q
 - [docs/upstream-sync.md](docs/upstream-sync.md) — Upstream sync workflow + sync-log precedent
 - [docs/sync-logs/2026-04-sync-0a049149.md](docs/sync-logs/2026-04-sync-0a049149.md) — Per-hunk classification for the v1.3 upstream sync
 - [docs/releases/v1.4.0-upstream-sync-cd057255.md](docs/releases/v1.4.0-upstream-sync-cd057255.md) — Release notes for the v1.4 upstream sync package
+- [docs/releases/v1.4.30-runtime-model-binding-receipts.md](docs/releases/v1.4.30-runtime-model-binding-receipts.md) — Release notes for Hermes runtime model binding receipts and fail-fast validation
 
 See [CHANGELOG.md](CHANGELOG.md) for release history.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -6,7 +6,7 @@
 
 ## GSD Hermes v1.4 Release Note
 
-`gsd-hermes@1.4.0` syncs the command surface with upstream `get-shit-done@cd057255` while keeping Hermes command files installable through the downstream package. Upstream-owned Claude/Qwen assets may reference the newer `gsd:<command>` identity, but Hermes-installed commands remain available through the `gsd-<command>` frontmatter names expected by Hermes command discovery.
+`gsd-hermes@1.4.30` keeps the upstream `get-shit-done@cd057255` command surface while adding Hermes runtime model binding receipts and fail-fast validation. Upstream-owned Claude/Qwen assets may reference the newer `gsd:<command>` identity, but Hermes-installed commands remain available through the `gsd-<command>` frontmatter names expected by Hermes command discovery.
 
 ---
 
@@ -233,6 +233,8 @@ Execute all plans in a phase with wave-based parallelization, or run a specific 
 /gsd-execute-phase 1 --validate     # Validate state before execution
 /gsd-execute-phase 2 --cross-ai     # Delegate phase 2 to external AI CLI
 ```
+
+**Hermes runtime model receipts:** On Hermes, execute-phase init payloads include `model_binding_receipts` for executor and verifier agents. These receipts show the configured model, resolved model token, binding source, Hermes binding channel, and proof boundary before dispatch. Explicit per-agent `model_overrides` must either bind through the Hermes child construction path or fail before spawn; execute-phase must not silently fall back to the parent/default model.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -6,7 +6,7 @@
 
 ## GSD Hermes v1.4 Release Note
 
-`gsd-hermes@1.4.0` carries upstream config and SDK query fixes through `upstream/main@cd057255`, including runtime-aware model override propagation, config-schema parity checks, workstream-aware query dispatch, ROADMAP checkbox precedence, and state frontmatter mutation guards. Hermes keeps the downstream default of avoiding silent model fallback: configured model bindings must resolve as configured or fail with actionable diagnostics.
+`gsd-hermes@1.4.30` carries upstream config and SDK query fixes through `upstream/main@cd057255` and adds Hermes runtime model binding receipts, child-construction binding tests, and fail-fast validation for explicit per-agent model overrides. Hermes keeps the downstream default of avoiding silent model fallback: configured model bindings must resolve as configured or fail with actionable diagnostics.
 
 ---
 
@@ -626,16 +626,33 @@ Override specific agents without changing the entire profile:
 
 Valid override values: `opus`, `sonnet`, `haiku`, `inherit`, or any fully-qualified model ID (e.g., `"openai/o3"`, `"google/gemini-2.5-pro"`).
 
+#### Hermes binding receipts and fail-fast semantics
+
+For Hermes installs, `model_overrides` are strict runtime intent, not best-effort hints. Plan-phase and execute-phase init payloads include `model_binding_receipts` for each participating GSD agent. The structured receipt records:
+
+- `agent` — the GSD agent being spawned.
+- `configured_model` — the literal configured value when an override exists.
+- `resolved_model` / legacy `*_model` token — the token GSD intends to hand to the runtime.
+- `source` and `binding` — whether the value came from an explicit override, profile tier, inherit, omit, or runtime default path.
+- `runtime_binding_channel` — the Hermes binding seam, currently direct `delegate_task(model=...)` or batch `tasks[].model` for child construction.
+- `runtime_enforced` / proof metadata — conservative proof status. Child construction proof is distinct from provider wire-level proof.
+
+If an explicit Hermes override cannot be honored by the selected runtime channel, GSD fails before spawning the child and reports the agent, configured model, runtime/channel, and suggested fix. It must not drop the model token and let the child inherit the parent/default model.
+
+Proof boundary: current tests prove GSD resolver behavior, workflow receipt serialization, fail-fast validation, and Hermes child `AIAgent(model=...)` construction. They do not claim live provider wire-level `model=...` enforcement unless future provider instrumentation records sanitized request metadata.
+
 `model_overrides` can be set in either `.planning/config.json` (per-project)
 or `~/.gsd/defaults.json` (global). Per-project entries win on conflict and
 non-conflicting global entries are preserved, so you can tune a single
 agent's model in one repo without re-setting global defaults. This applies
-uniformly across Claude Code, Codex, OpenCode, Kilo, and the other
-supported runtimes. On Codex and OpenCode, the resolved model is embedded
-into each agent's static config at install time — `spawn_agent` and
-OpenCode's `task` interface do not accept an inline `model` parameter, so
-running `gsd install <runtime>` after editing `model_overrides` is required
-for the change to take effect. See issue #2256.
+uniformly across Claude Code, Hermes, Codex, OpenCode, Kilo, and the other
+supported runtimes. On Hermes, explicit per-agent values flow through the
+Hermes child construction channel (`delegate_task(model=...)` or batch
+`tasks[].model`) and are recorded in `model_binding_receipts`. On Codex and
+OpenCode, the resolved model is embedded into each agent's static config at
+install time — `spawn_agent` and OpenCode's `task` interface do not accept an
+inline `model` parameter, so running `gsd install <runtime>` after editing
+`model_overrides` is required for the change to take effect. See issue #2256.
 
 ### Non-Claude Runtimes (Codex, OpenCode, Gemini CLI, Kilo)
 

--- a/docs/hermes-compatibility.md
+++ b/docs/hermes-compatibility.md
@@ -37,6 +37,20 @@ Tracks how the Hermes v1.2 runtime-model adapter composes with upstream #2517 ru
 
 Validation evidence: `node --test tests/runtime-model-parity.test.cjs` (enrolled in `scripts/validate-hermes-compat.cjs::testFiles[]` during Phase 7 Plan 01; 13 subtests green covering all five binding paths above).
 
+### Runtime Binding Receipt Layers
+
+Phase 10 adds `model_binding_receipts` to the plan-phase and execute-phase init payloads. These receipts are intentionally observational: they make the model-binding handoff visible without claiming that Hermes has already enforced the requested child model at provider request time.
+
+| Layer | Receipt field | Meaning | Proof boundary |
+| --- | --- | --- | --- |
+| Resolver | `resolved_by_gsd` | GSD recognized the agent and resolved the configured model/profile/omit path into a binding token or an explicit rejection. | Proves GSD resolver behavior only. |
+| Workflow handoff | `passed_to_runtime` | GSD has a non-empty explicit token ready for a workflow `Task(..., model=...)` style handoff. | Does not prove Hermes accepted or used that token. |
+| Runtime/provider proof | `runtime_enforced` | Whether runtime or provider request evidence proves the spawned child actually used the intended model. | Phase 10 reports `unknown` for Hermes unless later enforcement/proof code records concrete evidence. |
+
+`runtime_enforced=unknown is not runtime proof`. It means the GSD resolver and workflow can show intent, but Hermes child-agent construction and provider request metadata have not yet been observed. Preferred proof in later phases is provider request or wire-level `model=...` metadata, followed by runtime child-agent construction evidence. A subagent self-report is not proof and must not be treated as evidence of enforcement.
+
+Do not log secrets while collecting receipt evidence. Provider requests or diagnostic captures must redact API keys, tokens, cookies, passwords, and connection strings.
+
 ## Known Gaps
 
 - Project-linked mode depends on `~/.hermes/config.yaml` `skills.external_dirs`, so duplicate global and project-linked command names can depend on Hermes discovery order.

--- a/docs/hermes-compatibility.md
+++ b/docs/hermes-compatibility.md
@@ -1,6 +1,6 @@
 # Hermes Compatibility and Guardrails
 
-This document makes the current Hermes support boundary explicit after Phase 6.
+This document makes the current Hermes support boundary explicit after Phase 13.
 It should be read alongside [Fork Ownership](./fork-ownership.md),
 [Upstream Sync Workflow](./upstream-sync.md), and
 [Hermes Install](./hermes-install.md) so future runtime work stays inside the
@@ -18,6 +18,7 @@ approved seams.
 | Update / uninstall / doctor | supported | `npm run test:hermes` | Phase 5 complete: global and project-linked lifecycle coverage includes reinstall updates, safe uninstall, read-only doctor diagnostics, and deterministic fixture coverage. |
 | Upstream sync routine | supported maintenance workflow | `npm run test:hermes` plus `npm test` when feasible | Sync review stays anchored to governance docs and merge history from upstream/main so Hermes drift remains visible. |
 | Native local Hermes install mode | out of scope | Documentation and docs tests | Project-linked mode uses skills.external_dirs instead. |
+| Runtime model binding receipts | supported with conservative proof boundary | `npm run test:hermes`, `tests/runtime-model-parity.test.cjs`, SDK init tests | Resolver/workflow receipts and Hermes child-construction proof are supported; live provider wire-level enforcement is not claimed without sanitized provider request evidence. |
 
 ## Runtime-Model Composition
 
@@ -39,19 +40,23 @@ Validation evidence: `node --test tests/runtime-model-parity.test.cjs` (enrolled
 
 ### Runtime Binding Receipt Layers
 
-Phase 10 adds `model_binding_receipts` to the plan-phase and execute-phase init payloads. These receipts are intentionally observational: they make the model-binding handoff visible without claiming that Hermes has already enforced the requested child model at provider request time.
+`model_binding_receipts` appear in plan-phase and execute-phase init payloads. They make model-binding intent and proof boundaries visible before runtime dispatch. They are deliberately more precise than a single yes/no flag: GSD resolver proof, workflow handoff proof, Hermes child-construction proof, and provider wire-level proof are separate layers.
 
-| Layer | Receipt field | Meaning | Proof boundary |
+| Layer | Receipt/proof field | Meaning | Proof boundary |
 | --- | --- | --- | --- |
 | Resolver | `resolved_by_gsd` | GSD recognized the agent and resolved the configured model/profile/omit path into a binding token or an explicit rejection. | Proves GSD resolver behavior only. |
-| Workflow handoff | `passed_to_runtime` | GSD has a non-empty explicit token ready for a workflow `Task(..., model=...)` style handoff. | Does not prove Hermes accepted or used that token. |
-| Runtime/provider proof | `runtime_enforced` | Whether runtime or provider request evidence proves the spawned child actually used the intended model. | Phase 10 reports `unknown` for Hermes unless later enforcement/proof code records concrete evidence. |
+| Workflow handoff | `passed_to_runtime` | GSD has a non-empty explicit token ready for a runtime handoff. | Proves workflow payload construction, not provider use. |
+| Hermes child construction | `runtime_binding_channel`, child construction tests | Hermes receives the intended child model through direct `delegate_task(model=...)` or batch `tasks[].model`. | Proves child `AIAgent(model=...)` construction, not live provider wire-level dispatch. |
+| Provider diagnostics | sanitized provider metadata | Safe metadata can expose provider/model/proof source without raw headers, request bodies, messages, or secrets. | Diagnostic proof only; credentials and raw payloads must never be stored. |
+| Provider wire-level proof | `runtime_enforced` when supported by sanitized request evidence | A provider request or wire-level capture proves the live child request used `model=...`. | Highest-confidence proof; not claimed unless captured safely. |
 
-`runtime_enforced=unknown is not runtime proof`. It means the GSD resolver and workflow can show intent, but Hermes child-agent construction and provider request metadata have not yet been observed. Preferred proof in later phases is provider request or wire-level `model=...` metadata, followed by runtime child-agent construction evidence. A subagent self-report is not proof and must not be treated as evidence of enforcement.
+`runtime_enforced=unknown` is not failure and is not provider proof. It means GSD can show resolver intent, workflow handoff, and possibly Hermes child construction, but it has not captured sanitized provider request evidence proving live provider-side `model=...` dispatch. A subagent self-report is not proof and must not be treated as evidence of enforcement.
 
-Phase 11 selects the canonical direct Hermes binding seam as `delegate_task(model=...)` for single child spawns and `tasks[].model` for batch spawns. `delegation.model` remains a global default/fallback, not a per-agent GSD override channel. ACP `--model` remains transport-specific and is only relevant when ACP subprocess routing is selected. Phase 11 proof stops at child `AIAgent(model=...)` construction; provider request or wire-level `model=...` proof remains a later provider-instrumentation boundary.
+Phase 11 selects the canonical direct Hermes binding seam as `delegate_task(model=...)` for single child spawns and `tasks[].model` for batch spawns. `delegation.model` remains a global default/fallback, not a per-agent GSD override channel. ACP `--model` remains transport-specific and is only relevant when ACP subprocess routing is selected. Phase 11 proof stops at child `AIAgent(model=...)` construction; provider request or wire-level `model=...` proof remains a separate provider-instrumentation boundary.
 
-Do not log secrets while collecting receipt evidence. Provider requests or diagnostic captures must redact API keys, tokens, cookies, passwords, and connection strings.
+Phase 12 adds fail-fast validation and proof tests: unsupported explicit Hermes bindings fail before spawn with actionable diagnostics, invalid explicit model tokens cannot silently fall back to the parent/default model, and Hermes Agent tests verify that GSD planner/executor overrides reach child `AIAgent(model=...)` construction.
+
+Do not log secrets while collecting receipt evidence. Provider requests or diagnostic captures must redact API keys, tokens, cookies, passwords, authorization headers, client secrets, and credential-bearing URLs. Raw provider headers, request bodies, messages, and connection strings must not be persisted.
 
 ## Known Gaps
 

--- a/docs/hermes-compatibility.md
+++ b/docs/hermes-compatibility.md
@@ -49,6 +49,8 @@ Phase 10 adds `model_binding_receipts` to the plan-phase and execute-phase init 
 
 `runtime_enforced=unknown is not runtime proof`. It means the GSD resolver and workflow can show intent, but Hermes child-agent construction and provider request metadata have not yet been observed. Preferred proof in later phases is provider request or wire-level `model=...` metadata, followed by runtime child-agent construction evidence. A subagent self-report is not proof and must not be treated as evidence of enforcement.
 
+Phase 11 selects the canonical direct Hermes binding seam as `delegate_task(model=...)` for single child spawns and `tasks[].model` for batch spawns. `delegation.model` remains a global default/fallback, not a per-agent GSD override channel. ACP `--model` remains transport-specific and is only relevant when ACP subprocess routing is selected. Phase 11 proof stops at child `AIAgent(model=...)` construction; provider request or wire-level `model=...` proof remains a later provider-instrumentation boundary.
+
 Do not log secrets while collecting receipt evidence. Provider requests or diagnostic captures must redact API keys, tokens, cookies, passwords, and connection strings.
 
 ## Known Gaps

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -8,6 +8,16 @@ Use the `Publish npm` workflow in `.github/workflows/publish-npm.yml`.
 
 The workflow validates the package name and version, runs the test suite, checks the npm tarball with `npm pack --dry-run`, publishes to npm, and verifies that the expected package version is visible in the npm registry.
 
+For the `gsd-hermes@1.4.30` runtime-model-binding release, the local repo selected `1.4.30` because `1.4.0` is already published and local `v1.4.1`–`v1.4.29` tags are present. Before running the release/publish workflow, verify all three collision guards are clear:
+
+```bash
+npm view gsd-hermes@1.4.30 version --json 2>/dev/null || true
+git tag --list v1.4.30
+gh release view v1.4.30 --json tagName,url 2>/dev/null || true
+```
+
+Do not reuse an existing npm version, git tag, or GitHub Release. If any guard reports an existing artifact, pick the next patch version and update `package.json`, `package-lock.json`, CHANGELOG, and `docs/releases/` before publishing.
+
 For the `gsd-hermes@1.4.0` upstream-sync release, use the formal `Release` workflow rather than republishing the already-published `1.3.0` package:
 
 1. Merge release docs and workflow readiness updates to `main`.

--- a/docs/releases/v1.4.30-runtime-model-binding-receipts.md
+++ b/docs/releases/v1.4.30-runtime-model-binding-receipts.md
@@ -1,0 +1,70 @@
+# gsd-hermes v1.4.30 — Hermes Runtime Model Binding Receipts
+
+Release date: 2026-04-26
+Package: `gsd-hermes@1.4.30`
+Upstream GSD base: `upstream/main@cd057255`
+Previous package: `gsd-hermes@1.4.0`
+Tracker: https://github.com/pingchesu/gsd-hermes/issues/32
+
+## Summary
+
+`gsd-hermes@1.4.30` closes the gap between GSD resolver intent and Hermes child-agent runtime construction for per-agent model overrides. GSD now surfaces structured model binding receipts, validates unsupported explicit bindings before spawn, and documents the proof boundary between resolver/workflow metadata, Hermes child construction, safe provider diagnostics, and live provider wire-level enforcement.
+
+This release intentionally remains conservative: it proves Hermes child `AIAgent(model=...)` construction for configured per-agent overrides, but it does not claim provider wire-level `model=...` enforcement unless a future sanitized provider request capture proves it.
+
+## Highlights
+
+- Adds structured `model_binding_receipts` to plan-phase and execute-phase init payloads while keeping legacy flat `*_model` fields for compatibility.
+- Establishes direct `delegate_task(model=...)` and batch `tasks[].model` as the Hermes child binding channels for GSD per-agent overrides.
+- Fails fast when an explicit Hermes model binding cannot be honored, naming the agent, configured model, runtime/channel, and suggested fix.
+- Adds tests proving invalid explicit model tokens cannot silently fall back to parent/default model.
+- Adds Hermes Agent tests proving GSD planner/executor model tokens reach child `AIAgent(model=...)` construction.
+- Adds sanitized provider diagnostics helpers that redact API keys, tokens, passwords, authorization headers, client secrets, and credential-bearing URLs.
+
+## Proof boundary
+
+| Evidence layer | Status in v1.4.30 | Notes |
+| --- | --- | --- |
+| GSD resolver proof | Supported | `model_overrides` and profile/runtime paths serialize into structured receipts. |
+| Workflow handoff proof | Supported | Init payloads display configured/resolved model and binding channel before dispatch. |
+| Hermes child-construction proof | Supported by tests | `delegate_task(model=...)` and `tasks[].model` reach child `AIAgent(model=...)`. |
+| Safe provider diagnostics | Supported helper/test coverage | Only sanitized provider/model/proof metadata is retained. |
+| Live provider wire-level proof | Not claimed | Requires future sanitized provider request instrumentation. |
+
+`runtime_enforced=unknown` means provider wire-level proof has not been captured. It is not permission to silently fall back to the parent/default model.
+
+## User impact
+
+Users who configure `.planning/config.json` with per-agent `model_overrides` on Hermes get clearer behavior:
+
+- A supported explicit override is passed into the Hermes child construction channel and shown in receipts.
+- An unsupported explicit override fails before spawn with actionable diagnostics.
+- A child agent inheriting the parent/default model when an explicit override was configured is considered a bug.
+
+## Verification
+
+Release validation should include:
+
+```bash
+npm run build:sdk
+cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts
+cd ..
+node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs
+npm run test:hermes
+npm test
+npm pack --dry-run
+```
+
+Hermes Agent companion validation:
+
+```bash
+cd /home/whiskey/.hermes/hermes-agent
+.venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py tests/agent/test_provider_diagnostics.py -q
+.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py agent/provider_diagnostics.py agent/redact.py tests/tools/test_delegate.py tests/agent/test_provider_diagnostics.py
+```
+
+## Links
+
+- Tracker issue: https://github.com/pingchesu/gsd-hermes/issues/32
+- Upstream sync release notes: ./v1.4.0-upstream-sync-cd057255.md
+- Hermes compatibility docs: ../hermes-compatibility.md

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 const { loadConfig, resolveModelInternal, findPhaseInternal, getRoadmapPhaseInternal, pathExistsInternal, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, stripShippedMilestones, extractCurrentMilestone, normalizePhaseName, planningPaths, planningDir, planningRoot, toPosixPath, output, error, checkAgentsInstalled, phaseTokenMatches } = require('./core.cjs');
+const { resolveAgentBinding, toBindingReceipt } = require('./model-profiles.cjs');
 
 function getLatestCompletedMilestone(cwd) {
   const milestonesPath = path.join(planningRoot(cwd), 'MILESTONES.md');
@@ -63,6 +64,15 @@ function withProjectRoot(cwd, result) {
   return result;
 }
 
+function buildModelBindingReceipts(workflow, config, specs) {
+  const agents = {};
+  for (const spec of specs) {
+    agents[spec.role] = toBindingReceipt(resolveAgentBinding(config, spec.agent), spec.role);
+  }
+  const runtime = specs.length > 0 ? agents[specs[0].role].runtime : (config.runtime || 'claude');
+  return { workflow, runtime, agents };
+}
+
 function cmdInitExecutePhase(cwd, phase, raw, options = {}) {
   if (!phase) {
     error('phase required for init execute-phase');
@@ -112,6 +122,10 @@ function cmdInitExecutePhase(cwd, phase, raw, options = {}) {
     // Models
     executor_model: resolveModelInternal(cwd, 'gsd-executor', { initContext: true }),
     verifier_model: resolveModelInternal(cwd, 'gsd-verifier', { initContext: true }),
+    model_binding_receipts: buildModelBindingReceipts('execute-phase', config, [
+      { role: 'executor', agent: 'gsd-executor' },
+      { role: 'verifier', agent: 'gsd-verifier' },
+    ]),
 
     // Config flags
     tdd_mode: options.tdd || config.tdd_mode || false,
@@ -246,6 +260,11 @@ function cmdInitPlanPhase(cwd, phase, raw, options = {}) {
     researcher_model: resolveModelInternal(cwd, 'gsd-phase-researcher'),
     planner_model: resolveModelInternal(cwd, 'gsd-planner'),
     checker_model: resolveModelInternal(cwd, 'gsd-plan-checker'),
+    model_binding_receipts: buildModelBindingReceipts('plan-phase', config, [
+      { role: 'researcher', agent: 'gsd-phase-researcher' },
+      { role: 'planner', agent: 'gsd-planner' },
+      { role: 'checker', agent: 'gsd-plan-checker' },
+    ]),
 
     // Workflow flags
     tdd_mode: options.tdd || config.tdd_mode || false,

--- a/get-shit-done/bin/lib/model-profiles.cjs
+++ b/get-shit-done/bin/lib/model-profiles.cjs
@@ -85,6 +85,42 @@ function detectModelFamily(model) {
   return 'unknown';
 }
 
+function runtimeBindingChannelForRuntime(runtime, options = {}) {
+  if (runtime === 'hermes') {
+    const available = options.hermesDelegateModelChannelAvailable !== undefined
+      ? !!options.hermesDelegateModelChannelAvailable
+      : true;
+    return {
+      kind: 'hermes-delegate-task-model',
+      available,
+      proof_level: available ? 'child-construction' : 'none',
+      reason: available ? null : 'Hermes delegate_task.model / tasks[].model binding channel is unavailable.',
+      suggested_fix: available
+        ? null
+        : 'Upgrade or restart Hermes Agent with delegate_task.model / tasks[].model support, set the override to inherit, remove the explicit model_overrides entry, or use explicit cross-AI execution.',
+    };
+  }
+
+  const capability = runtimeCapability(runtime);
+  if (capability.supportsExplicitModel) {
+    return {
+      kind: 'runtime-native-model-parameter',
+      available: true,
+      proof_level: 'runtime-dispatch',
+      reason: null,
+      suggested_fix: null,
+    };
+  }
+
+  return {
+    kind: 'none',
+    available: false,
+    proof_level: 'none',
+    reason: `Runtime '${runtime}' does not expose an explicit model binding channel.`,
+    suggested_fix: 'Use inherit/runtime-default binding or route through a runtime with explicit model support.',
+  };
+}
+
 function detectRuntime(config = {}) {
   const envValue = process.env.GSD_RUNTIME;
   if (envValue && SUPPORTED_RUNTIMES.includes(envValue)) return envValue;
@@ -358,6 +394,7 @@ function toBindingReceipt(resolution, role) {
     passed_to_runtime: resolution.kind === 'resolved' && !!resolution.modelToken,
     runtime_enforced: 'unknown',
     enforceability: receiptEnforceability(resolution),
+    runtime_binding_channel: runtimeBindingChannelForRuntime(resolution.runtime || 'claude'),
   };
 }
 
@@ -421,6 +458,7 @@ module.exports = {
   getAgentToModelMapForProfile,
   normalizeModelProfile,
   resolveAgentBinding,
+  runtimeBindingChannelForRuntime,
   serializeRuntimeModelResolution,
   toBindingReceipt,
   toLegacyModelToken,

--- a/get-shit-done/bin/lib/model-profiles.cjs
+++ b/get-shit-done/bin/lib/model-profiles.cjs
@@ -35,6 +35,64 @@ const MODEL_ALIAS_MAP = {
   haiku: 'claude-haiku-4-5',
 };
 
+const SUPPORTED_RUNTIMES = [
+  'claude', 'opencode', 'kilo', 'gemini', 'codex', 'copilot', 'antigravity',
+  'cursor', 'windsurf', 'augment', 'trae', 'qwen', 'codebuddy', 'cline', 'hermes',
+];
+
+const OPENAI_COMPATIBLE_RUNTIMES = ['codex', 'copilot', 'cursor', 'windsurf', 'cline'];
+const GOOGLE_COMPATIBLE_RUNTIMES = ['gemini'];
+const HERMES_MULTI_PROVIDER_RUNTIMES = ['hermes'];
+
+function explicitModelFamiliesForRuntime(runtime) {
+  if (runtime === 'claude') return ['anthropic'];
+  if (OPENAI_COMPATIBLE_RUNTIMES.includes(runtime)) return ['openai'];
+  if (GOOGLE_COMPATIBLE_RUNTIMES.includes(runtime)) return ['google'];
+  if (HERMES_MULTI_PROVIDER_RUNTIMES.includes(runtime)) return ['anthropic', 'openai', 'google', 'unknown'];
+  return ['openai', 'google', 'unknown'];
+}
+
+function runtimeCapability(runtime) {
+  return {
+    runtime,
+    supportsExplicitModel: true,
+    supportsInheritBinding: true,
+    supportsRuntimeDefaultBinding: true,
+    supportsCrossAiExecution: true,
+    explicitModelFamilies: explicitModelFamiliesForRuntime(runtime),
+  };
+}
+
+function isAnthropicModel(model) {
+  return /^(?:claude(?:-|$)|anthropic\/claude-|opus$|sonnet$|haiku$)/i.test(model);
+}
+
+function isOpenAiModel(model) {
+  return /^(?:openai\/|gpt-|o[134](?:$|[-.])|o3(?:$|[-.])|o4(?:$|[-.]))/i.test(model);
+}
+
+function isGoogleModel(model) {
+  return /^(?:gemini(?:$|[-.])|google\/)/i.test(model);
+}
+
+function detectModelFamily(model) {
+  if (!model) return 'unknown';
+  const normalized = String(model).trim();
+  if (!normalized) return 'unknown';
+  if (isAnthropicModel(normalized)) return 'anthropic';
+  if (isOpenAiModel(normalized)) return 'openai';
+  if (isGoogleModel(normalized)) return 'google';
+  return 'unknown';
+}
+
+function detectRuntime(config = {}) {
+  const envValue = process.env.GSD_RUNTIME;
+  if (envValue && SUPPORTED_RUNTIMES.includes(envValue)) return envValue;
+  const configValue = config.runtime;
+  if (typeof configValue === 'string' && SUPPORTED_RUNTIMES.includes(configValue)) return configValue;
+  return 'claude';
+}
+
 function normalizeModelProfile(profile) {
   const normalized = typeof profile === 'string' ? profile.toLowerCase().trim() : '';
   return ACCEPTED_MODEL_PROFILES.includes(normalized) ? normalized : 'balanced';
@@ -63,7 +121,7 @@ function toResolvedModelValue(model, resolveModelIds) {
   return model;
 }
 
-function resolveAgentBinding(config = {}, agent) {
+function resolveAgentBindingBase(config = {}, agent) {
   const profile = normalizeModelProfile(config.model_profile);
   const resolveModelIds = resolveModelIdsSetting(config);
   const overrides = normalizeOverrides(config.model_overrides);
@@ -197,6 +255,112 @@ function resolveAgentBinding(config = {}, agent) {
   };
 }
 
+function suggestedFixFor(resolution) {
+  if (!resolution || resolution.kind === 'unsupported') {
+    if (resolution && resolution.bindingKind === 'runtime-default') {
+      return 'Use a supported agent with contract coverage before depending on runtime-default binding.';
+    }
+    return 'Use a supported agent with contract coverage or add explicit Phase 5 contract coverage before execution.';
+  }
+  if (resolution.bindingKind === 'explicit') {
+    return 'Adjust model_overrides for this agent or remove the override to use profile/runtime defaults.';
+  }
+  if (resolution.bindingKind === 'inherit') {
+    return resolution.source === 'override'
+      ? 'Remove the inherit override to fall back to profile-based resolution.'
+      : 'Set model_profile to a tiered profile or add model_overrides if a literal model token is required.';
+  }
+  if (resolution.bindingKind === 'runtime-default') {
+    return 'Set model_overrides for this agent if you need an explicit model token.';
+  }
+  return 'Choose a different model_profile or add model_overrides for this agent.';
+}
+
+function messageFor(resolution) {
+  if (!resolution || resolution.kind !== 'unsupported') return undefined;
+  if (resolution.bindingKind === 'runtime-default') {
+    return `Runtime-default binding was requested for unknown agent '${resolution.agent}'.`;
+  }
+  return `No runtime-model contract coverage exists for agent '${resolution.agent}'.`;
+}
+
+function resolveConfiguredCrossAiExecution(config = {}) {
+  const workflow = config.workflow;
+  return !!workflow && typeof workflow === 'object' && !Array.isArray(workflow)
+    && workflow.cross_ai_execution === true;
+}
+
+function resolveAgentBinding(config = {}, agent) {
+  const resolution = resolveAgentBindingBase(config, agent);
+  const runtime = detectRuntime(config);
+  return {
+    ...resolution,
+    runtime,
+    runtimeCapability: runtimeCapability(runtime),
+    crossAiExecutionConfigured: resolveConfiguredCrossAiExecution(config),
+    suggestedFix: suggestedFixFor(resolution),
+    ...(resolution.kind === 'unsupported' ? { message: messageFor(resolution) } : {}),
+  };
+}
+
+function serializeRuntimeModelResolution(resolution) {
+  const base = {
+    agent: resolution.agent,
+    status: resolution.kind,
+    known_agent: resolution.knownAgent,
+    runtime: resolution.runtime || 'claude',
+    profile: resolution.profile,
+    binding_kind: resolution.bindingKind,
+    source: resolution.source,
+    configured_model: resolution.configuredModel,
+    resolved_model: resolution.resolvedModel,
+    model_token: resolution.modelToken,
+    resolve_model_ids: resolution.resolveModelIds,
+    suggested_fix: resolution.suggestedFix || suggestedFixFor(resolution),
+    cross_ai: {
+      execution_supported: !!(resolution.runtimeCapability && resolution.runtimeCapability.supportsCrossAiExecution),
+      execution_configured: !!resolution.crossAiExecutionConfigured,
+    },
+    runtime_capability: {
+      supports_explicit_model: !!(resolution.runtimeCapability && resolution.runtimeCapability.supportsExplicitModel),
+      supports_inherit_binding: !!(resolution.runtimeCapability && resolution.runtimeCapability.supportsInheritBinding),
+      supports_runtime_default_binding: !!(resolution.runtimeCapability && resolution.runtimeCapability.supportsRuntimeDefaultBinding),
+    },
+  };
+
+  if (resolution.kind === 'unsupported') {
+    return {
+      ...base,
+      rejection_reason: resolution.rejectionReason,
+      message: resolution.message || messageFor(resolution),
+    };
+  }
+
+  return base;
+}
+
+function receiptEnforceability(resolution) {
+  if (resolution.kind === 'unsupported') return 'unsupported';
+  if (resolution.bindingKind === 'explicit' && !!resolution.modelToken) {
+    return 'explicit-token-needs-runtime-proof';
+  }
+  return 'inherits-or-runtime-default';
+}
+
+function toBindingReceipt(resolution, role) {
+  const serialized = serializeRuntimeModelResolution(resolution);
+  const providerModel = resolution.modelToken || resolution.resolvedModel || resolution.configuredModel;
+  return {
+    ...serialized,
+    role,
+    provider_family: detectModelFamily(providerModel),
+    resolved_by_gsd: resolution.kind === 'resolved',
+    passed_to_runtime: resolution.kind === 'resolved' && !!resolution.modelToken,
+    runtime_enforced: 'unknown',
+    enforceability: receiptEnforceability(resolution),
+  };
+}
+
 function toLegacyModelToken(resolution, fallback = '') {
   if (!resolution || resolution.kind !== 'resolved') return fallback;
   if (resolution.bindingKind === 'inherit' || resolution.resolvedModel === 'inherit') return 'inherit';
@@ -257,6 +421,8 @@ module.exports = {
   getAgentToModelMapForProfile,
   normalizeModelProfile,
   resolveAgentBinding,
+  serializeRuntimeModelResolution,
+  toBindingReceipt,
   toLegacyModelToken,
   toInitModelToken,
 };

--- a/get-shit-done/bin/lib/model-profiles.cjs
+++ b/get-shit-done/bin/lib/model-profiles.cjs
@@ -339,6 +339,107 @@ function resolveAgentBinding(config = {}, agent) {
   };
 }
 
+function buildBindingValidationIssue(binding, rejectionReason, reason) {
+  const crossAiExecutionSupported = !!(binding.runtimeCapability && binding.runtimeCapability.supportsCrossAiExecution);
+  const crossAiExecutionRecommended = rejectionReason === 'runtime-model-unsupported' && crossAiExecutionSupported;
+  return {
+    agent: binding.agent,
+    runtime: binding.runtime,
+    bindingKind: binding.bindingKind,
+    source: binding.source,
+    configuredModel: binding.configuredModel,
+    resolvedModel: binding.resolvedModel,
+    rejectionReason,
+    reason,
+    suggestedFix: rejectionReason === 'missing-runtime-binding-channel' && binding.runtime === 'hermes'
+      ? 'Upgrade or restart Hermes Agent with delegate_task.model / tasks[].model support, set the override to inherit, remove the explicit model_overrides entry, or use explicit cross-AI execution.'
+      : binding.suggestedFix || suggestedFixFor(binding),
+    crossAiExecutionSupported,
+    crossAiExecutionConfigured: !!binding.crossAiExecutionConfigured,
+    crossAiExecutionRecommended,
+    crossAiExecutionSuggestion: crossAiExecutionSupported
+      ? (crossAiExecutionRecommended
+          ? `Use workflow.cross_ai_execution as an explicit cross-provider path if you want this binding executed outside the active runtime; workflow.cross_ai_execution is ${binding.crossAiExecutionConfigured ? 'already enabled' : 'currently disabled'}.`
+          : `cross_ai_execution is available for this runtime; workflow.cross_ai_execution is ${binding.crossAiExecutionConfigured ? 'already enabled' : 'currently disabled'}.`)
+      : null,
+    availableAlternative: crossAiExecutionRecommended ? 'cross_ai_execution' : null,
+  };
+}
+
+function validateResolvedAgentBinding(binding, options = {}) {
+  if (binding.kind === 'unsupported') {
+    return {
+      ok: false,
+      agent: binding.agent,
+      runtime: binding.runtime,
+      bindingKind: binding.bindingKind,
+      source: binding.source,
+      configuredModel: binding.configuredModel,
+      resolvedModel: binding.resolvedModel,
+      issue: buildBindingValidationIssue(binding, binding.rejectionReason, binding.message || messageFor(binding)),
+      binding,
+    };
+  }
+
+  if (binding.bindingKind === 'inherit' || binding.bindingKind === 'runtime-default') {
+    return {
+      ok: true,
+      agent: binding.agent,
+      runtime: binding.runtime,
+      bindingKind: binding.bindingKind,
+      source: binding.source,
+      configuredModel: binding.configuredModel,
+      resolvedModel: binding.resolvedModel,
+      issue: null,
+      binding,
+    };
+  }
+
+  if (binding.runtime === 'hermes' && binding.bindingKind === 'explicit') {
+    const channel = runtimeBindingChannelForRuntime(binding.runtime, options);
+    if (!channel.available) {
+      return {
+        ok: false,
+        agent: binding.agent,
+        runtime: binding.runtime,
+        bindingKind: binding.bindingKind,
+        source: binding.source,
+        configuredModel: binding.configuredModel,
+        resolvedModel: binding.resolvedModel,
+        issue: buildBindingValidationIssue(
+          binding,
+          'missing-runtime-binding-channel',
+          channel.reason || 'Hermes delegate_task.model / tasks[].model binding channel is unavailable'
+        ),
+        binding,
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    agent: binding.agent,
+    runtime: binding.runtime,
+    bindingKind: binding.bindingKind,
+    source: binding.source,
+    configuredModel: binding.configuredModel,
+    resolvedModel: binding.resolvedModel,
+    issue: null,
+    binding,
+  };
+}
+
+function validateAgentBinding(config = {}, agent, options = {}) {
+  return validateResolvedAgentBinding(resolveAgentBinding(config, agent), options);
+}
+
+function validateAgentBindings(config = {}, agents = [], options = {}) {
+  const results = agents.map((agent) => validateAgentBinding(config, agent, options));
+  const issues = results.flatMap((result) => result.issue ? [result.issue] : []);
+  const runtime = results[0] ? results[0].runtime : detectRuntime(config);
+  return { ok: issues.length === 0, runtime, agents, results, issues };
+}
+
 function serializeRuntimeModelResolution(resolution) {
   const base = {
     agent: resolution.agent,
@@ -459,6 +560,9 @@ module.exports = {
   normalizeModelProfile,
   resolveAgentBinding,
   runtimeBindingChannelForRuntime,
+  validateAgentBinding,
+  validateAgentBindings,
+  validateResolvedAgentBinding,
   serializeRuntimeModelResolution,
   toBindingReceipt,
   toLegacyModelToken,

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -76,18 +76,14 @@ AGENT_SKILLS=$(gsd-sdk query agent-skills gsd-executor)
 
 Parse JSON for: `executor_model`, `verifier_model`, `model_binding_receipts`, `commit_docs`, `parallelization`, `branching_strategy`, `branch_name`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `plans`, `incomplete_plans`, `plan_count`, `incomplete_count`, `state_exists`, `roadmap_exists`, `phase_req_ids`, `response_language`.
 
-**Display runtime/model binding receipt before executor/verifier Task dispatch and before cross-AI fallback decisions.** Render `model_binding_receipts` concisely so the transcript shows the GSD resolver intent and current proof boundary:
+**Display runtime/model binding receipt before executor/verifier Task dispatch and before cross-AI fallback decisions.** Render `model_binding_receipts` concisely so the transcript shows GSD resolver intent and the proof boundary:
 
 ```text
-## Runtime/model binding receipt
-Workflow: {model_binding_receipts.workflow}
-Runtime: {model_binding_receipts.runtime}
+## Runtime/model binding receipt — workflow={model_binding_receipts.workflow} runtime={model_binding_receipts.runtime}
 - executor / gsd-executor: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
 - verifier / gsd-verifier: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
-
-Note: runtime_enforced=unknown is not runtime proof; it remains expected until Phase 11/12 add Hermes child/provider enforcement proof. passed_to_runtime=true means GSD has an explicit token ready to pass, not that Hermes has proven enforcement.
+Note: runtime_enforced=unknown is not runtime proof; passed_to_runtime=true means GSD has an explicit token ready to pass, not that Hermes has proven enforcement.
 ```
-
 Do not change Task dispatch semantics in this display step. Continue to preserve the existing `executor_model === "inherit"` guidance exactly: omit `model=` when inherit/empty.
 
 **Model resolution:** If `executor_model` is `"inherit"`, omit the `model=` parameter from all `Task()` calls — do NOT pass `model="inherit"` to Task. Omitting the `model=` parameter causes Claude Code to inherit the current orchestrator model automatically. Only set `model=` when `executor_model` is an explicit model name (e.g., `"claude-sonnet-4-6"`, `"claude-opus-4-7"`).

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -74,7 +74,21 @@ if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 AGENT_SKILLS=$(gsd-sdk query agent-skills gsd-executor)
 ```
 
-Parse JSON for: `executor_model`, `verifier_model`, `commit_docs`, `parallelization`, `branching_strategy`, `branch_name`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `plans`, `incomplete_plans`, `plan_count`, `incomplete_count`, `state_exists`, `roadmap_exists`, `phase_req_ids`, `response_language`.
+Parse JSON for: `executor_model`, `verifier_model`, `model_binding_receipts`, `commit_docs`, `parallelization`, `branching_strategy`, `branch_name`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `plans`, `incomplete_plans`, `plan_count`, `incomplete_count`, `state_exists`, `roadmap_exists`, `phase_req_ids`, `response_language`.
+
+**Display runtime/model binding receipt before executor/verifier Task dispatch and before cross-AI fallback decisions.** Render `model_binding_receipts` concisely so the transcript shows the GSD resolver intent and current proof boundary:
+
+```text
+## Runtime/model binding receipt
+Workflow: {model_binding_receipts.workflow}
+Runtime: {model_binding_receipts.runtime}
+- executor / gsd-executor: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
+- verifier / gsd-verifier: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
+
+Note: runtime_enforced=unknown is not runtime proof; it remains expected until Phase 11/12 add Hermes child/provider enforcement proof. passed_to_runtime=true means GSD has an explicit token ready to pass, not that Hermes has proven enforcement.
+```
+
+Do not change Task dispatch semantics in this display step. Continue to preserve the existing `executor_model === "inherit"` guidance exactly: omit `model=` when inherit/empty.
 
 **Model resolution:** If `executor_model` is `"inherit"`, omit the `model=` parameter from all `Task()` calls — do NOT pass `model="inherit"` to Task. Omitting the `model=` parameter causes Claude Code to inherit the current orchestrator model automatically. Only set `model=` when `executor_model` is an explicit model name (e.g., `"claude-sonnet-4-6"`, `"claude-opus-4-7"`).
 

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -82,9 +82,9 @@ Parse JSON for: `executor_model`, `verifier_model`, `model_binding_receipts`, `c
 ## Runtime/model binding receipt — workflow={model_binding_receipts.workflow} runtime={model_binding_receipts.runtime}
 - executor / gsd-executor: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
 - verifier / gsd-verifier: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
-Note: runtime_enforced=unknown is not runtime proof; passed_to_runtime=true means GSD has an explicit token ready to pass, not that Hermes has proven enforcement.
+Note: runtime_enforced=unknown is not provider proof. For Hermes, runtime_binding_channel.kind=hermes-delegate-task-model with proof_level=child-construction means pass explicit tokens via delegate_task(model=...) or tasks[].model; if unavailable, stop on the pre-spawn validation error instead of spawning.
 ```
-Do not change Task dispatch semantics in this display step. Continue to preserve the existing `executor_model === "inherit"` guidance exactly: omit `model=` when inherit/empty.
+Keep existing `executor_model === "inherit"` semantics: omit `model=` when inherit/empty. Under Hermes, explicit executor/verifier tokens map to delegate_task model fields, not provider wire-level proof.
 
 **Model resolution:** If `executor_model` is `"inherit"`, omit the `model=` parameter from all `Task()` calls — do NOT pass `model="inherit"` to Task. Omitting the `model=` parameter causes Claude Code to inherit the current orchestrator model automatically. Only set `model=` when `executor_model` is an explicit model name (e.g., `"claude-sonnet-4-6"`, `"claude-opus-4-7"`).
 

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -46,7 +46,22 @@ When `TDD_MODE` is `true`, the planner agent is instructed to apply `type: tdd` 
 
 When `CONTEXT_WINDOW >= 500000`, the planner prompt includes the 3 most recent prior phase CONTEXT.md and SUMMARY.md files PLUS any phases explicitly listed in the current phase's `Depends on:` field in ROADMAP.md. Explicit dependencies always load regardless of recency (e.g., Phase 7 declaring `Depends on: Phase 2` always sees Phase 2's context). Bounded recency keeps the planner's context budget focused on recent work.
 
-Parse JSON for: `researcher_model`, `planner_model`, `checker_model`, `research_enabled`, `plan_checker_enabled`, `nyquist_validation_enabled`, `commit_docs`, `text_mode`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_reviews`, `has_plans`, `plan_count`, `planning_exists`, `roadmap_exists`, `phase_req_ids`, `response_language`.
+Parse JSON for: `researcher_model`, `planner_model`, `checker_model`, `model_binding_receipts`, `research_enabled`, `plan_checker_enabled`, `nyquist_validation_enabled`, `commit_docs`, `text_mode`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_reviews`, `has_plans`, `plan_count`, `planning_exists`, `roadmap_exists`, `phase_req_ids`, `response_language`.
+
+**Display runtime/model binding receipt before any researcher/planner/checker Task dispatch.** Render `model_binding_receipts` concisely so the transcript shows the GSD resolver intent and the current proof boundary:
+
+```text
+## Runtime/model binding receipt
+Workflow: {model_binding_receipts.workflow}
+Runtime: {model_binding_receipts.runtime}
+- researcher / gsd-phase-researcher: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
+- planner / gsd-planner: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
+- checker / gsd-plan-checker: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
+
+Note: runtime_enforced=unknown is not runtime proof; it means GSD has not yet observed Hermes child/provider enforcement. passed_to_runtime=true means GSD has an explicit token ready to hand off, not that Hermes or the provider has proven enforcement.
+```
+
+Do not change Task dispatch semantics in this display step. Keep using the flat `researcher_model`, `planner_model`, and `checker_model` fields for existing model-argument behavior.
 
 **If `response_language` is set:** Include `response_language: {value}` in all spawned subagent prompts so any user-facing output stays in the configured language.
 

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -58,10 +58,10 @@ Runtime: {model_binding_receipts.runtime}
 - planner / gsd-planner: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
 - checker / gsd-plan-checker: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
 
-Note: runtime_enforced=unknown is not runtime proof; it means GSD has not yet observed Hermes child/provider enforcement. passed_to_runtime=true means GSD has an explicit token ready to hand off, not that Hermes or the provider has proven enforcement.
+Note: runtime_enforced=unknown is not provider proof. For Hermes, runtime_binding_channel.kind=hermes-delegate-task-model with proof_level=child-construction means pass explicit tokens via delegate_task(model=...) or tasks[].model; if unavailable, stop on the pre-spawn validation error instead of spawning.
 ```
 
-Do not change Task dispatch semantics in this display step. Keep using the flat `researcher_model`, `planner_model`, and `checker_model` fields for existing model-argument behavior.
+Keep using the flat `researcher_model`, `planner_model`, and `checker_model` fields for existing model-argument behavior; under Hermes these map to delegate_task model fields, not provider wire-level proof.
 
 **If `response_language` is set:** Include `response_language: {value}` in all spawned subagent prompts so any user-facing output stays in the configured language.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.4.0",
+  "version": "1.4.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.4.0",
+      "version": "1.4.30",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.4.0",
+  "version": "1.4.30",
   "description": "A get-shit-done fork that adds Hermes Agent runtime support while preserving upstream GSD workflows.",
   "bin": {
     "gsd-hermes": "bin/install.js",

--- a/scripts/verify-fork-identity.cjs
+++ b/scripts/verify-fork-identity.cjs
@@ -13,11 +13,11 @@ assert.ok(pkg.bin && pkg.bin['gsd-hermes'] === 'bin/install.js',
 assert.ok(pkg.bin['get-shit-done-cc'] === 'bin/install.js',
   'bin.get-shit-done-cc must still map to bin/install.js (upstream parity bin)');
 
-// Version is on downstream semver line (NOT upstream 1.38.x or 1.39.x)
-// Phase 6 accepts 1.2.x (pre-release-metadata) OR 1.3.x (post-release-metadata)
+// Version is on the downstream semver line (NOT upstream 1.38.x or 1.39.x).
+// gsd-hermes started at 1.2.x and advances by downstream minor releases (1.3.x, 1.4.x, ...).
 const version = pkg.version;
-assert.ok(/^1\.(2|3)\.\d+/.test(version),
-  `package.json version must be on gsd-hermes 1.2.x or 1.3.x line, got '${version}'`);
+assert.ok(/^1\.([2-9]|[1-9]\d+)\.\d+/.test(version),
+  `package.json version must be on gsd-hermes 1.2.x+ downstream line, got '${version}'`);
 assert.ok(!/^1\.3[89]\./.test(version),
   `package.json version must NOT be on upstream 1.38.x/1.39.x line (identity drift); got '${version}'`);
 

--- a/sdk/src/query/config-query.test.ts
+++ b/sdk/src/query/config-query.test.ts
@@ -128,6 +128,80 @@ describe('runtime-model contract', () => {
     expect(result.rejectionReason).toBe('unknown-agent');
     expect(result.suggestedFix).toContain('supported agent');
   });
+
+  it('projects explicit override bindings into runtime/model receipts with separated truth fields', async () => {
+    const { resolveAgentBinding, toRuntimeModelReceipt } = await import('./runtime-model-contract.js');
+    const resolution = resolveAgentBinding({
+      runtime: 'hermes',
+      model_profile: 'inherit',
+      resolve_model_ids: 'omit',
+      model_overrides: { 'gsd-planner': 'openai/gpt-5.4' },
+      workflow: {},
+    }, 'gsd-planner');
+
+    const receipt = toRuntimeModelReceipt(resolution, 'planner');
+
+    expect(receipt).toMatchObject({
+      role: 'planner',
+      agent: 'gsd-planner',
+      runtime: 'hermes',
+      profile: 'inherit',
+      binding_kind: 'explicit',
+      source: 'override',
+      configured_model: 'openai/gpt-5.4',
+      resolved_model: 'openai/gpt-5.4',
+      model_token: 'openai/gpt-5.4',
+      provider_family: 'openai',
+      known_agent: true,
+      resolved_by_gsd: true,
+      passed_to_runtime: true,
+      runtime_enforced: 'unknown',
+      enforceability: 'explicit-token-needs-runtime-proof',
+    });
+  });
+
+  it('projects runtime-default bindings as resolved by GSD but not passed to runtime', async () => {
+    const { resolveAgentBinding, toRuntimeModelReceipt } = await import('./runtime-model-contract.js');
+    const resolution = resolveAgentBinding({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      resolve_model_ids: 'omit',
+      workflow: {},
+    }, 'gsd-verifier');
+
+    const receipt = toRuntimeModelReceipt(resolution, 'verifier');
+
+    expect(receipt.resolved_by_gsd).toBe(true);
+    expect(receipt.passed_to_runtime).toBe(false);
+    expect(receipt.runtime_enforced).toBe('unknown');
+    expect(receipt.enforceability).toBe('inherits-or-runtime-default');
+    expect(receipt.model_token).toBeNull();
+    expect(receipt.provider_family).toBe('unknown');
+  });
+
+  it('projects unsupported unknown-agent bindings with actionable diagnostics', async () => {
+    const { resolveAgentBinding, toRuntimeModelReceipt } = await import('./runtime-model-contract.js');
+    const resolution = resolveAgentBinding({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      workflow: {},
+    }, 'unknown-agent');
+
+    const receipt = toRuntimeModelReceipt(resolution, 'mystery');
+
+    expect(receipt).toMatchObject({
+      role: 'mystery',
+      agent: 'unknown-agent',
+      known_agent: false,
+      resolved_by_gsd: false,
+      passed_to_runtime: false,
+      runtime_enforced: 'unknown',
+      enforceability: 'unsupported',
+      rejection_reason: 'unknown-agent',
+    });
+    expect(receipt.message).toContain('unknown-agent');
+    expect(receipt.suggested_fix).toContain('supported agent');
+  });
 });
 
 describe('strict runtime-model validation', () => {

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -26,6 +26,7 @@ import {
   initRemoveWorkspace,
   initIngestDocs,
 } from './init.js';
+import { validateAgentBinding } from './runtime-model-validation.js';
 
 let tmpDir: string;
 
@@ -333,6 +334,7 @@ describe('initExecutePhase', () => {
       expect(receipts.agents[role]).toHaveProperty('resolved_by_gsd');
       expect(receipts.agents[role]).toHaveProperty('passed_to_runtime');
       expect(receipts.agents[role]).toHaveProperty('runtime_enforced');
+      expect(receipts.agents[role]).toHaveProperty('runtime_binding_channel');
     }
     expect(data.commit_docs).toBeDefined();
     expect(data.project_root).toBe(tmpDir);
@@ -371,6 +373,7 @@ describe('initPlanPhase', () => {
       expect(receipts.agents[role]).toHaveProperty('resolved_by_gsd');
       expect(receipts.agents[role]).toHaveProperty('passed_to_runtime');
       expect(receipts.agents[role]).toHaveProperty('runtime_enforced');
+      expect(receipts.agents[role]).toHaveProperty('runtime_binding_channel');
     }
     expect(data.research_enabled).toBeDefined();
     expect(data.has_research).toBe(true);
@@ -382,6 +385,55 @@ describe('initPlanPhase', () => {
     const result = await initPlanPhase([], tmpDir);
     const data = result.data as Record<string, unknown>;
     expect(data.error).toBeDefined();
+  });
+});
+
+describe('Hermes runtime model binding channel', () => {
+  it('marks Hermes receipts with delegate_task child-construction channel metadata', async () => {
+    await writeFile(join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+    }));
+
+    const result = await initPlanPhase(['9'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    const receipts = data.model_binding_receipts as {
+      agents: Record<string, Record<string, unknown>>;
+    };
+    const plannerReceipt = receipts.agents.planner;
+
+    expect(plannerReceipt.model_token).toBe('openai/o4-mini');
+    expect(plannerReceipt.runtime_enforced).toBe('unknown');
+    expect(plannerReceipt.runtime_binding_channel).toEqual({
+      kind: 'hermes-delegate-task-model',
+      available: true,
+      proof_level: 'child-construction',
+      reason: null,
+      suggested_fix: null,
+    });
+  });
+
+  it('fails fast for explicit Hermes overrides when delegate model channel is unavailable', () => {
+    const result = validateAgentBinding(
+      {
+        runtime: 'hermes',
+        model_profile: 'balanced',
+        model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+      },
+      'gsd-planner',
+      { hermesDelegateModelChannelAvailable: false },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.issue).toMatchObject({
+      agent: 'gsd-planner',
+      runtime: 'hermes',
+      configuredModel: 'openai/o4-mini',
+      rejectionReason: 'missing-runtime-binding-channel',
+    });
+    expect(result.issue?.reason).toContain('delegate_task.model / tasks[].model');
+    expect(result.issue?.suggestedFix).toContain('Upgrade or restart Hermes Agent');
   });
 });
 

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -318,6 +318,22 @@ describe('initExecutePhase', () => {
     expect(data.phase_found).toBe(true);
     expect(data.phase_number).toBe('09');
     expect(data.executor_model).toBeDefined();
+    expect(data.verifier_model).toBeDefined();
+    const receipts = data.model_binding_receipts as {
+      workflow: string;
+      runtime: string;
+      agents: Record<string, Record<string, unknown>>;
+    };
+    expect(receipts.workflow).toBe('execute-phase');
+    expect(receipts.runtime).toBeDefined();
+    expect(receipts.agents.executor.agent).toBe('gsd-executor');
+    expect(receipts.agents.verifier.agent).toBe('gsd-verifier');
+    for (const role of ['executor', 'verifier']) {
+      expect(receipts.agents[role].role).toBe(role);
+      expect(receipts.agents[role]).toHaveProperty('resolved_by_gsd');
+      expect(receipts.agents[role]).toHaveProperty('passed_to_runtime');
+      expect(receipts.agents[role]).toHaveProperty('runtime_enforced');
+    }
     expect(data.commit_docs).toBeDefined();
     expect(data.project_root).toBe(tmpDir);
     expect(data.plans).toBeDefined();
@@ -340,6 +356,22 @@ describe('initPlanPhase', () => {
     expect(data.researcher_model).toBeDefined();
     expect(data.planner_model).toBeDefined();
     expect(data.checker_model).toBeDefined();
+    const receipts = data.model_binding_receipts as {
+      workflow: string;
+      runtime: string;
+      agents: Record<string, Record<string, unknown>>;
+    };
+    expect(receipts.workflow).toBe('plan-phase');
+    expect(receipts.runtime).toBeDefined();
+    expect(receipts.agents.researcher.agent).toBe('gsd-phase-researcher');
+    expect(receipts.agents.planner.agent).toBe('gsd-planner');
+    expect(receipts.agents.checker.agent).toBe('gsd-plan-checker');
+    for (const role of ['researcher', 'planner', 'checker']) {
+      expect(receipts.agents[role].role).toBe(role);
+      expect(receipts.agents[role]).toHaveProperty('resolved_by_gsd');
+      expect(receipts.agents[role]).toHaveProperty('passed_to_runtime');
+      expect(receipts.agents[role]).toHaveProperty('runtime_enforced');
+    }
     expect(data.research_enabled).toBeDefined();
     expect(data.has_research).toBe(true);
     expect(data.has_context).toBe(true);

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -430,10 +430,71 @@ describe('Hermes runtime model binding channel', () => {
       agent: 'gsd-planner',
       runtime: 'hermes',
       configuredModel: 'openai/o4-mini',
+      resolvedModel: 'openai/o4-mini',
+      bindingKind: 'explicit',
+      source: 'override',
       rejectionReason: 'missing-runtime-binding-channel',
+      crossAiExecutionSupported: true,
+      crossAiExecutionConfigured: false,
     });
     expect(result.issue?.reason).toContain('delegate_task.model / tasks[].model');
     expect(result.issue?.suggestedFix).toContain('Upgrade or restart Hermes Agent');
+  });
+
+  it('does not fail inherit or runtime-default bindings when Hermes delegate channel is unavailable', () => {
+    const inherit = validateAgentBinding(
+      { runtime: 'hermes', model_overrides: { 'gsd-planner': 'inherit' } },
+      'gsd-planner',
+      { hermesDelegateModelChannelAvailable: false },
+    );
+    const runtimeDefault = validateAgentBinding(
+      { runtime: 'hermes', resolve_model_ids: 'omit' },
+      'gsd-planner',
+      { hermesDelegateModelChannelAvailable: false },
+    );
+
+    expect(inherit.ok).toBe(true);
+    expect(inherit.issue).toBeNull();
+    expect(inherit.bindingKind).toBe('inherit');
+    expect(runtimeDefault.ok).toBe(true);
+    expect(runtimeDefault.issue).toBeNull();
+    expect(runtimeDefault.bindingKind).toBe('runtime-default');
+  });
+
+  it('preserves invalid explicit model tokens instead of silently inheriting defaults', () => {
+    const invalidModel = 'definitely-not-a-real-model-gsd-binding-test';
+    const result = validateAgentBinding(
+      {
+        runtime: 'hermes',
+        model_profile: 'balanced',
+        model_overrides: { 'gsd-planner': invalidModel },
+      },
+      'gsd-planner',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.configuredModel).toBe(invalidModel);
+    expect(result.resolvedModel).toBe(invalidModel);
+    expect(result.binding.modelToken).toBe(invalidModel);
+    expect(result.bindingKind).toBe('explicit');
+  });
+
+  it('represents explicit cross-AI execution as configured metadata, not silent fallback', () => {
+    const result = validateAgentBinding(
+      {
+        runtime: 'hermes',
+        model_profile: 'balanced',
+        workflow: { cross_ai_execution: true },
+        model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+      },
+      'gsd-planner',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.binding.crossAiExecutionConfigured).toBe(true);
+    expect(result.binding.runtimeCapability.supportsCrossAiExecution).toBe(true);
+    expect(result.bindingKind).toBe('explicit');
+    expect(result.source).toBe('override');
   });
 });
 

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -25,6 +25,7 @@ import { homedir } from 'node:os';
 
 import { loadConfig, type GSDConfig } from '../config.js';
 import { resolveModel, MODEL_PROFILES } from './config-query.js';
+import { resolveAgentBinding, toRuntimeModelReceipt, type RuntimeModelReceipt } from './runtime-model-contract.js';
 import { findPhase } from './phase.js';
 import { roadmapGetPhase, getMilestoneInfo, extractCurrentMilestone, extractPhasesFromSection } from './roadmap.js';
 import { planningPaths, normalizePhaseName, toPosixPath, resolveAgentsDir, detectRuntime } from './helpers.js';
@@ -40,6 +41,24 @@ async function getModelAlias(agentType: string, projectDir: string): Promise<str
   const result = await resolveModel([agentType], projectDir);
   const data = result.data as Record<string, unknown>;
   return (data.model as string) || 'sonnet';
+}
+
+interface ReceiptSpec {
+  role: string;
+  agent: string;
+}
+
+function buildModelBindingReceipts(
+  workflow: string,
+  config: GSDConfig,
+  specs: ReceiptSpec[],
+): { workflow: string; runtime: string; agents: Record<string, RuntimeModelReceipt> } {
+  const agents: Record<string, RuntimeModelReceipt> = {};
+  for (const spec of specs) {
+    agents[spec.role] = toRuntimeModelReceipt(resolveAgentBinding(config, spec.agent), spec.role);
+  }
+  const runtime = specs.length > 0 ? agents[specs[0].role].runtime : detectRuntime(config);
+  return { workflow, runtime, agents };
 }
 
 /**
@@ -295,6 +314,10 @@ export const initExecutePhase: QueryHandler = async (args, projectDir, workstrea
   const result: Record<string, unknown> = {
     executor_model: executorModel,
     verifier_model: verifierModel,
+    model_binding_receipts: buildModelBindingReceipts('execute-phase', config, [
+      { role: 'executor', agent: 'gsd-executor' },
+      { role: 'verifier', agent: 'gsd-verifier' },
+    ]),
     tdd_mode: config.workflow.tdd_mode ?? false,
     commit_docs: config.commit_docs,
     sub_repos: (config as Record<string, unknown>).sub_repos ?? [],
@@ -371,6 +394,11 @@ export const initPlanPhase: QueryHandler = async (args, projectDir, workstream) 
     researcher_model: researcherModel,
     planner_model: plannerModel,
     checker_model: checkerModel,
+    model_binding_receipts: buildModelBindingReceipts('plan-phase', config, [
+      { role: 'researcher', agent: 'gsd-phase-researcher' },
+      { role: 'planner', agent: 'gsd-planner' },
+      { role: 'checker', agent: 'gsd-plan-checker' },
+    ]),
     tdd_mode: config.workflow.tdd_mode ?? false,
     research_enabled: config.workflow.research,
     plan_checker_enabled: config.workflow.plan_check,

--- a/sdk/src/query/runtime-model-contract.ts
+++ b/sdk/src/query/runtime-model-contract.ts
@@ -42,7 +42,7 @@ export type AcceptedModelProfile = (typeof ACCEPTED_MODEL_PROFILES)[number];
 
 export type BindingKind = 'explicit' | 'profile' | 'inherit' | 'runtime-default';
 export type BindingSource = 'override' | 'profile' | 'inherit-profile' | 'resolve-model-omit';
-export type RejectionReason = 'unknown-agent' | 'missing-contract-coverage' | 'runtime-model-unsupported';
+export type RejectionReason = 'unknown-agent' | 'missing-contract-coverage' | 'runtime-model-unsupported' | 'missing-runtime-binding-channel';
 export type ModelFamily = 'anthropic' | 'openai' | 'google' | 'unknown';
 
 export interface RuntimeCapability {
@@ -137,6 +137,17 @@ export interface SerializedRuntimeModelResolution {
 }
 
 export type RuntimeEnforcementStatus = 'unknown' | boolean;
+export type RuntimeBindingChannelKind = 'hermes-delegate-task-model' | 'runtime-native-model-parameter' | 'none';
+export type RuntimeBindingChannelProofLevel = 'child-construction' | 'runtime-dispatch' | 'none';
+
+export interface RuntimeBindingChannel {
+  kind: RuntimeBindingChannelKind;
+  available: boolean;
+  proof_level: RuntimeBindingChannelProofLevel;
+  reason: string | null;
+  suggested_fix: string | null;
+}
+
 export type RuntimeModelReceiptEnforceability =
   | 'explicit-token-needs-runtime-proof'
   | 'inherits-or-runtime-default'
@@ -149,6 +160,7 @@ export interface RuntimeModelReceipt extends SerializedRuntimeModelResolution {
   passed_to_runtime: boolean;
   runtime_enforced: RuntimeEnforcementStatus;
   enforceability: RuntimeModelReceiptEnforceability;
+  runtime_binding_channel: RuntimeBindingChannel;
 }
 
 export const MODEL_ALIAS_MAP: Record<string, string> = {
@@ -221,6 +233,44 @@ export function evaluateRuntimeModelCompatibility(runtime: Runtime, model: strin
 
   return { supported: true, runtime, model, family, reason: null };
 }
+
+export function runtimeBindingChannelForRuntime(
+  runtime: Runtime,
+  options: { hermesDelegateModelChannelAvailable?: boolean } = {},
+): RuntimeBindingChannel {
+  if (runtime === 'hermes') {
+    const available = options.hermesDelegateModelChannelAvailable ?? true;
+    return {
+      kind: 'hermes-delegate-task-model',
+      available,
+      proof_level: available ? 'child-construction' : 'none',
+      reason: available ? null : 'Hermes delegate_task.model / tasks[].model binding channel is unavailable.',
+      suggested_fix: available
+        ? null
+        : 'Upgrade or restart Hermes Agent with delegate_task.model / tasks[].model support, set the override to inherit, remove the explicit model_overrides entry, or use explicit cross-AI execution.',
+    };
+  }
+
+  const capability = RUNTIME_CAPABILITIES[runtime];
+  if (capability.supportsExplicitModel) {
+    return {
+      kind: 'runtime-native-model-parameter',
+      available: true,
+      proof_level: 'runtime-dispatch',
+      reason: null,
+      suggested_fix: null,
+    };
+  }
+
+  return {
+    kind: 'none',
+    available: false,
+    proof_level: 'none',
+    reason: `Runtime '${runtime}' does not expose an explicit model binding channel.`,
+    suggested_fix: 'Use inherit/runtime-default binding or route through a runtime with explicit model support.',
+  };
+}
+
 
 function normalizeString(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -548,6 +598,7 @@ export function toRuntimeModelReceipt(
     passed_to_runtime: resolution.kind === 'resolved' && !!resolution.modelToken,
     runtime_enforced: 'unknown',
     enforceability: receiptEnforceability(resolution),
+    runtime_binding_channel: runtimeBindingChannelForRuntime(resolution.runtime),
   };
 }
 

--- a/sdk/src/query/runtime-model-contract.ts
+++ b/sdk/src/query/runtime-model-contract.ts
@@ -136,6 +136,21 @@ export interface SerializedRuntimeModelResolution {
   message?: string;
 }
 
+export type RuntimeEnforcementStatus = 'unknown' | boolean;
+export type RuntimeModelReceiptEnforceability =
+  | 'explicit-token-needs-runtime-proof'
+  | 'inherits-or-runtime-default'
+  | 'unsupported';
+
+export interface RuntimeModelReceipt extends SerializedRuntimeModelResolution {
+  role: string;
+  provider_family: ModelFamily;
+  resolved_by_gsd: boolean;
+  passed_to_runtime: boolean;
+  runtime_enforced: RuntimeEnforcementStatus;
+  enforceability: RuntimeModelReceiptEnforceability;
+}
+
 export const MODEL_ALIAS_MAP: Record<string, string> = {
   opus: 'claude-opus-4-6',
   sonnet: 'claude-sonnet-4-6',
@@ -509,6 +524,31 @@ export function serializeRuntimeModelResolution(resolution: RuntimeModelResoluti
   }
 
   return base;
+}
+
+function receiptEnforceability(resolution: RuntimeModelResolution): RuntimeModelReceiptEnforceability {
+  if (resolution.kind === 'unsupported') return 'unsupported';
+  if (resolution.bindingKind === 'explicit' && !!resolution.modelToken) {
+    return 'explicit-token-needs-runtime-proof';
+  }
+  return 'inherits-or-runtime-default';
+}
+
+export function toRuntimeModelReceipt(
+  resolution: RuntimeModelResolution,
+  role: string,
+): RuntimeModelReceipt {
+  const serialized = serializeRuntimeModelResolution(resolution);
+  const providerModel = resolution.modelToken ?? resolution.resolvedModel ?? resolution.configuredModel;
+  return {
+    ...serialized,
+    role,
+    provider_family: detectModelFamily(providerModel),
+    resolved_by_gsd: resolution.kind === 'resolved',
+    passed_to_runtime: resolution.kind === 'resolved' && !!resolution.modelToken,
+    runtime_enforced: 'unknown',
+    enforceability: receiptEnforceability(resolution),
+  };
 }
 
 export function toLegacyModelToken(resolution: RuntimeModelResolution, fallback = ''): string {

--- a/sdk/src/query/runtime-model-validation.ts
+++ b/sdk/src/query/runtime-model-validation.ts
@@ -13,6 +13,7 @@ import {
   type BindingKind,
   type BindingSource,
   type RejectionReason,
+  runtimeBindingChannelForRuntime,
   type RuntimeModelResolution,
 } from './runtime-model-contract.js';
 
@@ -43,6 +44,10 @@ export interface BindingValidationResult {
   resolvedModel: string | null;
   issue: BindingValidationIssue | null;
   binding: RuntimeModelResolution;
+}
+
+export interface RuntimeBindingChannelValidationOptions {
+  hermesDelegateModelChannelAvailable?: boolean;
 }
 
 export interface BindingValidationSummary {
@@ -286,7 +291,11 @@ export function evaluateCrossAiExecutionResult(options: {
   };
 }
 
-function buildSuggestedFix(binding: RuntimeModelResolution): string {
+function buildSuggestedFix(binding: RuntimeModelResolution, rejectionReason?: RejectionReason): string {
+  if (rejectionReason === 'missing-runtime-binding-channel' && binding.runtime === 'hermes') {
+    return 'Upgrade or restart Hermes Agent with delegate_task.model / tasks[].model support, set the override to inherit, remove the explicit model_overrides entry, or use explicit cross-AI execution.';
+  }
+
   if (binding.kind === 'unsupported') {
     return binding.suggestedFix;
   }
@@ -326,7 +335,7 @@ function buildIssue(binding: RuntimeModelResolution, rejectionReason: RejectionR
     resolvedModel: binding.resolvedModel,
     rejectionReason,
     reason,
-    suggestedFix: buildSuggestedFix(binding),
+    suggestedFix: buildSuggestedFix(binding, rejectionReason),
     crossAiExecutionSupported,
     crossAiExecutionConfigured: binding.crossAiExecutionConfigured,
     crossAiExecutionRecommended,
@@ -335,7 +344,10 @@ function buildIssue(binding: RuntimeModelResolution, rejectionReason: RejectionR
   };
 }
 
-export function validateResolvedAgentBinding(binding: RuntimeModelResolution): BindingValidationResult {
+export function validateResolvedAgentBinding(
+  binding: RuntimeModelResolution,
+  options: RuntimeBindingChannelValidationOptions = {},
+): BindingValidationResult {
   if (binding.kind === 'unsupported') {
     return {
       ok: false,
@@ -362,6 +374,27 @@ export function validateResolvedAgentBinding(binding: RuntimeModelResolution): B
       issue: null,
       binding,
     };
+  }
+
+  if (binding.runtime === 'hermes' && binding.bindingKind === 'explicit') {
+    const channel = runtimeBindingChannelForRuntime(binding.runtime, options);
+    if (!channel.available) {
+      return {
+        ok: false,
+        agent: binding.agent,
+        runtime: binding.runtime,
+        bindingKind: binding.bindingKind,
+        source: binding.source,
+        configuredModel: binding.configuredModel,
+        resolvedModel: binding.resolvedModel,
+        issue: buildIssue(
+          binding,
+          'missing-runtime-binding-channel',
+          channel.reason ?? 'Hermes delegate_task.model / tasks[].model binding channel is unavailable',
+        ),
+        binding,
+      };
+    }
   }
 
   const compatibility = evaluateRuntimeModelCompatibility(binding.runtime, binding.resolvedModel);
@@ -392,12 +425,20 @@ export function validateResolvedAgentBinding(binding: RuntimeModelResolution): B
   };
 }
 
-export function validateAgentBinding(config: GSDConfig | Record<string, unknown>, agent: string): BindingValidationResult {
-  return validateResolvedAgentBinding(resolveAgentBinding(config, agent));
+export function validateAgentBinding(
+  config: GSDConfig | Record<string, unknown>,
+  agent: string,
+  options: RuntimeBindingChannelValidationOptions = {},
+): BindingValidationResult {
+  return validateResolvedAgentBinding(resolveAgentBinding(config, agent), options);
 }
 
-export function validateAgentBindings(config: GSDConfig | Record<string, unknown>, agents: string[]): BindingValidationSummary {
-  const results = agents.map((agent) => validateAgentBinding(config, agent));
+export function validateAgentBindings(
+  config: GSDConfig | Record<string, unknown>,
+  agents: string[],
+  options: RuntimeBindingChannelValidationOptions = {},
+): BindingValidationSummary {
+  const results = agents.map((agent) => validateAgentBinding(config, agent, options));
   const issues = results.flatMap((result) => result.issue ? [result.issue] : []);
   const runtime = results[0]?.runtime ?? resolveAgentBinding(config, agents[0] ?? 'gsd-planner').runtime;
 
@@ -437,8 +478,9 @@ export function assertAgentBindingsSupported(
   config: GSDConfig | Record<string, unknown>,
   agents: string[],
   phaseLabel = 'workflow execution',
+  options: RuntimeBindingChannelValidationOptions = {},
 ): void {
-  const summary = validateAgentBindings(config, agents);
+  const summary = validateAgentBindings(config, agents, options);
   if (summary.ok) return;
   throw new GSDError(formatBindingValidationError(summary, phaseLabel), ErrorClassification.Validation);
 }

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -8,6 +8,16 @@ const fs = require('fs');
 const path = require('path');
 const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
 
+function assertReceiptRole(receipts, workflow, role, agent) {
+  assert.strictEqual(receipts.workflow, workflow);
+  assert.ok(receipts.runtime, 'receipt payload must include runtime');
+  assert.strictEqual(receipts.agents[role].role, role);
+  assert.strictEqual(receipts.agents[role].agent, agent);
+  assert.ok(Object.hasOwn(receipts.agents[role], 'resolved_by_gsd'));
+  assert.ok(Object.hasOwn(receipts.agents[role], 'passed_to_runtime'));
+  assert.ok(Object.hasOwn(receipts.agents[role], 'runtime_enforced'));
+}
+
 describe('init commands', () => {
   let tmpDir;
 
@@ -67,6 +77,26 @@ describe('init commands', () => {
       'model_overrides must take precedence even when resolve_model_ids is omit');
   });
 
+  test('init execute-phase emits conservative model binding receipts', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '01-foundation');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      model_overrides: { 'gsd-executor': 'openai/o4-mini' },
+    }));
+
+    const result = runGsdTools('init execute-phase 1 --raw', tmpDir, { HOME: tmpDir });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assertReceiptRole(output.model_binding_receipts, 'execute-phase', 'executor', 'gsd-executor');
+    assertReceiptRole(output.model_binding_receipts, 'execute-phase', 'verifier', 'gsd-verifier');
+    assert.strictEqual(output.model_binding_receipts.agents.executor.model, 'openai/o4-mini');
+    assert.strictEqual(output.model_binding_receipts.agents.executor.runtime_enforced, 'unknown');
+  });
+
   test('init plan-phase returns file paths', () => {
     const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
     fs.mkdirSync(phaseDir, { recursive: true });
@@ -107,6 +137,24 @@ describe('init commands', () => {
     assert.ok(result.success, `Command failed: ${result.error}`);
     const output = JSON.parse(result.output);
     assert.strictEqual(output.text_mode, true, 'text_mode should reflect config value');
+  });
+
+  test('init plan-phase emits conservative model binding receipts', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+    }));
+
+    const result = runGsdTools('init plan-phase 03 --raw', tmpDir, { HOME: tmpDir });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assertReceiptRole(output.model_binding_receipts, 'plan-phase', 'researcher', 'gsd-phase-researcher');
+    assertReceiptRole(output.model_binding_receipts, 'plan-phase', 'planner', 'gsd-planner');
+    assertReceiptRole(output.model_binding_receipts, 'plan-phase', 'checker', 'gsd-plan-checker');
+    assert.strictEqual(output.model_binding_receipts.agents.planner.model, 'openai/o4-mini');
+    assert.strictEqual(output.model_binding_receipts.agents.planner.runtime_enforced, 'unknown');
   });
 
   test('init progress returns file paths', () => {

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -7,6 +7,7 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+const { validateAgentBinding } = require('../get-shit-done/bin/lib/model-profiles.cjs');
 
 function assertReceiptRole(receipts, workflow, role, agent) {
   assert.strictEqual(receipts.workflow, workflow);
@@ -156,6 +157,67 @@ describe('init commands', () => {
     assertReceiptRole(output.model_binding_receipts, 'plan-phase', 'checker', 'gsd-plan-checker');
     assert.strictEqual(output.model_binding_receipts.agents.planner.model_token, 'openai/o4-mini');
     assert.strictEqual(output.model_binding_receipts.agents.planner.runtime_enforced, 'unknown');
+    assert.deepStrictEqual(output.model_binding_receipts.agents.planner.runtime_binding_channel, {
+      kind: 'hermes-delegate-task-model',
+      available: true,
+      proof_level: 'child-construction',
+      reason: null,
+      suggested_fix: null,
+    });
+  });
+
+  test('legacy CJS validation fails fast when Hermes delegate model channel is unavailable', () => {
+    const result = validateAgentBinding(
+      {
+        runtime: 'hermes',
+        model_profile: 'balanced',
+        model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+      },
+      'gsd-planner',
+      { hermesDelegateModelChannelAvailable: false }
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.deepStrictEqual(
+      {
+        agent: result.issue.agent,
+        runtime: result.issue.runtime,
+        configuredModel: result.issue.configuredModel,
+        resolvedModel: result.issue.resolvedModel,
+        bindingKind: result.issue.bindingKind,
+        source: result.issue.source,
+        rejectionReason: result.issue.rejectionReason,
+      },
+      {
+        agent: 'gsd-planner',
+        runtime: 'hermes',
+        configuredModel: 'openai/o4-mini',
+        resolvedModel: 'openai/o4-mini',
+        bindingKind: 'explicit',
+        source: 'override',
+        rejectionReason: 'missing-runtime-binding-channel',
+      }
+    );
+    assert.match(result.issue.reason, /delegate_task\.model \/ tasks\[\]\.model/);
+    assert.match(result.issue.suggestedFix, /Upgrade or restart Hermes Agent/);
+  });
+
+  test('legacy CJS receipts preserve invalid explicit model tokens', () => {
+    const invalidModel = 'definitely-not-a-real-model-gsd-binding-test';
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      model_overrides: { 'gsd-planner': invalidModel },
+    }));
+
+    const result = runGsdTools('init plan-phase 03 --raw', tmpDir, { HOME: tmpDir });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.model_binding_receipts.agents.planner.configured_model, invalidModel);
+    assert.strictEqual(output.model_binding_receipts.agents.planner.resolved_model, invalidModel);
+    assert.strictEqual(output.model_binding_receipts.agents.planner.model_token, invalidModel);
+    assert.notStrictEqual(output.model_binding_receipts.agents.planner.model_token, 'opus');
   });
 
   test('init progress returns file paths', () => {

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -93,7 +93,7 @@ describe('init commands', () => {
     const output = JSON.parse(result.output);
     assertReceiptRole(output.model_binding_receipts, 'execute-phase', 'executor', 'gsd-executor');
     assertReceiptRole(output.model_binding_receipts, 'execute-phase', 'verifier', 'gsd-verifier');
-    assert.strictEqual(output.model_binding_receipts.agents.executor.model, 'openai/o4-mini');
+    assert.strictEqual(output.model_binding_receipts.agents.executor.model_token, 'openai/o4-mini');
     assert.strictEqual(output.model_binding_receipts.agents.executor.runtime_enforced, 'unknown');
   });
 
@@ -153,7 +153,7 @@ describe('init commands', () => {
     assertReceiptRole(output.model_binding_receipts, 'plan-phase', 'researcher', 'gsd-phase-researcher');
     assertReceiptRole(output.model_binding_receipts, 'plan-phase', 'planner', 'gsd-planner');
     assertReceiptRole(output.model_binding_receipts, 'plan-phase', 'checker', 'gsd-plan-checker');
-    assert.strictEqual(output.model_binding_receipts.agents.planner.model, 'openai/o4-mini');
+    assert.strictEqual(output.model_binding_receipts.agents.planner.model_token, 'openai/o4-mini');
     assert.strictEqual(output.model_binding_receipts.agents.planner.runtime_enforced, 'unknown');
   });
 

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -16,6 +16,7 @@ function assertReceiptRole(receipts, workflow, role, agent) {
   assert.ok(Object.hasOwn(receipts.agents[role], 'resolved_by_gsd'));
   assert.ok(Object.hasOwn(receipts.agents[role], 'passed_to_runtime'));
   assert.ok(Object.hasOwn(receipts.agents[role], 'runtime_enforced'));
+  assert.ok(Object.hasOwn(receipts.agents[role], 'runtime_binding_channel'));
 }
 
 describe('init commands', () => {

--- a/tests/runtime-model-parity.test.cjs
+++ b/tests/runtime-model-parity.test.cjs
@@ -13,6 +13,7 @@ const PLAN_PHASE_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'wo
 const QUICK_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'quick.md');
 const VERIFY_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'verify-work.md');
 const EXECUTE_PHASE_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'execute-phase.md');
+const HERMES_COMPATIBILITY_DOC_PATH = path.join(__dirname, '..', 'docs', 'hermes-compatibility.md');
 
 const SDK_RUNTIME_MODEL_CONTRACT_PATH = pathToFileURL(
   path.join(__dirname, '..', 'sdk', 'dist', 'query', 'runtime-model-contract.js')
@@ -284,10 +285,31 @@ describe('runtime-model parity', () => {
     const quickWorkflow = fsNative.readFileSync(QUICK_WORKFLOW_PATH, 'utf8');
     const verifyWorkflow = fsNative.readFileSync(VERIFY_WORKFLOW_PATH, 'utf8');
     const executeWorkflow = fsNative.readFileSync(EXECUTE_PHASE_WORKFLOW_PATH, 'utf8');
+    const hermesDoc = fsNative.readFileSync(HERMES_COMPATIBILITY_DOC_PATH, 'utf8');
 
     assert.match(planWorkflow, /four runtime-model paths/i);
     assert.match(quickWorkflow, /four runtime-model paths/i);
     assert.match(verifyWorkflow, /four runtime-model paths/i);
     assert.match(executeWorkflow, /direct runtime support/i);
+
+    for (const [name, text] of [
+      ['plan-phase workflow', planWorkflow],
+      ['execute-phase workflow', executeWorkflow],
+    ]) {
+      assert.match(text, /model_binding_receipts/, `${name} must parse model_binding_receipts`);
+      assert.match(text, /runtime_enforced/, `${name} must display runtime_enforced`);
+      assert.match(text, /resolved_by_gsd/, `${name} must display resolved_by_gsd`);
+      assert.match(text, /passed_to_runtime/, `${name} must display passed_to_runtime`);
+      assert.match(
+        text,
+        /runtime_enforced=unknown is not runtime proof/i,
+        `${name} must warn that unknown enforcement is not runtime proof`
+      );
+    }
+
+    assert.match(hermesDoc, /resolved_by_gsd/);
+    assert.match(hermesDoc, /passed_to_runtime/);
+    assert.match(hermesDoc, /runtime_enforced/);
+    assert.match(hermesDoc, /subagent self-report is not proof/i);
   });
 });

--- a/tests/runtime-model-parity.test.cjs
+++ b/tests/runtime-model-parity.test.cjs
@@ -302,9 +302,11 @@ describe('runtime-model parity', () => {
       assert.match(text, /passed_to_runtime/, `${name} must display passed_to_runtime`);
       assert.match(
         text,
-        /runtime_enforced=unknown is not runtime proof/i,
-        `${name} must warn that unknown enforcement is not runtime proof`
+        /runtime_enforced=unknown is not provider proof/i,
+        `${name} must warn that unknown enforcement is not provider proof`
       );
+      assert.match(text, /runtime_binding_channel/, `${name} must display the binding channel boundary`);
+      assert.match(text, /child-construction/i, `${name} must distinguish child construction from provider proof`);
     }
 
     assert.match(hermesDoc, /resolved_by_gsd/);

--- a/tests/runtime-model-parity.test.cjs
+++ b/tests/runtime-model-parity.test.cjs
@@ -7,7 +7,7 @@ const path = require('path');
 const { pathToFileURL } = require('url');
 const { createTempProject, cleanup } = require('./helpers.cjs');
 const { resolveModelBindingInternal, resolveModelInternal } = require('../get-shit-done/bin/lib/core.cjs');
-const { toInitModelToken } = require('../get-shit-done/bin/lib/model-profiles.cjs');
+const { toInitModelToken, toBindingReceipt } = require('../get-shit-done/bin/lib/model-profiles.cjs');
 
 const PLAN_PHASE_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'plan-phase.md');
 const QUICK_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'quick.md');
@@ -167,6 +167,7 @@ describe('runtime-model parity', () => {
   let sdkResolveAgentBinding;
   let sdkToLegacyModelToken;
   let sdkToInitModelToken;
+  let sdkToRuntimeModelReceipt;
 
   beforeEach(async () => {
     tmpDir = createTempProject();
@@ -174,6 +175,7 @@ describe('runtime-model parity', () => {
     sdkResolveAgentBinding = sdkModule.resolveAgentBinding;
     sdkToLegacyModelToken = sdkModule.toLegacyModelToken;
     sdkToInitModelToken = sdkModule.toInitModelToken;
+    sdkToRuntimeModelReceipt = sdkModule.toRuntimeModelReceipt;
   });
 
   afterEach(() => {
@@ -230,6 +232,50 @@ describe('runtime-model parity', () => {
       }
       assert.strictEqual(cjsLegacyToken, entry.expectedLegacyToken);
       assert.strictEqual(cjsInitToken, entry.expectedInitToken);
+
+      const sdkReceipt = sdkToRuntimeModelReceipt(sdkResolution, 'executor');
+      const cjsReceipt = toBindingReceipt(cjsResolution, 'executor');
+      assert.deepStrictEqual(
+        {
+          role: cjsReceipt.role,
+          agent: cjsReceipt.agent,
+          status: cjsReceipt.status,
+          known_agent: cjsReceipt.known_agent,
+          runtime: cjsReceipt.runtime,
+          profile: cjsReceipt.profile,
+          binding_kind: cjsReceipt.binding_kind,
+          source: cjsReceipt.source,
+          configured_model: cjsReceipt.configured_model,
+          resolved_model: cjsReceipt.resolved_model,
+          model_token: cjsReceipt.model_token,
+          provider_family: cjsReceipt.provider_family,
+          resolved_by_gsd: cjsReceipt.resolved_by_gsd,
+          passed_to_runtime: cjsReceipt.passed_to_runtime,
+          runtime_enforced: cjsReceipt.runtime_enforced,
+          enforceability: cjsReceipt.enforceability,
+          rejection_reason: cjsReceipt.rejection_reason,
+        },
+        {
+          role: sdkReceipt.role,
+          agent: sdkReceipt.agent,
+          status: sdkReceipt.status,
+          known_agent: sdkReceipt.known_agent,
+          runtime: sdkReceipt.runtime,
+          profile: sdkReceipt.profile,
+          binding_kind: sdkReceipt.binding_kind,
+          source: sdkReceipt.source,
+          configured_model: sdkReceipt.configured_model,
+          resolved_model: sdkReceipt.resolved_model,
+          model_token: sdkReceipt.model_token,
+          provider_family: sdkReceipt.provider_family,
+          resolved_by_gsd: sdkReceipt.resolved_by_gsd,
+          passed_to_runtime: sdkReceipt.passed_to_runtime,
+          runtime_enforced: sdkReceipt.runtime_enforced,
+          enforceability: sdkReceipt.enforceability,
+          rejection_reason: sdkReceipt.rejection_reason,
+        },
+        'legacy CJS binding receipt projection must match SDK receipt projection for the shared matrix'
+      );
     });
   }
 

--- a/tests/runtime-model-parity.test.cjs
+++ b/tests/runtime-model-parity.test.cjs
@@ -150,6 +150,30 @@ const MATRIX = [
     expectedInitToken: 'claude-sonnet-4-6',
   },
   {
+    name: 'runtime: hermes + invalid explicit override preserves token for no-silent-fallback proof',
+    agent: 'gsd-planner',
+    config: {
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      model_overrides: { 'gsd-planner': 'definitely-not-a-real-model-gsd-binding-test' },
+      workflow: {},
+    },
+    expectedLegacyToken: 'definitely-not-a-real-model-gsd-binding-test',
+    expectedInitToken: 'definitely-not-a-real-model-gsd-binding-test',
+  },
+  {
+    name: 'runtime: hermes + cross_ai_execution flag remains metadata, not silent fallback',
+    agent: 'gsd-planner',
+    config: {
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      workflow: { cross_ai_execution: true },
+      model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+    },
+    expectedLegacyToken: 'openai/o4-mini',
+    expectedInitToken: 'openai/o4-mini',
+  },
+  {
     name: 'runtime: codex + inherit + model_profile_overrides — inherit dominates, overrides ignored by both resolvers',
     agent: 'gsd-planner',
     config: {
@@ -254,6 +278,7 @@ describe('runtime-model parity', () => {
           passed_to_runtime: cjsReceipt.passed_to_runtime,
           runtime_enforced: cjsReceipt.runtime_enforced,
           enforceability: cjsReceipt.enforceability,
+          runtime_binding_channel: cjsReceipt.runtime_binding_channel,
           rejection_reason: cjsReceipt.rejection_reason,
         },
         {
@@ -273,6 +298,7 @@ describe('runtime-model parity', () => {
           passed_to_runtime: sdkReceipt.passed_to_runtime,
           runtime_enforced: sdkReceipt.runtime_enforced,
           enforceability: sdkReceipt.enforceability,
+          runtime_binding_channel: sdkReceipt.runtime_binding_channel,
           rejection_reason: sdkReceipt.rejection_reason,
         },
         'legacy CJS binding receipt projection must match SDK receipt projection for the shared matrix'


### PR DESCRIPTION
# Ship Hermes runtime model binding receipts and fail-fast enforcement

Closes #32

## Tracker

- Issue: https://github.com/pingchesu/gsd-hermes/issues/32

## Root cause

GSD resolver/config surfaces could report explicit per-agent `model_overrides`, but the pre-fix Hermes delegation path did not expose a per-call child `model` binding. In Hermes, spawned child agents could therefore inherit the parent/default model even when GSD receipts showed `source=override` and `binding=explicit`.

Resolver truth was not runtime truth.

## Change summary

### Phase 10 — Runtime Binding Receipt Surface

- Added structured `model_binding_receipts` to plan-phase and execute-phase init payloads.
- Preserved backward-compatible flat `*_model` fields.
- Updated workflow transcript instructions to show resolver/runtime/proof boundaries conservatively.

### Phase 11 — Hermes Per-Agent Binding Channel

- Added Hermes Agent child binding support through direct `delegate_task(model=...)` and batch `tasks[].model`.
- Added GSD receipt metadata for `runtime_binding_channel.kind=hermes-delegate-task-model` with `proof_level=child-construction`.
- Documented that `delegation.model` is a global fallback, not a per-agent GSD override channel.

### Phase 12 — Fail-Fast Validation and Proof Tests

- Added SDK/CJS validation coverage so unsupported explicit Hermes bindings fail before spawn.
- Added regression tests proving invalid explicit model tokens are preserved and cannot silently fall back to parent/default model.
- Added Hermes Agent tests proving GSD planner/executor model tokens reach child `AIAgent(model=...)` construction.
- Added safe provider diagnostics that preserve sanitized model/provider metadata while redacting credentials.

### Phase 13 — Tracker, docs, release prep

- Created tracker issue #32.
- Updated README, COMMANDS, CONFIGURATION, Hermes compatibility docs, CHANGELOG, package metadata, and curated release notes for the selected patch release.
- Selected `gsd-hermes@1.4.30` / GitHub Release `v1.4.30` because `1.4.0` is already published and local `v1.4.1`–`v1.4.29` tags are present.

## Proof boundary

This PR intentionally separates evidence layers:

1. GSD resolver proof — config override resolves to the configured/resolved model token.
2. Workflow receipt proof — init payload/transcript displays binding metadata before dispatch.
3. Hermes child-construction proof — child `AIAgent(model=...)` receives the intended token.
4. Provider diagnostics proof — sanitized metadata can expose provider/model fields without secrets.
5. Provider wire-level enforcement — not claimed unless future live sanitized request instrumentation proves provider-side `model=` dispatch.

`runtime_enforced=unknown` is conservative and must not be read as provider wire-level proof.

## Validation

Local validation to run before PR/release:

```bash
npm run build:sdk
cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts
cd .. && node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs
npm run test:hermes
npm test
npm pack --dry-run
```

Hermes Agent proof tests:

```bash
cd /home/whiskey/.hermes/hermes-agent
.venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py tests/agent/test_provider_diagnostics.py -q
.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py agent/provider_diagnostics.py agent/redact.py tests/tools/test_delegate.py tests/agent/test_provider_diagnostics.py
```

Latest recorded Phase 12 results before Phase 13 docs/release updates:

- GSD full suite: PASS — `5597/5597`.
- GSD targeted gates: PASS.
- Hermes Agent targeted gates: PASS — `128 passed` plus `py_compile`.

Phase 13 final local/CI results will be recorded before merge/release.

## Release target

- npm package: `gsd-hermes@1.4.30`
- GitHub Release: `v1.4.30`
- Release notes: `docs/releases/v1.4.30-runtime-model-binding-receipts.md`

Pre-publish gates:

- [ ] `package.json` and `package-lock.json` both equal `1.4.30`.
- [ ] `npm view gsd-hermes versions --json` does not include `1.4.30`.
- [ ] `git tag --list v1.4.30` is empty before creating the release tag.
- [ ] `gh release view v1.4.30` reports no existing release before creating it.
- [ ] CI is green before publish.

## Acceptance checklist

- [ ] Structured plan/execute binding receipts are present and covered by SDK/CJS tests.
- [ ] Hermes child binding channel supports direct `model` and batch `tasks[].model`.
- [ ] Unsupported explicit bindings fail fast before spawn.
- [ ] Invalid explicit model tokens cannot be hidden by fallback to parent/default model.
- [ ] Provider diagnostics redact API keys, tokens, authorization headers, passwords, client secrets, and credential-bearing URLs.
- [ ] README, COMMANDS.md, CONFIGURATION.md, Hermes compatibility docs, CHANGELOG, and release notes document strict semantics and proof boundaries.
- [ ] npm/GitHub release evidence is recorded after publish.

## Rollback notes

Before publish, rollback is a normal PR revert/close. After npm publish, npm versions are immutable; corrections should ship as a follow-up patch release rather than unpublishing except under npm security policy.
