### PR TITLE
Ship Hermes runtime model binding receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ syncs from.
 
 No unreleased changes yet.
 
+## [1.4.30] — 2026-04-26
+
+GSD Hermes package version: `1.4.30`
+Upstream GSD base: `upstream/main@cd057255`
+Tracker: https://github.com/pingchesu/gsd-hermes/issues/32
+
+### Added
+- **Hermes runtime model binding receipts** — plan-phase and execute-phase init payloads now include structured `model_binding_receipts` that show resolver decision, configured model, resolved token, binding source, runtime binding channel, and proof boundary for each participating GSD agent while preserving legacy flat `*_model` fields.
+- **Hermes child binding channel evidence** — direct `delegate_task(model=...)` and batch `tasks[].model` are the canonical Hermes per-agent binding seams; tests verify GSD planner/executor overrides reach child `AIAgent(model=...)` construction.
+- **Safe provider diagnostics** — sanitized provider metadata helpers can record model/provider/proof-source fields without retaining raw headers, request bodies, messages, credentials, API keys, tokens, passwords, client secrets, or credential-bearing URLs.
+
+### Fixed
+- **No silent fallback for explicit Hermes model overrides** — unsupported explicit bindings now fail before spawn with actionable diagnostics instead of allowing a child agent to inherit the parent/default model.
+- **Runtime/model proof boundaries documented** — README, command reference, configuration reference, Hermes compatibility docs, PR checklist, and release notes now distinguish resolver proof, workflow handoff, Hermes child-construction proof, provider diagnostics, and live provider wire-level proof.
+
+### Verification
+- `npm run build:sdk`
+- `cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts`
+- `node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs`
+- `npm run test:hermes`
+- `npm test`
+- Hermes Agent targeted pytest/py_compile gates recorded in the Phase 12/13 planning artifacts.
+
 ## [1.4.0] — 2026-04-25
 
 GSD Hermes package version: `1.4.0`
@@ -2218,6 +2241,7 @@ Upstream GSD base: `get-shit-done-cc@1.37.1`
 [1.5.2]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.5.2
 [1.5.1]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.5.1
 [1.5.0]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.5.0
+[1.4.30]: https://github.com/pingchesu/gsd-hermes/releases/tag/v1.4.30
 [1.4.29]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.4.29
 [1.4.28]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.4.28
 [1.4.27]: https://github.com/glittercowboy/get-shit-done/releases/tag/v1.4.27

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **GSD Hermes** is a downstream fork of [get-shit-done-cc](https://github.com/gsd-build/get-shit-done) that adds Hermes Agent runtime support while preserving upstream GSD workflows.
 
-- **Package:** `gsd-hermes@1.4.0`
+- **Package:** `gsd-hermes@1.4.30`
 - **Upstream base:** `upstream/main@cd057255` (25 commits after the v1.3.0 base `0a049149`)
 - **Install:** `npx gsd-hermes --hermes --global`
 
@@ -24,6 +24,19 @@ After install, GSD commands (`/gsd-new-project`, `/gsd-plan-phase`, `/gsd-execut
 
 Compatibility gate: `npm run test:hermes` validates Hermes install modes + SDK query behavior + runtime-model parity + slash command inventory. This gate is the single authoritative Hermes-specific regression signal.
 
+### Hermes runtime model binding receipts
+
+`gsd-hermes@1.4.30` makes per-agent model binding explicit in plan-phase and execute-phase init payloads through `model_binding_receipts`. These receipts show the resolver decision, configured model, resolved runtime token, binding source, Hermes runtime binding channel, and proof boundary for each spawned GSD agent.
+
+Hermes model override semantics are strict: if `.planning/config.json` configures a per-agent model, GSD must either pass that model to the Hermes child construction path or fail before spawn with an actionable diagnostic. Silent fallback to the parent/default model is not acceptable.
+
+Current proof boundary is conservative:
+
+- GSD resolver and workflow receipts prove the configured intent and handoff metadata.
+- Hermes Agent child-construction tests prove `delegate_task(model=...)` and batch `tasks[].model` reach `AIAgent(model=...)`.
+- Safe provider diagnostics expose sanitized model/provider metadata only.
+- Live provider wire-level `model=...` enforcement is not claimed unless captured through future sanitized provider instrumentation.
+
 ## Docs
 
 - [docs/hermes-install.md](docs/hermes-install.md) — Hermes install modes (global, external-dir, macOS canonicalization)
@@ -32,6 +45,7 @@ Compatibility gate: `npm run test:hermes` validates Hermes install modes + SDK q
 - [docs/upstream-sync.md](docs/upstream-sync.md) — Upstream sync workflow + sync-log precedent
 - [docs/sync-logs/2026-04-sync-0a049149.md](docs/sync-logs/2026-04-sync-0a049149.md) — Per-hunk classification for the v1.3 upstream sync
 - [docs/releases/v1.4.0-upstream-sync-cd057255.md](docs/releases/v1.4.0-upstream-sync-cd057255.md) — Release notes for the v1.4 upstream sync package
+- [docs/releases/v1.4.30-runtime-model-binding-receipts.md](docs/releases/v1.4.30-runtime-model-binding-receipts.md) — Release notes for Hermes runtime model binding receipts and fail-fast validation
 
 See [CHANGELOG.md](CHANGELOG.md) for release history.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -6,7 +6,7 @@
 
 ## GSD Hermes v1.4 Release Note
 
-`gsd-hermes@1.4.0` syncs the command surface with upstream `get-shit-done@cd057255` while keeping Hermes command files installable through the downstream package. Upstream-owned Claude/Qwen assets may reference the newer `gsd:<command>` identity, but Hermes-installed commands remain available through the `gsd-<command>` frontmatter names expected by Hermes command discovery.
+`gsd-hermes@1.4.30` keeps the upstream `get-shit-done@cd057255` command surface while adding Hermes runtime model binding receipts and fail-fast validation. Upstream-owned Claude/Qwen assets may reference the newer `gsd:<command>` identity, but Hermes-installed commands remain available through the `gsd-<command>` frontmatter names expected by Hermes command discovery.
 
 ---
 
@@ -233,6 +233,8 @@ Execute all plans in a phase with wave-based parallelization, or run a specific 
 /gsd-execute-phase 1 --validate     # Validate state before execution
 /gsd-execute-phase 2 --cross-ai     # Delegate phase 2 to external AI CLI
 ```
+
+**Hermes runtime model receipts:** On Hermes, execute-phase init payloads include `model_binding_receipts` for executor and verifier agents. These receipts show the configured model, resolved model token, binding source, Hermes binding channel, and proof boundary before dispatch. Explicit per-agent `model_overrides` must either bind through the Hermes child construction path or fail before spawn; execute-phase must not silently fall back to the parent/default model.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -6,7 +6,7 @@
 
 ## GSD Hermes v1.4 Release Note
 
-`gsd-hermes@1.4.0` carries upstream config and SDK query fixes through `upstream/main@cd057255`, including runtime-aware model override propagation, config-schema parity checks, workstream-aware query dispatch, ROADMAP checkbox precedence, and state frontmatter mutation guards. Hermes keeps the downstream default of avoiding silent model fallback: configured model bindings must resolve as configured or fail with actionable diagnostics.
+`gsd-hermes@1.4.30` carries upstream config and SDK query fixes through `upstream/main@cd057255` and adds Hermes runtime model binding receipts, child-construction binding tests, and fail-fast validation for explicit per-agent model overrides. Hermes keeps the downstream default of avoiding silent model fallback: configured model bindings must resolve as configured or fail with actionable diagnostics.
 
 ---
 
@@ -626,16 +626,33 @@ Override specific agents without changing the entire profile:
 
 Valid override values: `opus`, `sonnet`, `haiku`, `inherit`, or any fully-qualified model ID (e.g., `"openai/o3"`, `"google/gemini-2.5-pro"`).
 
+#### Hermes binding receipts and fail-fast semantics
+
+For Hermes installs, `model_overrides` are strict runtime intent, not best-effort hints. Plan-phase and execute-phase init payloads include `model_binding_receipts` for each participating GSD agent. The structured receipt records:
+
+- `agent` — the GSD agent being spawned.
+- `configured_model` — the literal configured value when an override exists.
+- `resolved_model` / legacy `*_model` token — the token GSD intends to hand to the runtime.
+- `source` and `binding` — whether the value came from an explicit override, profile tier, inherit, omit, or runtime default path.
+- `runtime_binding_channel` — the Hermes binding seam, currently direct `delegate_task(model=...)` or batch `tasks[].model` for child construction.
+- `runtime_enforced` / proof metadata — conservative proof status. Child construction proof is distinct from provider wire-level proof.
+
+If an explicit Hermes override cannot be honored by the selected runtime channel, GSD fails before spawning the child and reports the agent, configured model, runtime/channel, and suggested fix. It must not drop the model token and let the child inherit the parent/default model.
+
+Proof boundary: current tests prove GSD resolver behavior, workflow receipt serialization, fail-fast validation, and Hermes child `AIAgent(model=...)` construction. They do not claim live provider wire-level `model=...` enforcement unless future provider instrumentation records sanitized request metadata.
+
 `model_overrides` can be set in either `.planning/config.json` (per-project)
 or `~/.gsd/defaults.json` (global). Per-project entries win on conflict and
 non-conflicting global entries are preserved, so you can tune a single
 agent's model in one repo without re-setting global defaults. This applies
-uniformly across Claude Code, Codex, OpenCode, Kilo, and the other
-supported runtimes. On Codex and OpenCode, the resolved model is embedded
-into each agent's static config at install time — `spawn_agent` and
-OpenCode's `task` interface do not accept an inline `model` parameter, so
-running `gsd install <runtime>` after editing `model_overrides` is required
-for the change to take effect. See issue #2256.
+uniformly across Claude Code, Hermes, Codex, OpenCode, Kilo, and the other
+supported runtimes. On Hermes, explicit per-agent values flow through the
+Hermes child construction channel (`delegate_task(model=...)` or batch
+`tasks[].model`) and are recorded in `model_binding_receipts`. On Codex and
+OpenCode, the resolved model is embedded into each agent's static config at
+install time — `spawn_agent` and OpenCode's `task` interface do not accept an
+inline `model` parameter, so running `gsd install <runtime>` after editing
+`model_overrides` is required for the change to take effect. See issue #2256.
 
 ### Non-Claude Runtimes (Codex, OpenCode, Gemini CLI, Kilo)
 

--- a/docs/hermes-compatibility.md
+++ b/docs/hermes-compatibility.md
@@ -1,6 +1,6 @@
 # Hermes Compatibility and Guardrails
 
-This document makes the current Hermes support boundary explicit after Phase 6.
+This document makes the current Hermes support boundary explicit after Phase 13.
 It should be read alongside [Fork Ownership](./fork-ownership.md),
 [Upstream Sync Workflow](./upstream-sync.md), and
 [Hermes Install](./hermes-install.md) so future runtime work stays inside the
@@ -18,6 +18,7 @@ approved seams.
 | Update / uninstall / doctor | supported | `npm run test:hermes` | Phase 5 complete: global and project-linked lifecycle coverage includes reinstall updates, safe uninstall, read-only doctor diagnostics, and deterministic fixture coverage. |
 | Upstream sync routine | supported maintenance workflow | `npm run test:hermes` plus `npm test` when feasible | Sync review stays anchored to governance docs and merge history from upstream/main so Hermes drift remains visible. |
 | Native local Hermes install mode | out of scope | Documentation and docs tests | Project-linked mode uses skills.external_dirs instead. |
+| Runtime model binding receipts | supported with conservative proof boundary | `npm run test:hermes`, `tests/runtime-model-parity.test.cjs`, SDK init tests | Resolver/workflow receipts and Hermes child-construction proof are supported; live provider wire-level enforcement is not claimed without sanitized provider request evidence. |
 
 ## Runtime-Model Composition
 
@@ -36,6 +37,26 @@ Tracks how the Hermes v1.2 runtime-model adapter composes with upstream #2517 ru
 **SDK/CJS contract asymmetry.** `sdk/src/query/runtime-model-contract.ts::resolveAgentBinding` returns the superset shape with `runtime`, `runtimeCapability`, `crossAiExecutionConfigured`, and `suggestedFix` fields. The CJS adapter (`get-shit-done/bin/lib/model-profiles.cjs::resolveAgentBinding`) returns the v1.1-minimum intersection: `{kind, agent, knownAgent, bindingKind, source, configuredModel, resolvedModel, modelToken, profile, resolveModelIds, rejectionReason?}`. `tests/runtime-model-parity.test.cjs` asserts only the intersection so divergence is controlled and non-breaking.
 
 Validation evidence: `node --test tests/runtime-model-parity.test.cjs` (enrolled in `scripts/validate-hermes-compat.cjs::testFiles[]` during Phase 7 Plan 01; 13 subtests green covering all five binding paths above).
+
+### Runtime Binding Receipt Layers
+
+`model_binding_receipts` appear in plan-phase and execute-phase init payloads. They make model-binding intent and proof boundaries visible before runtime dispatch. They are deliberately more precise than a single yes/no flag: GSD resolver proof, workflow handoff proof, Hermes child-construction proof, and provider wire-level proof are separate layers.
+
+| Layer | Receipt/proof field | Meaning | Proof boundary |
+| --- | --- | --- | --- |
+| Resolver | `resolved_by_gsd` | GSD recognized the agent and resolved the configured model/profile/omit path into a binding token or an explicit rejection. | Proves GSD resolver behavior only. |
+| Workflow handoff | `passed_to_runtime` | GSD has a non-empty explicit token ready for a runtime handoff. | Proves workflow payload construction, not provider use. |
+| Hermes child construction | `runtime_binding_channel`, child construction tests | Hermes receives the intended child model through direct `delegate_task(model=...)` or batch `tasks[].model`. | Proves child `AIAgent(model=...)` construction, not live provider wire-level dispatch. |
+| Provider diagnostics | sanitized provider metadata | Safe metadata can expose provider/model/proof source without raw headers, request bodies, messages, or secrets. | Diagnostic proof only; credentials and raw payloads must never be stored. |
+| Provider wire-level proof | `runtime_enforced` when supported by sanitized request evidence | A provider request or wire-level capture proves the live child request used `model=...`. | Highest-confidence proof; not claimed unless captured safely. |
+
+`runtime_enforced=unknown` is not failure and is not provider proof. It means GSD can show resolver intent, workflow handoff, and possibly Hermes child construction, but it has not captured sanitized provider request evidence proving live provider-side `model=...` dispatch. A subagent self-report is not proof and must not be treated as evidence of enforcement.
+
+Phase 11 selects the canonical direct Hermes binding seam as `delegate_task(model=...)` for single child spawns and `tasks[].model` for batch spawns. `delegation.model` remains a global default/fallback, not a per-agent GSD override channel. ACP `--model` remains transport-specific and is only relevant when ACP subprocess routing is selected. Phase 11 proof stops at child `AIAgent(model=...)` construction; provider request or wire-level `model=...` proof remains a separate provider-instrumentation boundary.
+
+Phase 12 adds fail-fast validation and proof tests: unsupported explicit Hermes bindings fail before spawn with actionable diagnostics, invalid explicit model tokens cannot silently fall back to the parent/default model, and Hermes Agent tests verify that GSD planner/executor overrides reach child `AIAgent(model=...)` construction.
+
+Do not log secrets while collecting receipt evidence. Provider requests or diagnostic captures must redact API keys, tokens, cookies, passwords, authorization headers, client secrets, and credential-bearing URLs. Raw provider headers, request bodies, messages, and connection strings must not be persisted.
 
 ## Known Gaps
 

--- a/docs/npm-publishing.md
+++ b/docs/npm-publishing.md
@@ -8,6 +8,16 @@ Use the `Publish npm` workflow in `.github/workflows/publish-npm.yml`.
 
 The workflow validates the package name and version, runs the test suite, checks the npm tarball with `npm pack --dry-run`, publishes to npm, and verifies that the expected package version is visible in the npm registry.
 
+For the `gsd-hermes@1.4.30` runtime-model-binding release, the local repo selected `1.4.30` because `1.4.0` is already published and local `v1.4.1`–`v1.4.29` tags are present. Before running the release/publish workflow, verify all three collision guards are clear:
+
+```bash
+npm view gsd-hermes@1.4.30 version --json 2>/dev/null || true
+git tag --list v1.4.30
+gh release view v1.4.30 --json tagName,url 2>/dev/null || true
+```
+
+Do not reuse an existing npm version, git tag, or GitHub Release. If any guard reports an existing artifact, pick the next patch version and update `package.json`, `package-lock.json`, CHANGELOG, and `docs/releases/` before publishing.
+
 For the `gsd-hermes@1.4.0` upstream-sync release, use the formal `Release` workflow rather than republishing the already-published `1.3.0` package:
 
 1. Merge release docs and workflow readiness updates to `main`.

--- a/docs/releases/v1.4.30-runtime-model-binding-receipts.md
+++ b/docs/releases/v1.4.30-runtime-model-binding-receipts.md
@@ -1,0 +1,70 @@
+# gsd-hermes v1.4.30 — Hermes Runtime Model Binding Receipts
+
+Release date: 2026-04-26
+Package: `gsd-hermes@1.4.30`
+Upstream GSD base: `upstream/main@cd057255`
+Previous package: `gsd-hermes@1.4.0`
+Tracker: https://github.com/pingchesu/gsd-hermes/issues/32
+
+## Summary
+
+`gsd-hermes@1.4.30` closes the gap between GSD resolver intent and Hermes child-agent runtime construction for per-agent model overrides. GSD now surfaces structured model binding receipts, validates unsupported explicit bindings before spawn, and documents the proof boundary between resolver/workflow metadata, Hermes child construction, safe provider diagnostics, and live provider wire-level enforcement.
+
+This release intentionally remains conservative: it proves Hermes child `AIAgent(model=...)` construction for configured per-agent overrides, but it does not claim provider wire-level `model=...` enforcement unless a future sanitized provider request capture proves it.
+
+## Highlights
+
+- Adds structured `model_binding_receipts` to plan-phase and execute-phase init payloads while keeping legacy flat `*_model` fields for compatibility.
+- Establishes direct `delegate_task(model=...)` and batch `tasks[].model` as the Hermes child binding channels for GSD per-agent overrides.
+- Fails fast when an explicit Hermes model binding cannot be honored, naming the agent, configured model, runtime/channel, and suggested fix.
+- Adds tests proving invalid explicit model tokens cannot silently fall back to parent/default model.
+- Adds Hermes Agent tests proving GSD planner/executor model tokens reach child `AIAgent(model=...)` construction.
+- Adds sanitized provider diagnostics helpers that redact API keys, tokens, passwords, authorization headers, client secrets, and credential-bearing URLs.
+
+## Proof boundary
+
+| Evidence layer | Status in v1.4.30 | Notes |
+| --- | --- | --- |
+| GSD resolver proof | Supported | `model_overrides` and profile/runtime paths serialize into structured receipts. |
+| Workflow handoff proof | Supported | Init payloads display configured/resolved model and binding channel before dispatch. |
+| Hermes child-construction proof | Supported by tests | `delegate_task(model=...)` and `tasks[].model` reach child `AIAgent(model=...)`. |
+| Safe provider diagnostics | Supported helper/test coverage | Only sanitized provider/model/proof metadata is retained. |
+| Live provider wire-level proof | Not claimed | Requires future sanitized provider request instrumentation. |
+
+`runtime_enforced=unknown` means provider wire-level proof has not been captured. It is not permission to silently fall back to the parent/default model.
+
+## User impact
+
+Users who configure `.planning/config.json` with per-agent `model_overrides` on Hermes get clearer behavior:
+
+- A supported explicit override is passed into the Hermes child construction channel and shown in receipts.
+- An unsupported explicit override fails before spawn with actionable diagnostics.
+- A child agent inheriting the parent/default model when an explicit override was configured is considered a bug.
+
+## Verification
+
+Release validation should include:
+
+```bash
+npm run build:sdk
+cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts
+cd ..
+node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs
+npm run test:hermes
+npm test
+npm pack --dry-run
+```
+
+Hermes Agent companion validation:
+
+```bash
+cd /home/whiskey/.hermes/hermes-agent
+.venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py tests/agent/test_provider_diagnostics.py -q
+.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py agent/provider_diagnostics.py agent/redact.py tests/tools/test_delegate.py tests/agent/test_provider_diagnostics.py
+```
+
+## Links
+
+- Tracker issue: https://github.com/pingchesu/gsd-hermes/issues/32
+- Upstream sync release notes: ./v1.4.0-upstream-sync-cd057255.md
+- Hermes compatibility docs: ../hermes-compatibility.md

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 const { loadConfig, resolveModelInternal, findPhaseInternal, getRoadmapPhaseInternal, pathExistsInternal, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, stripShippedMilestones, extractCurrentMilestone, normalizePhaseName, planningPaths, planningDir, planningRoot, toPosixPath, output, error, checkAgentsInstalled, phaseTokenMatches } = require('./core.cjs');
+const { resolveAgentBinding, toBindingReceipt } = require('./model-profiles.cjs');
 
 function getLatestCompletedMilestone(cwd) {
   const milestonesPath = path.join(planningRoot(cwd), 'MILESTONES.md');
@@ -63,6 +64,15 @@ function withProjectRoot(cwd, result) {
   return result;
 }
 
+function buildModelBindingReceipts(workflow, config, specs) {
+  const agents = {};
+  for (const spec of specs) {
+    agents[spec.role] = toBindingReceipt(resolveAgentBinding(config, spec.agent), spec.role);
+  }
+  const runtime = specs.length > 0 ? agents[specs[0].role].runtime : (config.runtime || 'claude');
+  return { workflow, runtime, agents };
+}
+
 function cmdInitExecutePhase(cwd, phase, raw, options = {}) {
   if (!phase) {
     error('phase required for init execute-phase');
@@ -112,6 +122,10 @@ function cmdInitExecutePhase(cwd, phase, raw, options = {}) {
     // Models
     executor_model: resolveModelInternal(cwd, 'gsd-executor', { initContext: true }),
     verifier_model: resolveModelInternal(cwd, 'gsd-verifier', { initContext: true }),
+    model_binding_receipts: buildModelBindingReceipts('execute-phase', config, [
+      { role: 'executor', agent: 'gsd-executor' },
+      { role: 'verifier', agent: 'gsd-verifier' },
+    ]),
 
     // Config flags
     tdd_mode: options.tdd || config.tdd_mode || false,
@@ -246,6 +260,11 @@ function cmdInitPlanPhase(cwd, phase, raw, options = {}) {
     researcher_model: resolveModelInternal(cwd, 'gsd-phase-researcher'),
     planner_model: resolveModelInternal(cwd, 'gsd-planner'),
     checker_model: resolveModelInternal(cwd, 'gsd-plan-checker'),
+    model_binding_receipts: buildModelBindingReceipts('plan-phase', config, [
+      { role: 'researcher', agent: 'gsd-phase-researcher' },
+      { role: 'planner', agent: 'gsd-planner' },
+      { role: 'checker', agent: 'gsd-plan-checker' },
+    ]),
 
     // Workflow flags
     tdd_mode: options.tdd || config.tdd_mode || false,

--- a/get-shit-done/bin/lib/model-profiles.cjs
+++ b/get-shit-done/bin/lib/model-profiles.cjs
@@ -35,6 +35,100 @@ const MODEL_ALIAS_MAP = {
   haiku: 'claude-haiku-4-5',
 };
 
+const SUPPORTED_RUNTIMES = [
+  'claude', 'opencode', 'kilo', 'gemini', 'codex', 'copilot', 'antigravity',
+  'cursor', 'windsurf', 'augment', 'trae', 'qwen', 'codebuddy', 'cline', 'hermes',
+];
+
+const OPENAI_COMPATIBLE_RUNTIMES = ['codex', 'copilot', 'cursor', 'windsurf', 'cline'];
+const GOOGLE_COMPATIBLE_RUNTIMES = ['gemini'];
+const HERMES_MULTI_PROVIDER_RUNTIMES = ['hermes'];
+
+function explicitModelFamiliesForRuntime(runtime) {
+  if (runtime === 'claude') return ['anthropic'];
+  if (OPENAI_COMPATIBLE_RUNTIMES.includes(runtime)) return ['openai'];
+  if (GOOGLE_COMPATIBLE_RUNTIMES.includes(runtime)) return ['google'];
+  if (HERMES_MULTI_PROVIDER_RUNTIMES.includes(runtime)) return ['anthropic', 'openai', 'google', 'unknown'];
+  return ['openai', 'google', 'unknown'];
+}
+
+function runtimeCapability(runtime) {
+  return {
+    runtime,
+    supportsExplicitModel: true,
+    supportsInheritBinding: true,
+    supportsRuntimeDefaultBinding: true,
+    supportsCrossAiExecution: true,
+    explicitModelFamilies: explicitModelFamiliesForRuntime(runtime),
+  };
+}
+
+function isAnthropicModel(model) {
+  return /^(?:claude(?:-|$)|anthropic\/claude-|opus$|sonnet$|haiku$)/i.test(model);
+}
+
+function isOpenAiModel(model) {
+  return /^(?:openai\/|gpt-|o[134](?:$|[-.])|o3(?:$|[-.])|o4(?:$|[-.]))/i.test(model);
+}
+
+function isGoogleModel(model) {
+  return /^(?:gemini(?:$|[-.])|google\/)/i.test(model);
+}
+
+function detectModelFamily(model) {
+  if (!model) return 'unknown';
+  const normalized = String(model).trim();
+  if (!normalized) return 'unknown';
+  if (isAnthropicModel(normalized)) return 'anthropic';
+  if (isOpenAiModel(normalized)) return 'openai';
+  if (isGoogleModel(normalized)) return 'google';
+  return 'unknown';
+}
+
+function runtimeBindingChannelForRuntime(runtime, options = {}) {
+  if (runtime === 'hermes') {
+    const available = options.hermesDelegateModelChannelAvailable !== undefined
+      ? !!options.hermesDelegateModelChannelAvailable
+      : true;
+    return {
+      kind: 'hermes-delegate-task-model',
+      available,
+      proof_level: available ? 'child-construction' : 'none',
+      reason: available ? null : 'Hermes delegate_task.model / tasks[].model binding channel is unavailable.',
+      suggested_fix: available
+        ? null
+        : 'Upgrade or restart Hermes Agent with delegate_task.model / tasks[].model support, set the override to inherit, remove the explicit model_overrides entry, or use explicit cross-AI execution.',
+    };
+  }
+
+  const capability = runtimeCapability(runtime);
+  if (capability.supportsExplicitModel) {
+    return {
+      kind: 'runtime-native-model-parameter',
+      available: true,
+      proof_level: 'runtime-dispatch',
+      reason: null,
+      suggested_fix: null,
+    };
+  }
+
+  return {
+    kind: 'none',
+    available: false,
+    proof_level: 'none',
+    reason: `Runtime '${runtime}' does not expose an explicit model binding channel.`,
+    suggested_fix: 'Use inherit/runtime-default binding or route through a runtime with explicit model support.',
+  };
+}
+
+function detectRuntime(config = {}) {
+  const envValue = process.env.GSD_RUNTIME;
+  if (envValue && SUPPORTED_RUNTIMES.includes(envValue)) return envValue;
+  const configValue = config.runtime;
+  if (typeof configValue === 'string' && SUPPORTED_RUNTIMES.includes(configValue)) return configValue;
+  return 'claude';
+}
+
 function normalizeModelProfile(profile) {
   const normalized = typeof profile === 'string' ? profile.toLowerCase().trim() : '';
   return ACCEPTED_MODEL_PROFILES.includes(normalized) ? normalized : 'balanced';
@@ -63,7 +157,7 @@ function toResolvedModelValue(model, resolveModelIds) {
   return model;
 }
 
-function resolveAgentBinding(config = {}, agent) {
+function resolveAgentBindingBase(config = {}, agent) {
   const profile = normalizeModelProfile(config.model_profile);
   const resolveModelIds = resolveModelIdsSetting(config);
   const overrides = normalizeOverrides(config.model_overrides);
@@ -197,6 +291,214 @@ function resolveAgentBinding(config = {}, agent) {
   };
 }
 
+function suggestedFixFor(resolution) {
+  if (!resolution || resolution.kind === 'unsupported') {
+    if (resolution && resolution.bindingKind === 'runtime-default') {
+      return 'Use a supported agent with contract coverage before depending on runtime-default binding.';
+    }
+    return 'Use a supported agent with contract coverage or add explicit Phase 5 contract coverage before execution.';
+  }
+  if (resolution.bindingKind === 'explicit') {
+    return 'Adjust model_overrides for this agent or remove the override to use profile/runtime defaults.';
+  }
+  if (resolution.bindingKind === 'inherit') {
+    return resolution.source === 'override'
+      ? 'Remove the inherit override to fall back to profile-based resolution.'
+      : 'Set model_profile to a tiered profile or add model_overrides if a literal model token is required.';
+  }
+  if (resolution.bindingKind === 'runtime-default') {
+    return 'Set model_overrides for this agent if you need an explicit model token.';
+  }
+  return 'Choose a different model_profile or add model_overrides for this agent.';
+}
+
+function messageFor(resolution) {
+  if (!resolution || resolution.kind !== 'unsupported') return undefined;
+  if (resolution.bindingKind === 'runtime-default') {
+    return `Runtime-default binding was requested for unknown agent '${resolution.agent}'.`;
+  }
+  return `No runtime-model contract coverage exists for agent '${resolution.agent}'.`;
+}
+
+function resolveConfiguredCrossAiExecution(config = {}) {
+  const workflow = config.workflow;
+  return !!workflow && typeof workflow === 'object' && !Array.isArray(workflow)
+    && workflow.cross_ai_execution === true;
+}
+
+function resolveAgentBinding(config = {}, agent) {
+  const resolution = resolveAgentBindingBase(config, agent);
+  const runtime = detectRuntime(config);
+  return {
+    ...resolution,
+    runtime,
+    runtimeCapability: runtimeCapability(runtime),
+    crossAiExecutionConfigured: resolveConfiguredCrossAiExecution(config),
+    suggestedFix: suggestedFixFor(resolution),
+    ...(resolution.kind === 'unsupported' ? { message: messageFor(resolution) } : {}),
+  };
+}
+
+function buildBindingValidationIssue(binding, rejectionReason, reason) {
+  const crossAiExecutionSupported = !!(binding.runtimeCapability && binding.runtimeCapability.supportsCrossAiExecution);
+  const crossAiExecutionRecommended = rejectionReason === 'runtime-model-unsupported' && crossAiExecutionSupported;
+  return {
+    agent: binding.agent,
+    runtime: binding.runtime,
+    bindingKind: binding.bindingKind,
+    source: binding.source,
+    configuredModel: binding.configuredModel,
+    resolvedModel: binding.resolvedModel,
+    rejectionReason,
+    reason,
+    suggestedFix: rejectionReason === 'missing-runtime-binding-channel' && binding.runtime === 'hermes'
+      ? 'Upgrade or restart Hermes Agent with delegate_task.model / tasks[].model support, set the override to inherit, remove the explicit model_overrides entry, or use explicit cross-AI execution.'
+      : binding.suggestedFix || suggestedFixFor(binding),
+    crossAiExecutionSupported,
+    crossAiExecutionConfigured: !!binding.crossAiExecutionConfigured,
+    crossAiExecutionRecommended,
+    crossAiExecutionSuggestion: crossAiExecutionSupported
+      ? (crossAiExecutionRecommended
+          ? `Use workflow.cross_ai_execution as an explicit cross-provider path if you want this binding executed outside the active runtime; workflow.cross_ai_execution is ${binding.crossAiExecutionConfigured ? 'already enabled' : 'currently disabled'}.`
+          : `cross_ai_execution is available for this runtime; workflow.cross_ai_execution is ${binding.crossAiExecutionConfigured ? 'already enabled' : 'currently disabled'}.`)
+      : null,
+    availableAlternative: crossAiExecutionRecommended ? 'cross_ai_execution' : null,
+  };
+}
+
+function validateResolvedAgentBinding(binding, options = {}) {
+  if (binding.kind === 'unsupported') {
+    return {
+      ok: false,
+      agent: binding.agent,
+      runtime: binding.runtime,
+      bindingKind: binding.bindingKind,
+      source: binding.source,
+      configuredModel: binding.configuredModel,
+      resolvedModel: binding.resolvedModel,
+      issue: buildBindingValidationIssue(binding, binding.rejectionReason, binding.message || messageFor(binding)),
+      binding,
+    };
+  }
+
+  if (binding.bindingKind === 'inherit' || binding.bindingKind === 'runtime-default') {
+    return {
+      ok: true,
+      agent: binding.agent,
+      runtime: binding.runtime,
+      bindingKind: binding.bindingKind,
+      source: binding.source,
+      configuredModel: binding.configuredModel,
+      resolvedModel: binding.resolvedModel,
+      issue: null,
+      binding,
+    };
+  }
+
+  if (binding.runtime === 'hermes' && binding.bindingKind === 'explicit') {
+    const channel = runtimeBindingChannelForRuntime(binding.runtime, options);
+    if (!channel.available) {
+      return {
+        ok: false,
+        agent: binding.agent,
+        runtime: binding.runtime,
+        bindingKind: binding.bindingKind,
+        source: binding.source,
+        configuredModel: binding.configuredModel,
+        resolvedModel: binding.resolvedModel,
+        issue: buildBindingValidationIssue(
+          binding,
+          'missing-runtime-binding-channel',
+          channel.reason || 'Hermes delegate_task.model / tasks[].model binding channel is unavailable'
+        ),
+        binding,
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    agent: binding.agent,
+    runtime: binding.runtime,
+    bindingKind: binding.bindingKind,
+    source: binding.source,
+    configuredModel: binding.configuredModel,
+    resolvedModel: binding.resolvedModel,
+    issue: null,
+    binding,
+  };
+}
+
+function validateAgentBinding(config = {}, agent, options = {}) {
+  return validateResolvedAgentBinding(resolveAgentBinding(config, agent), options);
+}
+
+function validateAgentBindings(config = {}, agents = [], options = {}) {
+  const results = agents.map((agent) => validateAgentBinding(config, agent, options));
+  const issues = results.flatMap((result) => result.issue ? [result.issue] : []);
+  const runtime = results[0] ? results[0].runtime : detectRuntime(config);
+  return { ok: issues.length === 0, runtime, agents, results, issues };
+}
+
+function serializeRuntimeModelResolution(resolution) {
+  const base = {
+    agent: resolution.agent,
+    status: resolution.kind,
+    known_agent: resolution.knownAgent,
+    runtime: resolution.runtime || 'claude',
+    profile: resolution.profile,
+    binding_kind: resolution.bindingKind,
+    source: resolution.source,
+    configured_model: resolution.configuredModel,
+    resolved_model: resolution.resolvedModel,
+    model_token: resolution.modelToken,
+    resolve_model_ids: resolution.resolveModelIds,
+    suggested_fix: resolution.suggestedFix || suggestedFixFor(resolution),
+    cross_ai: {
+      execution_supported: !!(resolution.runtimeCapability && resolution.runtimeCapability.supportsCrossAiExecution),
+      execution_configured: !!resolution.crossAiExecutionConfigured,
+    },
+    runtime_capability: {
+      supports_explicit_model: !!(resolution.runtimeCapability && resolution.runtimeCapability.supportsExplicitModel),
+      supports_inherit_binding: !!(resolution.runtimeCapability && resolution.runtimeCapability.supportsInheritBinding),
+      supports_runtime_default_binding: !!(resolution.runtimeCapability && resolution.runtimeCapability.supportsRuntimeDefaultBinding),
+    },
+  };
+
+  if (resolution.kind === 'unsupported') {
+    return {
+      ...base,
+      rejection_reason: resolution.rejectionReason,
+      message: resolution.message || messageFor(resolution),
+    };
+  }
+
+  return base;
+}
+
+function receiptEnforceability(resolution) {
+  if (resolution.kind === 'unsupported') return 'unsupported';
+  if (resolution.bindingKind === 'explicit' && !!resolution.modelToken) {
+    return 'explicit-token-needs-runtime-proof';
+  }
+  return 'inherits-or-runtime-default';
+}
+
+function toBindingReceipt(resolution, role) {
+  const serialized = serializeRuntimeModelResolution(resolution);
+  const providerModel = resolution.modelToken || resolution.resolvedModel || resolution.configuredModel;
+  return {
+    ...serialized,
+    role,
+    provider_family: detectModelFamily(providerModel),
+    resolved_by_gsd: resolution.kind === 'resolved',
+    passed_to_runtime: resolution.kind === 'resolved' && !!resolution.modelToken,
+    runtime_enforced: 'unknown',
+    enforceability: receiptEnforceability(resolution),
+    runtime_binding_channel: runtimeBindingChannelForRuntime(resolution.runtime || 'claude'),
+  };
+}
+
 function toLegacyModelToken(resolution, fallback = '') {
   if (!resolution || resolution.kind !== 'resolved') return fallback;
   if (resolution.bindingKind === 'inherit' || resolution.resolvedModel === 'inherit') return 'inherit';
@@ -257,6 +559,12 @@ module.exports = {
   getAgentToModelMapForProfile,
   normalizeModelProfile,
   resolveAgentBinding,
+  runtimeBindingChannelForRuntime,
+  validateAgentBinding,
+  validateAgentBindings,
+  validateResolvedAgentBinding,
+  serializeRuntimeModelResolution,
+  toBindingReceipt,
   toLegacyModelToken,
   toInitModelToken,
 };

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -74,7 +74,17 @@ if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 AGENT_SKILLS=$(gsd-sdk query agent-skills gsd-executor)
 ```
 
-Parse JSON for: `executor_model`, `verifier_model`, `commit_docs`, `parallelization`, `branching_strategy`, `branch_name`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `plans`, `incomplete_plans`, `plan_count`, `incomplete_count`, `state_exists`, `roadmap_exists`, `phase_req_ids`, `response_language`.
+Parse JSON for: `executor_model`, `verifier_model`, `model_binding_receipts`, `commit_docs`, `parallelization`, `branching_strategy`, `branch_name`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `plans`, `incomplete_plans`, `plan_count`, `incomplete_count`, `state_exists`, `roadmap_exists`, `phase_req_ids`, `response_language`.
+
+**Display runtime/model binding receipt before executor/verifier Task dispatch and before cross-AI fallback decisions.** Render `model_binding_receipts` concisely so the transcript shows GSD resolver intent and the proof boundary:
+
+```text
+## Runtime/model binding receipt — workflow={model_binding_receipts.workflow} runtime={model_binding_receipts.runtime}
+- executor / gsd-executor: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
+- verifier / gsd-verifier: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
+Note: runtime_enforced=unknown is not provider proof. For Hermes, runtime_binding_channel.kind=hermes-delegate-task-model with proof_level=child-construction means pass explicit tokens via delegate_task(model=...) or tasks[].model; if unavailable, stop on the pre-spawn validation error instead of spawning.
+```
+Keep existing `executor_model === "inherit"` semantics: omit `model=` when inherit/empty. Under Hermes, explicit executor/verifier tokens map to delegate_task model fields, not provider wire-level proof.
 
 **Model resolution:** If `executor_model` is `"inherit"`, omit the `model=` parameter from all `Task()` calls — do NOT pass `model="inherit"` to Task. Omitting the `model=` parameter causes Claude Code to inherit the current orchestrator model automatically. Only set `model=` when `executor_model` is an explicit model name (e.g., `"claude-sonnet-4-6"`, `"claude-opus-4-7"`).
 

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -46,7 +46,22 @@ When `TDD_MODE` is `true`, the planner agent is instructed to apply `type: tdd` 
 
 When `CONTEXT_WINDOW >= 500000`, the planner prompt includes the 3 most recent prior phase CONTEXT.md and SUMMARY.md files PLUS any phases explicitly listed in the current phase's `Depends on:` field in ROADMAP.md. Explicit dependencies always load regardless of recency (e.g., Phase 7 declaring `Depends on: Phase 2` always sees Phase 2's context). Bounded recency keeps the planner's context budget focused on recent work.
 
-Parse JSON for: `researcher_model`, `planner_model`, `checker_model`, `research_enabled`, `plan_checker_enabled`, `nyquist_validation_enabled`, `commit_docs`, `text_mode`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_reviews`, `has_plans`, `plan_count`, `planning_exists`, `roadmap_exists`, `phase_req_ids`, `response_language`.
+Parse JSON for: `researcher_model`, `planner_model`, `checker_model`, `model_binding_receipts`, `research_enabled`, `plan_checker_enabled`, `nyquist_validation_enabled`, `commit_docs`, `text_mode`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_reviews`, `has_plans`, `plan_count`, `planning_exists`, `roadmap_exists`, `phase_req_ids`, `response_language`.
+
+**Display runtime/model binding receipt before any researcher/planner/checker Task dispatch.** Render `model_binding_receipts` concisely so the transcript shows the GSD resolver intent and the current proof boundary:
+
+```text
+## Runtime/model binding receipt
+Workflow: {model_binding_receipts.workflow}
+Runtime: {model_binding_receipts.runtime}
+- researcher / gsd-phase-researcher: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
+- planner / gsd-planner: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
+- checker / gsd-plan-checker: configured={configured_model} resolved={resolved_model} token={model_token} source={source} binding={binding_kind} provider={provider_family} resolved_by_gsd={resolved_by_gsd} passed_to_runtime={passed_to_runtime} runtime_enforced={runtime_enforced}
+
+Note: runtime_enforced=unknown is not provider proof. For Hermes, runtime_binding_channel.kind=hermes-delegate-task-model with proof_level=child-construction means pass explicit tokens via delegate_task(model=...) or tasks[].model; if unavailable, stop on the pre-spawn validation error instead of spawning.
+```
+
+Keep using the flat `researcher_model`, `planner_model`, and `checker_model` fields for existing model-argument behavior; under Hermes these map to delegate_task model fields, not provider wire-level proof.
 
 **If `response_language` is set:** Include `response_language: {value}` in all spawned subagent prompts so any user-facing output stays in the configured language.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.4.0",
+  "version": "1.4.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.4.0",
+      "version": "1.4.30",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.4.0",
+  "version": "1.4.30",
   "description": "A get-shit-done fork that adds Hermes Agent runtime support while preserving upstream GSD workflows.",
   "bin": {
     "gsd-hermes": "bin/install.js",

--- a/scripts/verify-fork-identity.cjs
+++ b/scripts/verify-fork-identity.cjs
@@ -13,11 +13,11 @@ assert.ok(pkg.bin && pkg.bin['gsd-hermes'] === 'bin/install.js',
 assert.ok(pkg.bin['get-shit-done-cc'] === 'bin/install.js',
   'bin.get-shit-done-cc must still map to bin/install.js (upstream parity bin)');
 
-// Version is on downstream semver line (NOT upstream 1.38.x or 1.39.x)
-// Phase 6 accepts 1.2.x (pre-release-metadata) OR 1.3.x (post-release-metadata)
+// Version is on the downstream semver line (NOT upstream 1.38.x or 1.39.x).
+// gsd-hermes started at 1.2.x and advances by downstream minor releases (1.3.x, 1.4.x, ...).
 const version = pkg.version;
-assert.ok(/^1\.(2|3)\.\d+/.test(version),
-  `package.json version must be on gsd-hermes 1.2.x or 1.3.x line, got '${version}'`);
+assert.ok(/^1\.([2-9]|[1-9]\d+)\.\d+/.test(version),
+  `package.json version must be on gsd-hermes 1.2.x+ downstream line, got '${version}'`);
 assert.ok(!/^1\.3[89]\./.test(version),
   `package.json version must NOT be on upstream 1.38.x/1.39.x line (identity drift); got '${version}'`);
 

--- a/sdk/src/query/config-query.test.ts
+++ b/sdk/src/query/config-query.test.ts
@@ -128,6 +128,80 @@ describe('runtime-model contract', () => {
     expect(result.rejectionReason).toBe('unknown-agent');
     expect(result.suggestedFix).toContain('supported agent');
   });
+
+  it('projects explicit override bindings into runtime/model receipts with separated truth fields', async () => {
+    const { resolveAgentBinding, toRuntimeModelReceipt } = await import('./runtime-model-contract.js');
+    const resolution = resolveAgentBinding({
+      runtime: 'hermes',
+      model_profile: 'inherit',
+      resolve_model_ids: 'omit',
+      model_overrides: { 'gsd-planner': 'openai/gpt-5.4' },
+      workflow: {},
+    }, 'gsd-planner');
+
+    const receipt = toRuntimeModelReceipt(resolution, 'planner');
+
+    expect(receipt).toMatchObject({
+      role: 'planner',
+      agent: 'gsd-planner',
+      runtime: 'hermes',
+      profile: 'inherit',
+      binding_kind: 'explicit',
+      source: 'override',
+      configured_model: 'openai/gpt-5.4',
+      resolved_model: 'openai/gpt-5.4',
+      model_token: 'openai/gpt-5.4',
+      provider_family: 'openai',
+      known_agent: true,
+      resolved_by_gsd: true,
+      passed_to_runtime: true,
+      runtime_enforced: 'unknown',
+      enforceability: 'explicit-token-needs-runtime-proof',
+    });
+  });
+
+  it('projects runtime-default bindings as resolved by GSD but not passed to runtime', async () => {
+    const { resolveAgentBinding, toRuntimeModelReceipt } = await import('./runtime-model-contract.js');
+    const resolution = resolveAgentBinding({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      resolve_model_ids: 'omit',
+      workflow: {},
+    }, 'gsd-verifier');
+
+    const receipt = toRuntimeModelReceipt(resolution, 'verifier');
+
+    expect(receipt.resolved_by_gsd).toBe(true);
+    expect(receipt.passed_to_runtime).toBe(false);
+    expect(receipt.runtime_enforced).toBe('unknown');
+    expect(receipt.enforceability).toBe('inherits-or-runtime-default');
+    expect(receipt.model_token).toBeNull();
+    expect(receipt.provider_family).toBe('unknown');
+  });
+
+  it('projects unsupported unknown-agent bindings with actionable diagnostics', async () => {
+    const { resolveAgentBinding, toRuntimeModelReceipt } = await import('./runtime-model-contract.js');
+    const resolution = resolveAgentBinding({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      workflow: {},
+    }, 'unknown-agent');
+
+    const receipt = toRuntimeModelReceipt(resolution, 'mystery');
+
+    expect(receipt).toMatchObject({
+      role: 'mystery',
+      agent: 'unknown-agent',
+      known_agent: false,
+      resolved_by_gsd: false,
+      passed_to_runtime: false,
+      runtime_enforced: 'unknown',
+      enforceability: 'unsupported',
+      rejection_reason: 'unknown-agent',
+    });
+    expect(receipt.message).toContain('unknown-agent');
+    expect(receipt.suggested_fix).toContain('supported agent');
+  });
 });
 
 describe('strict runtime-model validation', () => {

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -26,6 +26,7 @@ import {
   initRemoveWorkspace,
   initIngestDocs,
 } from './init.js';
+import { validateAgentBinding } from './runtime-model-validation.js';
 
 let tmpDir: string;
 
@@ -318,6 +319,23 @@ describe('initExecutePhase', () => {
     expect(data.phase_found).toBe(true);
     expect(data.phase_number).toBe('09');
     expect(data.executor_model).toBeDefined();
+    expect(data.verifier_model).toBeDefined();
+    const receipts = data.model_binding_receipts as {
+      workflow: string;
+      runtime: string;
+      agents: Record<string, Record<string, unknown>>;
+    };
+    expect(receipts.workflow).toBe('execute-phase');
+    expect(receipts.runtime).toBeDefined();
+    expect(receipts.agents.executor.agent).toBe('gsd-executor');
+    expect(receipts.agents.verifier.agent).toBe('gsd-verifier');
+    for (const role of ['executor', 'verifier']) {
+      expect(receipts.agents[role].role).toBe(role);
+      expect(receipts.agents[role]).toHaveProperty('resolved_by_gsd');
+      expect(receipts.agents[role]).toHaveProperty('passed_to_runtime');
+      expect(receipts.agents[role]).toHaveProperty('runtime_enforced');
+      expect(receipts.agents[role]).toHaveProperty('runtime_binding_channel');
+    }
     expect(data.commit_docs).toBeDefined();
     expect(data.project_root).toBe(tmpDir);
     expect(data.plans).toBeDefined();
@@ -340,6 +358,23 @@ describe('initPlanPhase', () => {
     expect(data.researcher_model).toBeDefined();
     expect(data.planner_model).toBeDefined();
     expect(data.checker_model).toBeDefined();
+    const receipts = data.model_binding_receipts as {
+      workflow: string;
+      runtime: string;
+      agents: Record<string, Record<string, unknown>>;
+    };
+    expect(receipts.workflow).toBe('plan-phase');
+    expect(receipts.runtime).toBeDefined();
+    expect(receipts.agents.researcher.agent).toBe('gsd-phase-researcher');
+    expect(receipts.agents.planner.agent).toBe('gsd-planner');
+    expect(receipts.agents.checker.agent).toBe('gsd-plan-checker');
+    for (const role of ['researcher', 'planner', 'checker']) {
+      expect(receipts.agents[role].role).toBe(role);
+      expect(receipts.agents[role]).toHaveProperty('resolved_by_gsd');
+      expect(receipts.agents[role]).toHaveProperty('passed_to_runtime');
+      expect(receipts.agents[role]).toHaveProperty('runtime_enforced');
+      expect(receipts.agents[role]).toHaveProperty('runtime_binding_channel');
+    }
     expect(data.research_enabled).toBeDefined();
     expect(data.has_research).toBe(true);
     expect(data.has_context).toBe(true);
@@ -350,6 +385,116 @@ describe('initPlanPhase', () => {
     const result = await initPlanPhase([], tmpDir);
     const data = result.data as Record<string, unknown>;
     expect(data.error).toBeDefined();
+  });
+});
+
+describe('Hermes runtime model binding channel', () => {
+  it('marks Hermes receipts with delegate_task child-construction channel metadata', async () => {
+    await writeFile(join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+    }));
+
+    const result = await initPlanPhase(['9'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    const receipts = data.model_binding_receipts as {
+      agents: Record<string, Record<string, unknown>>;
+    };
+    const plannerReceipt = receipts.agents.planner;
+
+    expect(plannerReceipt.model_token).toBe('openai/o4-mini');
+    expect(plannerReceipt.runtime_enforced).toBe('unknown');
+    expect(plannerReceipt.runtime_binding_channel).toEqual({
+      kind: 'hermes-delegate-task-model',
+      available: true,
+      proof_level: 'child-construction',
+      reason: null,
+      suggested_fix: null,
+    });
+  });
+
+  it('fails fast for explicit Hermes overrides when delegate model channel is unavailable', () => {
+    const result = validateAgentBinding(
+      {
+        runtime: 'hermes',
+        model_profile: 'balanced',
+        model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+      },
+      'gsd-planner',
+      { hermesDelegateModelChannelAvailable: false },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.issue).toMatchObject({
+      agent: 'gsd-planner',
+      runtime: 'hermes',
+      configuredModel: 'openai/o4-mini',
+      resolvedModel: 'openai/o4-mini',
+      bindingKind: 'explicit',
+      source: 'override',
+      rejectionReason: 'missing-runtime-binding-channel',
+      crossAiExecutionSupported: true,
+      crossAiExecutionConfigured: false,
+    });
+    expect(result.issue?.reason).toContain('delegate_task.model / tasks[].model');
+    expect(result.issue?.suggestedFix).toContain('Upgrade or restart Hermes Agent');
+  });
+
+  it('does not fail inherit or runtime-default bindings when Hermes delegate channel is unavailable', () => {
+    const inherit = validateAgentBinding(
+      { runtime: 'hermes', model_overrides: { 'gsd-planner': 'inherit' } },
+      'gsd-planner',
+      { hermesDelegateModelChannelAvailable: false },
+    );
+    const runtimeDefault = validateAgentBinding(
+      { runtime: 'hermes', resolve_model_ids: 'omit' },
+      'gsd-planner',
+      { hermesDelegateModelChannelAvailable: false },
+    );
+
+    expect(inherit.ok).toBe(true);
+    expect(inherit.issue).toBeNull();
+    expect(inherit.bindingKind).toBe('inherit');
+    expect(runtimeDefault.ok).toBe(true);
+    expect(runtimeDefault.issue).toBeNull();
+    expect(runtimeDefault.bindingKind).toBe('runtime-default');
+  });
+
+  it('preserves invalid explicit model tokens instead of silently inheriting defaults', () => {
+    const invalidModel = 'definitely-not-a-real-model-gsd-binding-test';
+    const result = validateAgentBinding(
+      {
+        runtime: 'hermes',
+        model_profile: 'balanced',
+        model_overrides: { 'gsd-planner': invalidModel },
+      },
+      'gsd-planner',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.configuredModel).toBe(invalidModel);
+    expect(result.resolvedModel).toBe(invalidModel);
+    expect(result.binding.modelToken).toBe(invalidModel);
+    expect(result.bindingKind).toBe('explicit');
+  });
+
+  it('represents explicit cross-AI execution as configured metadata, not silent fallback', () => {
+    const result = validateAgentBinding(
+      {
+        runtime: 'hermes',
+        model_profile: 'balanced',
+        workflow: { cross_ai_execution: true },
+        model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+      },
+      'gsd-planner',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.binding.crossAiExecutionConfigured).toBe(true);
+    expect(result.binding.runtimeCapability.supportsCrossAiExecution).toBe(true);
+    expect(result.bindingKind).toBe('explicit');
+    expect(result.source).toBe('override');
   });
 });
 

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -25,6 +25,7 @@ import { homedir } from 'node:os';
 
 import { loadConfig, type GSDConfig } from '../config.js';
 import { resolveModel, MODEL_PROFILES } from './config-query.js';
+import { resolveAgentBinding, toRuntimeModelReceipt, type RuntimeModelReceipt } from './runtime-model-contract.js';
 import { findPhase } from './phase.js';
 import { roadmapGetPhase, getMilestoneInfo, extractCurrentMilestone, extractPhasesFromSection } from './roadmap.js';
 import { planningPaths, normalizePhaseName, toPosixPath, resolveAgentsDir, detectRuntime } from './helpers.js';
@@ -40,6 +41,24 @@ async function getModelAlias(agentType: string, projectDir: string): Promise<str
   const result = await resolveModel([agentType], projectDir);
   const data = result.data as Record<string, unknown>;
   return (data.model as string) || 'sonnet';
+}
+
+interface ReceiptSpec {
+  role: string;
+  agent: string;
+}
+
+function buildModelBindingReceipts(
+  workflow: string,
+  config: GSDConfig,
+  specs: ReceiptSpec[],
+): { workflow: string; runtime: string; agents: Record<string, RuntimeModelReceipt> } {
+  const agents: Record<string, RuntimeModelReceipt> = {};
+  for (const spec of specs) {
+    agents[spec.role] = toRuntimeModelReceipt(resolveAgentBinding(config, spec.agent), spec.role);
+  }
+  const runtime = specs.length > 0 ? agents[specs[0].role].runtime : detectRuntime(config);
+  return { workflow, runtime, agents };
 }
 
 /**
@@ -295,6 +314,10 @@ export const initExecutePhase: QueryHandler = async (args, projectDir, workstrea
   const result: Record<string, unknown> = {
     executor_model: executorModel,
     verifier_model: verifierModel,
+    model_binding_receipts: buildModelBindingReceipts('execute-phase', config, [
+      { role: 'executor', agent: 'gsd-executor' },
+      { role: 'verifier', agent: 'gsd-verifier' },
+    ]),
     tdd_mode: config.workflow.tdd_mode ?? false,
     commit_docs: config.commit_docs,
     sub_repos: (config as Record<string, unknown>).sub_repos ?? [],
@@ -371,6 +394,11 @@ export const initPlanPhase: QueryHandler = async (args, projectDir, workstream) 
     researcher_model: researcherModel,
     planner_model: plannerModel,
     checker_model: checkerModel,
+    model_binding_receipts: buildModelBindingReceipts('plan-phase', config, [
+      { role: 'researcher', agent: 'gsd-phase-researcher' },
+      { role: 'planner', agent: 'gsd-planner' },
+      { role: 'checker', agent: 'gsd-plan-checker' },
+    ]),
     tdd_mode: config.workflow.tdd_mode ?? false,
     research_enabled: config.workflow.research,
     plan_checker_enabled: config.workflow.plan_check,

--- a/sdk/src/query/runtime-model-contract.ts
+++ b/sdk/src/query/runtime-model-contract.ts
@@ -42,7 +42,7 @@ export type AcceptedModelProfile = (typeof ACCEPTED_MODEL_PROFILES)[number];
 
 export type BindingKind = 'explicit' | 'profile' | 'inherit' | 'runtime-default';
 export type BindingSource = 'override' | 'profile' | 'inherit-profile' | 'resolve-model-omit';
-export type RejectionReason = 'unknown-agent' | 'missing-contract-coverage' | 'runtime-model-unsupported';
+export type RejectionReason = 'unknown-agent' | 'missing-contract-coverage' | 'runtime-model-unsupported' | 'missing-runtime-binding-channel';
 export type ModelFamily = 'anthropic' | 'openai' | 'google' | 'unknown';
 
 export interface RuntimeCapability {
@@ -136,6 +136,33 @@ export interface SerializedRuntimeModelResolution {
   message?: string;
 }
 
+export type RuntimeEnforcementStatus = 'unknown' | boolean;
+export type RuntimeBindingChannelKind = 'hermes-delegate-task-model' | 'runtime-native-model-parameter' | 'none';
+export type RuntimeBindingChannelProofLevel = 'child-construction' | 'runtime-dispatch' | 'none';
+
+export interface RuntimeBindingChannel {
+  kind: RuntimeBindingChannelKind;
+  available: boolean;
+  proof_level: RuntimeBindingChannelProofLevel;
+  reason: string | null;
+  suggested_fix: string | null;
+}
+
+export type RuntimeModelReceiptEnforceability =
+  | 'explicit-token-needs-runtime-proof'
+  | 'inherits-or-runtime-default'
+  | 'unsupported';
+
+export interface RuntimeModelReceipt extends SerializedRuntimeModelResolution {
+  role: string;
+  provider_family: ModelFamily;
+  resolved_by_gsd: boolean;
+  passed_to_runtime: boolean;
+  runtime_enforced: RuntimeEnforcementStatus;
+  enforceability: RuntimeModelReceiptEnforceability;
+  runtime_binding_channel: RuntimeBindingChannel;
+}
+
 export const MODEL_ALIAS_MAP: Record<string, string> = {
   opus: 'claude-opus-4-6',
   sonnet: 'claude-sonnet-4-6',
@@ -206,6 +233,44 @@ export function evaluateRuntimeModelCompatibility(runtime: Runtime, model: strin
 
   return { supported: true, runtime, model, family, reason: null };
 }
+
+export function runtimeBindingChannelForRuntime(
+  runtime: Runtime,
+  options: { hermesDelegateModelChannelAvailable?: boolean } = {},
+): RuntimeBindingChannel {
+  if (runtime === 'hermes') {
+    const available = options.hermesDelegateModelChannelAvailable ?? true;
+    return {
+      kind: 'hermes-delegate-task-model',
+      available,
+      proof_level: available ? 'child-construction' : 'none',
+      reason: available ? null : 'Hermes delegate_task.model / tasks[].model binding channel is unavailable.',
+      suggested_fix: available
+        ? null
+        : 'Upgrade or restart Hermes Agent with delegate_task.model / tasks[].model support, set the override to inherit, remove the explicit model_overrides entry, or use explicit cross-AI execution.',
+    };
+  }
+
+  const capability = RUNTIME_CAPABILITIES[runtime];
+  if (capability.supportsExplicitModel) {
+    return {
+      kind: 'runtime-native-model-parameter',
+      available: true,
+      proof_level: 'runtime-dispatch',
+      reason: null,
+      suggested_fix: null,
+    };
+  }
+
+  return {
+    kind: 'none',
+    available: false,
+    proof_level: 'none',
+    reason: `Runtime '${runtime}' does not expose an explicit model binding channel.`,
+    suggested_fix: 'Use inherit/runtime-default binding or route through a runtime with explicit model support.',
+  };
+}
+
 
 function normalizeString(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -509,6 +574,32 @@ export function serializeRuntimeModelResolution(resolution: RuntimeModelResoluti
   }
 
   return base;
+}
+
+function receiptEnforceability(resolution: RuntimeModelResolution): RuntimeModelReceiptEnforceability {
+  if (resolution.kind === 'unsupported') return 'unsupported';
+  if (resolution.bindingKind === 'explicit' && !!resolution.modelToken) {
+    return 'explicit-token-needs-runtime-proof';
+  }
+  return 'inherits-or-runtime-default';
+}
+
+export function toRuntimeModelReceipt(
+  resolution: RuntimeModelResolution,
+  role: string,
+): RuntimeModelReceipt {
+  const serialized = serializeRuntimeModelResolution(resolution);
+  const providerModel = resolution.modelToken ?? resolution.resolvedModel ?? resolution.configuredModel;
+  return {
+    ...serialized,
+    role,
+    provider_family: detectModelFamily(providerModel),
+    resolved_by_gsd: resolution.kind === 'resolved',
+    passed_to_runtime: resolution.kind === 'resolved' && !!resolution.modelToken,
+    runtime_enforced: 'unknown',
+    enforceability: receiptEnforceability(resolution),
+    runtime_binding_channel: runtimeBindingChannelForRuntime(resolution.runtime),
+  };
 }
 
 export function toLegacyModelToken(resolution: RuntimeModelResolution, fallback = ''): string {

--- a/sdk/src/query/runtime-model-validation.ts
+++ b/sdk/src/query/runtime-model-validation.ts
@@ -13,6 +13,7 @@ import {
   type BindingKind,
   type BindingSource,
   type RejectionReason,
+  runtimeBindingChannelForRuntime,
   type RuntimeModelResolution,
 } from './runtime-model-contract.js';
 
@@ -43,6 +44,10 @@ export interface BindingValidationResult {
   resolvedModel: string | null;
   issue: BindingValidationIssue | null;
   binding: RuntimeModelResolution;
+}
+
+export interface RuntimeBindingChannelValidationOptions {
+  hermesDelegateModelChannelAvailable?: boolean;
 }
 
 export interface BindingValidationSummary {
@@ -286,7 +291,11 @@ export function evaluateCrossAiExecutionResult(options: {
   };
 }
 
-function buildSuggestedFix(binding: RuntimeModelResolution): string {
+function buildSuggestedFix(binding: RuntimeModelResolution, rejectionReason?: RejectionReason): string {
+  if (rejectionReason === 'missing-runtime-binding-channel' && binding.runtime === 'hermes') {
+    return 'Upgrade or restart Hermes Agent with delegate_task.model / tasks[].model support, set the override to inherit, remove the explicit model_overrides entry, or use explicit cross-AI execution.';
+  }
+
   if (binding.kind === 'unsupported') {
     return binding.suggestedFix;
   }
@@ -326,7 +335,7 @@ function buildIssue(binding: RuntimeModelResolution, rejectionReason: RejectionR
     resolvedModel: binding.resolvedModel,
     rejectionReason,
     reason,
-    suggestedFix: buildSuggestedFix(binding),
+    suggestedFix: buildSuggestedFix(binding, rejectionReason),
     crossAiExecutionSupported,
     crossAiExecutionConfigured: binding.crossAiExecutionConfigured,
     crossAiExecutionRecommended,
@@ -335,7 +344,10 @@ function buildIssue(binding: RuntimeModelResolution, rejectionReason: RejectionR
   };
 }
 
-export function validateResolvedAgentBinding(binding: RuntimeModelResolution): BindingValidationResult {
+export function validateResolvedAgentBinding(
+  binding: RuntimeModelResolution,
+  options: RuntimeBindingChannelValidationOptions = {},
+): BindingValidationResult {
   if (binding.kind === 'unsupported') {
     return {
       ok: false,
@@ -362,6 +374,27 @@ export function validateResolvedAgentBinding(binding: RuntimeModelResolution): B
       issue: null,
       binding,
     };
+  }
+
+  if (binding.runtime === 'hermes' && binding.bindingKind === 'explicit') {
+    const channel = runtimeBindingChannelForRuntime(binding.runtime, options);
+    if (!channel.available) {
+      return {
+        ok: false,
+        agent: binding.agent,
+        runtime: binding.runtime,
+        bindingKind: binding.bindingKind,
+        source: binding.source,
+        configuredModel: binding.configuredModel,
+        resolvedModel: binding.resolvedModel,
+        issue: buildIssue(
+          binding,
+          'missing-runtime-binding-channel',
+          channel.reason ?? 'Hermes delegate_task.model / tasks[].model binding channel is unavailable',
+        ),
+        binding,
+      };
+    }
   }
 
   const compatibility = evaluateRuntimeModelCompatibility(binding.runtime, binding.resolvedModel);
@@ -392,12 +425,20 @@ export function validateResolvedAgentBinding(binding: RuntimeModelResolution): B
   };
 }
 
-export function validateAgentBinding(config: GSDConfig | Record<string, unknown>, agent: string): BindingValidationResult {
-  return validateResolvedAgentBinding(resolveAgentBinding(config, agent));
+export function validateAgentBinding(
+  config: GSDConfig | Record<string, unknown>,
+  agent: string,
+  options: RuntimeBindingChannelValidationOptions = {},
+): BindingValidationResult {
+  return validateResolvedAgentBinding(resolveAgentBinding(config, agent), options);
 }
 
-export function validateAgentBindings(config: GSDConfig | Record<string, unknown>, agents: string[]): BindingValidationSummary {
-  const results = agents.map((agent) => validateAgentBinding(config, agent));
+export function validateAgentBindings(
+  config: GSDConfig | Record<string, unknown>,
+  agents: string[],
+  options: RuntimeBindingChannelValidationOptions = {},
+): BindingValidationSummary {
+  const results = agents.map((agent) => validateAgentBinding(config, agent, options));
   const issues = results.flatMap((result) => result.issue ? [result.issue] : []);
   const runtime = results[0]?.runtime ?? resolveAgentBinding(config, agents[0] ?? 'gsd-planner').runtime;
 
@@ -437,8 +478,9 @@ export function assertAgentBindingsSupported(
   config: GSDConfig | Record<string, unknown>,
   agents: string[],
   phaseLabel = 'workflow execution',
+  options: RuntimeBindingChannelValidationOptions = {},
 ): void {
-  const summary = validateAgentBindings(config, agents);
+  const summary = validateAgentBindings(config, agents, options);
   if (summary.ok) return;
   throw new GSDError(formatBindingValidationError(summary, phaseLabel), ErrorClassification.Validation);
 }

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -7,6 +7,18 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+const { validateAgentBinding } = require('../get-shit-done/bin/lib/model-profiles.cjs');
+
+function assertReceiptRole(receipts, workflow, role, agent) {
+  assert.strictEqual(receipts.workflow, workflow);
+  assert.ok(receipts.runtime, 'receipt payload must include runtime');
+  assert.strictEqual(receipts.agents[role].role, role);
+  assert.strictEqual(receipts.agents[role].agent, agent);
+  assert.ok(Object.hasOwn(receipts.agents[role], 'resolved_by_gsd'));
+  assert.ok(Object.hasOwn(receipts.agents[role], 'passed_to_runtime'));
+  assert.ok(Object.hasOwn(receipts.agents[role], 'runtime_enforced'));
+  assert.ok(Object.hasOwn(receipts.agents[role], 'runtime_binding_channel'));
+}
 
 describe('init commands', () => {
   let tmpDir;
@@ -67,6 +79,26 @@ describe('init commands', () => {
       'model_overrides must take precedence even when resolve_model_ids is omit');
   });
 
+  test('init execute-phase emits conservative model binding receipts', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '01-foundation');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      model_overrides: { 'gsd-executor': 'openai/o4-mini' },
+    }));
+
+    const result = runGsdTools('init execute-phase 1 --raw', tmpDir, { HOME: tmpDir });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assertReceiptRole(output.model_binding_receipts, 'execute-phase', 'executor', 'gsd-executor');
+    assertReceiptRole(output.model_binding_receipts, 'execute-phase', 'verifier', 'gsd-verifier');
+    assert.strictEqual(output.model_binding_receipts.agents.executor.model_token, 'openai/o4-mini');
+    assert.strictEqual(output.model_binding_receipts.agents.executor.runtime_enforced, 'unknown');
+  });
+
   test('init plan-phase returns file paths', () => {
     const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
     fs.mkdirSync(phaseDir, { recursive: true });
@@ -107,6 +139,85 @@ describe('init commands', () => {
     assert.ok(result.success, `Command failed: ${result.error}`);
     const output = JSON.parse(result.output);
     assert.strictEqual(output.text_mode, true, 'text_mode should reflect config value');
+  });
+
+  test('init plan-phase emits conservative model binding receipts', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+    }));
+
+    const result = runGsdTools('init plan-phase 03 --raw', tmpDir, { HOME: tmpDir });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assertReceiptRole(output.model_binding_receipts, 'plan-phase', 'researcher', 'gsd-phase-researcher');
+    assertReceiptRole(output.model_binding_receipts, 'plan-phase', 'planner', 'gsd-planner');
+    assertReceiptRole(output.model_binding_receipts, 'plan-phase', 'checker', 'gsd-plan-checker');
+    assert.strictEqual(output.model_binding_receipts.agents.planner.model_token, 'openai/o4-mini');
+    assert.strictEqual(output.model_binding_receipts.agents.planner.runtime_enforced, 'unknown');
+    assert.deepStrictEqual(output.model_binding_receipts.agents.planner.runtime_binding_channel, {
+      kind: 'hermes-delegate-task-model',
+      available: true,
+      proof_level: 'child-construction',
+      reason: null,
+      suggested_fix: null,
+    });
+  });
+
+  test('legacy CJS validation fails fast when Hermes delegate model channel is unavailable', () => {
+    const result = validateAgentBinding(
+      {
+        runtime: 'hermes',
+        model_profile: 'balanced',
+        model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+      },
+      'gsd-planner',
+      { hermesDelegateModelChannelAvailable: false }
+    );
+
+    assert.strictEqual(result.ok, false);
+    assert.deepStrictEqual(
+      {
+        agent: result.issue.agent,
+        runtime: result.issue.runtime,
+        configuredModel: result.issue.configuredModel,
+        resolvedModel: result.issue.resolvedModel,
+        bindingKind: result.issue.bindingKind,
+        source: result.issue.source,
+        rejectionReason: result.issue.rejectionReason,
+      },
+      {
+        agent: 'gsd-planner',
+        runtime: 'hermes',
+        configuredModel: 'openai/o4-mini',
+        resolvedModel: 'openai/o4-mini',
+        bindingKind: 'explicit',
+        source: 'override',
+        rejectionReason: 'missing-runtime-binding-channel',
+      }
+    );
+    assert.match(result.issue.reason, /delegate_task\.model \/ tasks\[\]\.model/);
+    assert.match(result.issue.suggestedFix, /Upgrade or restart Hermes Agent/);
+  });
+
+  test('legacy CJS receipts preserve invalid explicit model tokens', () => {
+    const invalidModel = 'definitely-not-a-real-model-gsd-binding-test';
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      model_overrides: { 'gsd-planner': invalidModel },
+    }));
+
+    const result = runGsdTools('init plan-phase 03 --raw', tmpDir, { HOME: tmpDir });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.model_binding_receipts.agents.planner.configured_model, invalidModel);
+    assert.strictEqual(output.model_binding_receipts.agents.planner.resolved_model, invalidModel);
+    assert.strictEqual(output.model_binding_receipts.agents.planner.model_token, invalidModel);
+    assert.notStrictEqual(output.model_binding_receipts.agents.planner.model_token, 'opus');
   });
 
   test('init progress returns file paths', () => {

--- a/tests/runtime-model-parity.test.cjs
+++ b/tests/runtime-model-parity.test.cjs
@@ -7,12 +7,13 @@ const path = require('path');
 const { pathToFileURL } = require('url');
 const { createTempProject, cleanup } = require('./helpers.cjs');
 const { resolveModelBindingInternal, resolveModelInternal } = require('../get-shit-done/bin/lib/core.cjs');
-const { toInitModelToken } = require('../get-shit-done/bin/lib/model-profiles.cjs');
+const { toInitModelToken, toBindingReceipt } = require('../get-shit-done/bin/lib/model-profiles.cjs');
 
 const PLAN_PHASE_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'plan-phase.md');
 const QUICK_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'quick.md');
 const VERIFY_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'verify-work.md');
 const EXECUTE_PHASE_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'execute-phase.md');
+const HERMES_COMPATIBILITY_DOC_PATH = path.join(__dirname, '..', 'docs', 'hermes-compatibility.md');
 
 const SDK_RUNTIME_MODEL_CONTRACT_PATH = pathToFileURL(
   path.join(__dirname, '..', 'sdk', 'dist', 'query', 'runtime-model-contract.js')
@@ -149,6 +150,30 @@ const MATRIX = [
     expectedInitToken: 'claude-sonnet-4-6',
   },
   {
+    name: 'runtime: hermes + invalid explicit override preserves token for no-silent-fallback proof',
+    agent: 'gsd-planner',
+    config: {
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      model_overrides: { 'gsd-planner': 'definitely-not-a-real-model-gsd-binding-test' },
+      workflow: {},
+    },
+    expectedLegacyToken: 'definitely-not-a-real-model-gsd-binding-test',
+    expectedInitToken: 'definitely-not-a-real-model-gsd-binding-test',
+  },
+  {
+    name: 'runtime: hermes + cross_ai_execution flag remains metadata, not silent fallback',
+    agent: 'gsd-planner',
+    config: {
+      runtime: 'hermes',
+      model_profile: 'balanced',
+      workflow: { cross_ai_execution: true },
+      model_overrides: { 'gsd-planner': 'openai/o4-mini' },
+    },
+    expectedLegacyToken: 'openai/o4-mini',
+    expectedInitToken: 'openai/o4-mini',
+  },
+  {
     name: 'runtime: codex + inherit + model_profile_overrides — inherit dominates, overrides ignored by both resolvers',
     agent: 'gsd-planner',
     config: {
@@ -167,6 +192,7 @@ describe('runtime-model parity', () => {
   let sdkResolveAgentBinding;
   let sdkToLegacyModelToken;
   let sdkToInitModelToken;
+  let sdkToRuntimeModelReceipt;
 
   beforeEach(async () => {
     tmpDir = createTempProject();
@@ -174,6 +200,7 @@ describe('runtime-model parity', () => {
     sdkResolveAgentBinding = sdkModule.resolveAgentBinding;
     sdkToLegacyModelToken = sdkModule.toLegacyModelToken;
     sdkToInitModelToken = sdkModule.toInitModelToken;
+    sdkToRuntimeModelReceipt = sdkModule.toRuntimeModelReceipt;
   });
 
   afterEach(() => {
@@ -230,6 +257,52 @@ describe('runtime-model parity', () => {
       }
       assert.strictEqual(cjsLegacyToken, entry.expectedLegacyToken);
       assert.strictEqual(cjsInitToken, entry.expectedInitToken);
+
+      const sdkReceipt = sdkToRuntimeModelReceipt(sdkResolution, 'executor');
+      const cjsReceipt = toBindingReceipt(cjsResolution, 'executor');
+      assert.deepStrictEqual(
+        {
+          role: cjsReceipt.role,
+          agent: cjsReceipt.agent,
+          status: cjsReceipt.status,
+          known_agent: cjsReceipt.known_agent,
+          runtime: cjsReceipt.runtime,
+          profile: cjsReceipt.profile,
+          binding_kind: cjsReceipt.binding_kind,
+          source: cjsReceipt.source,
+          configured_model: cjsReceipt.configured_model,
+          resolved_model: cjsReceipt.resolved_model,
+          model_token: cjsReceipt.model_token,
+          provider_family: cjsReceipt.provider_family,
+          resolved_by_gsd: cjsReceipt.resolved_by_gsd,
+          passed_to_runtime: cjsReceipt.passed_to_runtime,
+          runtime_enforced: cjsReceipt.runtime_enforced,
+          enforceability: cjsReceipt.enforceability,
+          runtime_binding_channel: cjsReceipt.runtime_binding_channel,
+          rejection_reason: cjsReceipt.rejection_reason,
+        },
+        {
+          role: sdkReceipt.role,
+          agent: sdkReceipt.agent,
+          status: sdkReceipt.status,
+          known_agent: sdkReceipt.known_agent,
+          runtime: sdkReceipt.runtime,
+          profile: sdkReceipt.profile,
+          binding_kind: sdkReceipt.binding_kind,
+          source: sdkReceipt.source,
+          configured_model: sdkReceipt.configured_model,
+          resolved_model: sdkReceipt.resolved_model,
+          model_token: sdkReceipt.model_token,
+          provider_family: sdkReceipt.provider_family,
+          resolved_by_gsd: sdkReceipt.resolved_by_gsd,
+          passed_to_runtime: sdkReceipt.passed_to_runtime,
+          runtime_enforced: sdkReceipt.runtime_enforced,
+          enforceability: sdkReceipt.enforceability,
+          runtime_binding_channel: sdkReceipt.runtime_binding_channel,
+          rejection_reason: sdkReceipt.rejection_reason,
+        },
+        'legacy CJS binding receipt projection must match SDK receipt projection for the shared matrix'
+      );
     });
   }
 
@@ -238,10 +311,33 @@ describe('runtime-model parity', () => {
     const quickWorkflow = fsNative.readFileSync(QUICK_WORKFLOW_PATH, 'utf8');
     const verifyWorkflow = fsNative.readFileSync(VERIFY_WORKFLOW_PATH, 'utf8');
     const executeWorkflow = fsNative.readFileSync(EXECUTE_PHASE_WORKFLOW_PATH, 'utf8');
+    const hermesDoc = fsNative.readFileSync(HERMES_COMPATIBILITY_DOC_PATH, 'utf8');
 
     assert.match(planWorkflow, /four runtime-model paths/i);
     assert.match(quickWorkflow, /four runtime-model paths/i);
     assert.match(verifyWorkflow, /four runtime-model paths/i);
     assert.match(executeWorkflow, /direct runtime support/i);
+
+    for (const [name, text] of [
+      ['plan-phase workflow', planWorkflow],
+      ['execute-phase workflow', executeWorkflow],
+    ]) {
+      assert.match(text, /model_binding_receipts/, `${name} must parse model_binding_receipts`);
+      assert.match(text, /runtime_enforced/, `${name} must display runtime_enforced`);
+      assert.match(text, /resolved_by_gsd/, `${name} must display resolved_by_gsd`);
+      assert.match(text, /passed_to_runtime/, `${name} must display passed_to_runtime`);
+      assert.match(
+        text,
+        /runtime_enforced=unknown is not provider proof/i,
+        `${name} must warn that unknown enforcement is not provider proof`
+      );
+      assert.match(text, /runtime_binding_channel/, `${name} must display the binding channel boundary`);
+      assert.match(text, /child-construction/i, `${name} must distinguish child construction from provider proof`);
+    }
+
+    assert.match(hermesDoc, /resolved_by_gsd/);
+    assert.match(hermesDoc, /passed_to_runtime/);
+    assert.match(hermesDoc, /runtime_enforced/);
+    assert.match(hermesDoc, /subagent self-report is not proof/i);
   });
 });


### PR DESCRIPTION
# Ship Hermes runtime model binding receipts and fail-fast enforcement

Closes #32

## Tracker

- Issue: https://github.com/pingchesu/gsd-hermes/issues/32

## Root cause

GSD resolver/config surfaces could report explicit per-agent `model_overrides`, but the pre-fix Hermes delegation path did not expose a per-call child `model` binding. In Hermes, spawned child agents could therefore inherit the parent/default model even when GSD receipts showed `source=override` and `binding=explicit`.

Resolver truth was not runtime truth.

## Change summary

### Phase 10 — Runtime Binding Receipt Surface

- Added structured `model_binding_receipts` to plan-phase and execute-phase init payloads.
- Preserved backward-compatible flat `*_model` fields.
- Updated workflow transcript instructions to show resolver/runtime/proof boundaries conservatively.

### Phase 11 — Hermes Per-Agent Binding Channel

- Added Hermes Agent child binding support through direct `delegate_task(model=...)` and batch `tasks[].model`.
- Added GSD receipt metadata for `runtime_binding_channel.kind=hermes-delegate-task-model` with `proof_level=child-construction`.
- Documented that `delegation.model` is a global fallback, not a per-agent GSD override channel.

### Phase 12 — Fail-Fast Validation and Proof Tests

- Added SDK/CJS validation coverage so unsupported explicit Hermes bindings fail before spawn.
- Added regression tests proving invalid explicit model tokens are preserved and cannot silently fall back to parent/default model.
- Added Hermes Agent tests proving GSD planner/executor model tokens reach child `AIAgent(model=...)` construction.
- Added safe provider diagnostics that preserve sanitized model/provider metadata while redacting credentials.

### Phase 13 — Tracker, docs, release prep

- Created tracker issue #32.
- Updated README, COMMANDS, CONFIGURATION, Hermes compatibility docs, CHANGELOG, package metadata, and curated release notes for the selected patch release.
- Selected `gsd-hermes@1.4.30` / GitHub Release `v1.4.30` because `1.4.0` is already published and local `v1.4.1`–`v1.4.29` tags are present.

## Proof boundary

This PR intentionally separates evidence layers:

1. GSD resolver proof — config override resolves to the configured/resolved model token.
2. Workflow receipt proof — init payload/transcript displays binding metadata before dispatch.
3. Hermes child-construction proof — child `AIAgent(model=...)` receives the intended token.
4. Provider diagnostics proof — sanitized metadata can expose provider/model fields without secrets.
5. Provider wire-level enforcement — not claimed unless future live sanitized request instrumentation proves provider-side `model=` dispatch.

`runtime_enforced=unknown` is conservative and must not be read as provider wire-level proof.

## Validation

Local validation to run before PR/release:

```bash
npm run build:sdk
cd sdk && npx vitest run src/query/init.test.ts src/query/config-query.test.ts
cd .. && node --test tests/init.test.cjs tests/runtime-model-parity.test.cjs tests/workflow-size-budget.test.cjs tests/hermes-docs.test.cjs
npm run test:hermes
npm test
npm pack --dry-run
```

Hermes Agent proof tests:

```bash
cd /home/whiskey/.hermes/hermes-agent
.venv/bin/python -m pytest tests/tools/test_delegate.py tests/agent/test_auxiliary_codex_responses_conversion.py tests/agent/test_provider_diagnostics.py -q
.venv/bin/python -m py_compile tools/delegate_tool.py run_agent.py agent/provider_diagnostics.py agent/redact.py tests/tools/test_delegate.py tests/agent/test_provider_diagnostics.py
```

Latest recorded Phase 12 results before Phase 13 docs/release updates:

- GSD full suite: PASS — `5597/5597`.
- GSD targeted gates: PASS.
- Hermes Agent targeted gates: PASS — `128 passed` plus `py_compile`.

Phase 13 final local/CI results will be recorded before merge/release.

## Release target

- npm package: `gsd-hermes@1.4.30`
- GitHub Release: `v1.4.30`
- Release notes: `docs/releases/v1.4.30-runtime-model-binding-receipts.md`

Pre-publish gates:

- [ ] `package.json` and `package-lock.json` both equal `1.4.30`.
- [ ] `npm view gsd-hermes versions --json` does not include `1.4.30`.
- [ ] `git tag --list v1.4.30` is empty before creating the release tag.
- [ ] `gh release view v1.4.30` reports no existing release before creating it.
- [ ] CI is green before publish.

## Acceptance checklist

- [ ] Structured plan/execute binding receipts are present and covered by SDK/CJS tests.
- [ ] Hermes child binding channel supports direct `model` and batch `tasks[].model`.
- [ ] Unsupported explicit bindings fail fast before spawn.
- [ ] Invalid explicit model tokens cannot be hidden by fallback to parent/default model.
- [ ] Provider diagnostics redact API keys, tokens, authorization headers, passwords, client secrets, and credential-bearing URLs.
- [ ] README, COMMANDS.md, CONFIGURATION.md, Hermes compatibility docs, CHANGELOG, and release notes document strict semantics and proof boundaries.
- [ ] npm/GitHub release evidence is recorded after publish.

## Rollback notes

Before publish, rollback is a normal PR revert/close. After npm publish, npm versions are immutable; corrections should ship as a follow-up patch release rather than unpublishing except under npm security policy.
