### PR TITLE
sync: merge upstream get-shit-done eeaf9c55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   overrides a root value. (#2714)
 
 ### Fixed
+- **`extractCurrentMilestone` no longer truncates ROADMAP.md at heading-like lines inside fenced code blocks** — the milestone-end search now scans line-by-line while tracking ` ``` ` / `~~~` fence state, so a line like `# Ops runbook (v1.0 compat)` inside a code block no longer acts as a milestone boundary. Previously, any phase defined after such a block was invisible to `roadmap analyze`, `roadmap get-phase`, `/gsd-autonomous`, and all phase-number commands. (#2787)
 - **Codex install no longer corrupts existing `~/.codex/config.toml`** — the installer
   now defensively strips legacy `[agents]` (single-bracket) and `[[agents]]` (sequence)
   blocks regardless of GSD marker presence (both invalid in current Codex schema), emits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   ~700, useful for local LLMs with 32K–128K context (Sonnet 4.6 / Opus 4.7 don't need
   it). Re-run `gsd update` without `--minimal` to expand to the full surface. The
   install manifest now records `mode: "minimal" | "full"`. (#2762)
+- **`/gsd-edit-phase` command** — modify any field of an existing phase in ROADMAP.md
+  without changing its number or position. Supports `--force` to skip the confirmation
+  diff, validates `depends_on` references, and updates STATE.md on write. (#2617)
+- **Post-merge build & test gate** — execute-phase step 5.6 now runs in both parallel
+  and serial mode. Adds a build gate that auto-detects the build command from
+  `workflow.build_command` config, then falls back to Xcode (`.xcodeproj`), Makefile,
+  Justfile, Cargo, Go, Python, or npm. Xcode/iOS projects run `xcodebuild build` and
+  `xcodebuild test` automatically. (#2720)
+- **Extended runtime model profiles** — RUNTIME_PROFILE_MAP now covers `gemini`,
+  `qwen`, `opencode`, and `copilot` runtimes with full three-tier (fast/balanced/opus)
+  model mappings. Group B runtimes (kilo, cline, cursor, windsurf, augment, trae,
+  codebuddy, antigravity) fall through to the existing unknown-runtime fallback. (#2612)
+- **Workstream config inheritance** — when `GSD_WORKSTREAM` is set, the root
+  `.planning/config.json` is loaded first and deep-merged with the workstream config
+  (workstream wins on conflict). Explicit `null` in a workstream config now correctly
+  overrides a root value. (#2714)
 
 ### Fixed
 - **Codex install no longer corrupts existing `~/.codex/config.toml`** — the installer
@@ -26,6 +42,96 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   values, and unsupported value types. Both pre-write helper failures and write-time
   failures restore the pre-install snapshot and abort with a clear error rather than
   warn-and-continue. (#2760)
+- **Codex `[[agents]]` reverted to `[agents.<name>]` struct format** — the sequence
+  format introduced in #2645 is rejected by codex-cli 0.124.0 with "invalid type:
+  sequence, expected struct AgentsToml". Reverted to struct format which is correct for
+  0.120.0+. The self-healing stripper handles both formats for configs written by prior
+  GSD versions. (#2727)
+- **Codex legacy `[hooks]` map format auto-migrated** — Codex 0.124.0 requires
+  `[[hooks]]` array-of-tables; old GSD installs that wrote `[hooks.shell]` map-style
+  now self-heal on the next `gsd install --codex`. (#2637)
+- **`gsd-sdk` PATH verification tightened** — installer now probes for an executable
+  `gsd-sdk` shim on PATH after confirming `sdk/dist/cli.js` is present, and attempts
+  to materialize one via symlink at `~/.local/bin/gsd-sdk` when absent. Only prints
+  `✓ GSD SDK ready` when the probe succeeds. (#2775, #2777)
+- **USER-PROFILE.md no longer triggers false "locally modified" warning** — the file
+  was both preserved across reinstalls and tracked in `gsd-file-manifest.json`, causing
+  the stale-hash diff to fire on every profile refresh. `USER_OWNED_ARTIFACTS` is now a
+  single source of truth used by both the preserve and manifest write paths. (#2771)
+- **All `gsd-sdk query` handlers now respect `--ws`** — 18+ handlers accepted
+  `_workstream` but never forwarded it to `planningPaths`/`loadConfig`. Workstream now
+  scopes path resolution correctly in `initNewProject`, `configGet`, `configSet`,
+  `commit`, `validateHealth`, and all other handlers. (#2731)
+- **`resolveModel` threads workstream** — config-query `resolveModel` ignored
+  `_workstream` unlike `configGet`/`configPath`, so different workstreams with different
+  `model_profile` settings would get the root profile instead of their own. (#2742)
+- **`parseMustHavesBlock` quoted strings** — fully-quoted truths containing `:` (e.g.
+  `"App-side UUIDv4: generated locally"`) fell into the kv-parse branch, the regex
+  failed, and `current` stayed as `{}`, crashing `annotate-dependencies` with
+  `TypeError: t.trim is not a function`. Fixed in both `frontmatter.cjs` and
+  `roadmap.cjs`. (#2757, #2734)
+- **`gsd state complete-phase` subcommand** — was missing; unknown subcommands fell
+  through to `cmdStateLoad`. Now updates `Status`, `Last Activity`, and
+  `Current Position` to `COMPLETE`. (#2735)
+- **Non-string `depends_on` values preserved** — numeric YAML scalars and kv-shaped
+  truths were silently dropped by `annotate-dependencies` via an early `typeof t !==
+  'string'` skip. A `coerceTruthToString` helper now coerces numbers/booleans and
+  extracts a string field from object-shaped items. (#2770)
+- **Worktree isolation scoped to submodule-touching plans** — the previous guard
+  unconditionally set `USE_WORKTREES=false` when `.gitmodules` existed. Now parses
+  submodule paths and intersects per-plan `files_modified`; only plans that touch a
+  submodule path skip worktree isolation. (#2772)
+- **Worktree cleanup uses inclusion filter** — the exclusion-based cleanup
+  (`grep -v "$(pwd)$"`) failed in multi-workspace and cross-drive Windows setups,
+  destroying the workspace's `.git` pointer. Cleanup now targets only
+  `.claude/worktrees/agent-*` paths, which agent-spawned worktrees always use. (#2774)
+- **`Requirements:` header variants all parse correctly** — both `**Requirements:**`
+  (colon inside bold) and `**Requirements**:` (colon outside bold) now match in
+  `extractReqIds` and the `phase complete` traceability sweep. (#2769)
+- **`gsd-sdk query commit` paths passed via `--files`** — 81 invocations across 50
+  files were passing paths positionally, which appended them to the commit subject and
+  triggered the wholesale-stage fallback. All sites updated. (#2767)
+- **Phase detection in bullet/bold ROADMAP formats** — `phaseAdd`'s regex only matched
+  heading format (`## Phase N:`), missing bullet checklist and bold entries. Broadened
+  to all three formats with filesystem fallback on zero matches. (#2726)
+- **Plan-line overwrite when `**Plans:**` is empty** — `\s*` after `**Plans:**`
+  matched newlines, causing `[^\n]+` to consume the first plan checkbox. Replaced with
+  `[ \t]*` (horizontal whitespace only) and added section-boundary lookahead. (#2728)
+- **Phase-lifecycle `<details>`-wrapped active milestone** — `replaceInCurrentMilestone`
+  silently dropped replacements when the active milestone was itself inside a `<details>`
+  block (the after-slice was empty). Falls back to locating the last complete
+  `<details>…</details>` span. (#2641)
+- **Phase-lifecycle project-code-prefixed directory names** — filesystem fallback regex
+  `/^(\d+)-/` missed directories like `CK-45-foundation`. Updated to
+  `/^(?:[A-Z][A-Z0-9]*-)?(\d+)-/i`.
+- **`roadmap.update-plan-progress` regex** — `\s*` crossing newlines shared the same
+  corruption vector as `planCountPattern`; replaced with `[ \t]*` plus section-boundary
+  lookahead.
+- **`replaceInCurrentMilestone` fast-path guard** — the `after.trim().length > 0`
+  check incorrectly triggered when `after` contained only footer text, returning
+  unchanged content instead of falling through to the slow path.
+- **`graphify` CLI updated to subcommand form** — `graphify . --update` was removed in
+  v0.4.x in favour of `graphify update .`. Version detection now tries
+  `graphify --version` before falling back to the Python importlib query. (#2732)
+- **LM Studio model identity validated in review workflow** — captures the full API
+  response and compares the top-level `.model` field against `LM_STUDIO_MODEL`, emitting
+  a warning when the served model differs. Empty-content responses no longer write error
+  text into the review temp file (same fix applied to llama.cpp). (#2721)
+- **SDK `globalDefaults` preserved for nested config keys** — `workflow`, `git`,
+  `hooks`, `agent_skills`, and `features` sections were missing the `globalDefaults`
+  spread at the correct precedence level, silently dropping user values from
+  `~/.gsd/defaults.json`. (#2673)
+- **`MODEL_ALIAS_MAP` updated to `claude-opus-4-7`** — both `MODEL_ALIAS_MAP` and
+  `RUNTIME_PROFILE_MAP.claude.opus` were pinned to `claude-opus-4-6`. (#2733)
+- **Orchestrators wait for subagents before continuing** — 26 GSD workflow files now
+  include an explicit `ORCHESTRATOR RULE` blockquote immediately after every `Task()`
+  spawn, preventing the Codex parallel-work anti-pattern where the parent continues
+  reading files and producing conflicting output. (#2729)
+
+### Performance
+- **`discuss-phase` lazy file loading** — entry-point `@file` directives replaced with
+  on-demand `Read()` calls gated behind mode routing. Tokens loaded at skill entry drop
+  from ~13k to near zero; only the branch actually invoked is loaded. (#2606)
 
 ## [1.38.5] - 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   values, and unsupported value types. Both pre-write helper failures and write-time
   failures restore the pre-install snapshot and abort with a clear error rather than
   warn-and-continue. (#2760)
-- **Codex hooks migrator correctness hardening** — five edge-cases in the
+- **Codex hooks migrator correctness hardening** — four edge-cases in the
   `[[hooks.<Event>]]` → `[[hooks.<Event>.hooks]]` migration path fixed: (1) the TOML
   key parser in hook-body classification now uses `parseTomlKey()` instead of a bare
   regex, so hyphenated keys (e.g. `status-message`) and quoted keys are no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   values, and unsupported value types. Both pre-write helper failures and write-time
   failures restore the pre-install snapshot and abort with a clear error rather than
   warn-and-continue. (#2760)
+- **Codex hooks migrator correctness hardening** — five edge-cases in the
+  `[[hooks.<Event>]]` → `[[hooks.<Event>.hooks]]` migration path fixed: (1) the TOML
+  key parser in hook-body classification now uses `parseTomlKey()` instead of a bare
+  regex, so hyphenated keys (e.g. `status-message`) and quoted keys are no longer
+  silently dropped; (2) `buildNestedBlock` no longer synthesises an empty
+  `[[hooks.TYPE.hooks]]` sub-table for matcher-only sections that carry no handler
+  fields — previously produced a broken entry with `type = "command"` but no
+  `command`; (3) the `legacyMapSections` filter now uses the parsed segment count
+  instead of dot-splitting the path string, preventing three-segment tables such as
+  `[hooks.SessionStart.hooks]` from being misclassified as event entries (same class
+  of bug fixed for `staleNamespacedAotSections` in the previous round); (4) regression
+  test added: `[[hooks."before.tool"]]` (a quoted key containing a dot) is correctly
+  treated as a two-segment namespace and not split on the inner dot. (#2809)
 - **Codex `[[agents]]` reverted to `[agents.<name>]` struct format** — the sequence
   format introduced in #2645 is rejected by codex-cli 0.124.0 with "invalid type:
   sequence, expected struct AgentsToml". Reverted to struct format which is correct for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   it). Re-run `gsd update` without `--minimal` to expand to the full surface. The
   install manifest now records `mode: "minimal" | "full"`. (#2762)
 
+### Fixed
+- **Codex install no longer corrupts existing `~/.codex/config.toml`** — the installer
+  now defensively strips legacy `[agents]` (single-bracket) and `[[agents]]` (sequence)
+  blocks regardless of GSD marker presence (both invalid in current Codex schema), emits
+  the GSD-managed hook in the user's preferred shape (`[[hooks.<Event>]]` namespaced AoT
+  if any user hook uses it, otherwise top-level `[[hooks]]`), migrates legacy
+  `[hooks.<Event>]` to namespaced AoT, and atomically writes via temp-file +
+  `renameSync`. A strict TOML parser validates the post-write bytes against the Codex
+  schema and rejects duplicate keys, repeated table headers, trailing bytes after
+  values, and unsupported value types. Both pre-write helper failures and write-time
+  failures restore the pre-install snapshot and abort with a clear error rather than
+  warn-and-continue. (#2760)
+
 ## [1.38.5] - 2026-04-25
 
 ### Fixed

--- a/agents/gsd-code-fixer.md
+++ b/agents/gsd-code-fixer.md
@@ -345,6 +345,7 @@ Use `gsd-sdk query commit` with conventional format (message first, then every s
 ```bash
 gsd-sdk query commit \
   "fix({padded_phase}): {finding_id} {short_description}" \
+  --files \
   {all_modified_files}
 ```
 
@@ -354,7 +355,7 @@ Examples:
 
 **Multiple files:** List ALL modified files after the message (space-separated):
 ```bash
-gsd-sdk query commit "fix(02): CR-01 ..." \
+gsd-sdk query commit "fix(02): CR-01 ..." --files \
   src/api/auth.ts src/types/user.ts tests/auth.test.ts
 ```
 

--- a/agents/gsd-debugger.md
+++ b/agents/gsd-debugger.md
@@ -1168,7 +1168,7 @@ Root cause: {root_cause}"
 
 Then commit planning docs via CLI (respects `commit_docs` config automatically):
 ```bash
-gsd-sdk query commit "docs: resolve debug {slug}" .planning/debug/resolved/{slug}.md
+gsd-sdk query commit "docs: resolve debug {slug}" --files .planning/debug/resolved/{slug}.md
 ```
 
 **Append to knowledge base:**
@@ -1199,7 +1199,7 @@ Then append the entry:
 
 Commit the knowledge base update alongside the resolved session:
 ```bash
-gsd-sdk query commit "docs: update debug knowledge base with {slug}" .planning/debug/knowledge-base.md
+gsd-sdk query commit "docs: update debug knowledge base with {slug}" --files .planning/debug/knowledge-base.md
 ```
 
 Report completion and offer next steps.

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -563,7 +563,7 @@ gsd-sdk query state.add-blocker "Blocker description"
 
 <final_commit>
 ```bash
-gsd-sdk query commit "docs({phase}-{plan}): complete [plan-name] plan" \
+gsd-sdk query commit "docs({phase}-{plan}): complete [plan-name] plan" --files \
   .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md .planning/STATE.md .planning/ROADMAP.md .planning/REQUIREMENTS.md
 ```
 

--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -755,7 +755,7 @@ Write to: `$PHASE_DIR/$PADDED_PHASE-RESEARCH.md`
 ## Step 7: Commit Research (optional)
 
 ```bash
-gsd-sdk query commit "docs($PHASE): research phase domain" "$PHASE_DIR/$PADDED_PHASE-RESEARCH.md"
+gsd-sdk query commit "docs($PHASE): research phase domain" --files "$PHASE_DIR/$PADDED_PHASE-RESEARCH.md"
 ```
 
 ## Step 8: Return Structured Result

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -1136,7 +1136,7 @@ Plans:
 
 <step name="git_commit">
 ```bash
-gsd-sdk query commit "docs($PHASE): create phase plan" \
+gsd-sdk query commit "docs($PHASE): create phase plan" --files \
   .planning/phases/$PHASE-*/$PHASE-*-PLAN.md .planning/ROADMAP.md
 ```
 </step>

--- a/agents/gsd-research-synthesizer.md
+++ b/agents/gsd-research-synthesizer.md
@@ -139,7 +139,7 @@ Write to `.planning/research/SUMMARY.md`
 The 4 parallel researcher agents write files but do NOT commit. You commit everything together.
 
 ```bash
-gsd-sdk query commit "docs: complete project research" .planning/research/
+gsd-sdk query commit "docs: complete project research" --files .planning/research/
 ```
 
 ## Step 8: Return Summary

--- a/agents/gsd-ui-researcher.md
+++ b/agents/gsd-ui-researcher.md
@@ -292,7 +292,7 @@ Fill all sections. Write to `$PHASE_DIR/$PADDED_PHASE-UI-SPEC.md`.
 ## Step 6: Commit (optional)
 
 ```bash
-gsd-sdk query commit "docs($PHASE): UI design contract" "$PHASE_DIR/$PADDED_PHASE-UI-SPEC.md"
+gsd-sdk query commit "docs($PHASE): UI design contract" --files "$PHASE_DIR/$PADDED_PHASE-UI-SPEC.md"
 ```
 
 ## Step 7: Return Structured Result

--- a/bin/gsd-sdk.js
+++ b/bin/gsd-sdk.js
@@ -2,11 +2,16 @@
 /**
  * bin/gsd-sdk.js — back-compat shim for external callers of `gsd-sdk`.
  *
- * When the parent package is installed globally (`npm install -g get-shit-done-cc`
- * or `npx get-shit-done-cc`), npm creates a `gsd-sdk` symlink in the global bin
- * directory pointing at this file. npm correctly chmods bin entries from a tarball,
- * so the execute-bit problem that afflicted the sub-install approach (issue #2453)
- * cannot occur here.
+ * When the parent package is installed globally (`npm install -g get-shit-done-cc`)
+ * npm creates a `gsd-sdk` symlink in the global bin directory pointing at this
+ * file. npm correctly chmods bin entries from a tarball, so the execute-bit
+ * problem that afflicted the sub-install approach (issue #2453) cannot occur here.
+ *
+ * NOTE (#2775): `npx get-shit-done-cc` does NOT link this shim — npx only
+ * exposes the package's primary bin (`get-shit-done-cc`). For npx-based usage,
+ * the installer (`bin/install.js#installSdkIfNeeded`) self-symlinks `gsd-sdk`
+ * into `~/.local/bin` when needed and verifies PATH callability before
+ * reporting `✓ GSD SDK ready`.
  *
  * This shim resolves sdk/dist/cli.js relative to its own location and delegates
  * to it via `node`, so `gsd-sdk <args>` behaves identically to

--- a/bin/install.js
+++ b/bin/install.js
@@ -7427,14 +7427,49 @@ function installSdkIfNeeded(opts) {
     // `node sdkCliPath` invocation in bin/gsd-sdk.js.
   }
 
-  console.log(`  ${green}✓${reset} GSD SDK ready (sdk/dist/cli.js)`);
+  // #2775: do not assert "GSD SDK ready" until `gsd-sdk` actually resolves on
+  // PATH. `npx get-shit-done-cc` only links the package's primary bin; the
+  // secondary `gsd-sdk` shim is left dangling under the npx cache and is NOT
+  // callable as a bare command. The previous file-presence-only check was a
+  // strictly weaker invariant than the one workflows depend on
+  // (`command -v gsd-sdk` resolving), and led to a false ✓ in npx-cache
+  // installs (issue #2775).
+  const shimSrc = path.resolve(__dirname, 'gsd-sdk.js');
+  let onPath = isGsdSdkOnPath();
+
+  if (!onPath) {
+    // Try to materialize the shim into a user-writable PATH location so the
+    // installer can deliver on the success message without requiring the user
+    // to run `npm install -g` separately. Picks the first PATH entry that
+    // looks like a user-owned bin dir; falls back to ~/.local/bin even if
+    // it's not on PATH (then a follow-up suggestion is printed).
+    const linked = trySelfLinkGsdSdk(shimSrc);
+    if (linked) {
+      onPath = isGsdSdkOnPath();
+      if (onPath) {
+        console.log(`  ${dim}↪ linked gsd-sdk → ${linked}${reset}`);
+      }
+    }
+  }
+
+  if (onPath) {
+    console.log(`  ${green}✓${reset} GSD SDK ready (sdk/dist/cli.js)`);
+  } else {
+    console.log('');
+    console.log(`  ${yellow}⚠${reset} GSD SDK files are present but ${bold}gsd-sdk${reset} is not on your PATH.`);
+    console.log(`    Workflows that call ${cyan}gsd-sdk query …${reset} will fail with "command not found".`);
+    console.log(`    Install globally to materialize the bin symlink:`);
+    console.log(`      ${cyan}npm install -g get-shit-done-cc${reset}`);
+    console.log(`    Or add a directory containing the shim to your PATH manually.`);
+    console.log('');
+  }
 
   // #2620: warn if npm's global bin is not on PATH, suppressing the
   // absolute-path suggestion when the user's rc already covers it via
   // a HOME-relative entry (e.g. `export PATH="$HOME/.npm-global/bin:$PATH"`).
   try {
-    const { execSync } = require('child_process');
-    const npmPrefix = execSync('npm prefix -g', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    const cp = require('child_process');
+    const npmPrefix = cp.execSync('npm prefix -g', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
     if (npmPrefix) {
       // On Windows npm prefix IS the bin dir; on POSIX it's `${prefix}/bin`.
       const globalBin = process.platform === 'win32' ? npmPrefix : path.join(npmPrefix, 'bin');
@@ -7443,6 +7478,105 @@ function installSdkIfNeeded(opts) {
   } catch {
     // npm not available / exec failed — silently skip the PATH advice.
   }
+}
+
+/**
+ * #2775 helper: check whether a callable `gsd-sdk` exists on the current PATH.
+ *
+ * Pure PATH walk (no spawn) — we look for a regular file or symlink named
+ * `gsd-sdk` (or `gsd-sdk.cmd`/`.exe` on Windows) in any directory on PATH and
+ * verify it carries the execute bit on POSIX. Avoids paying spawn cost and
+ * avoids the chicken-and-egg of needing to run the not-yet-installed binary.
+ */
+function isGsdSdkOnPath() {
+  const path = require('path');
+  const fs = require('fs');
+  const pathEnv = process.env.PATH || '';
+  const exts = process.platform === 'win32' ? ['.cmd', '.exe', '.bat', ''] : [''];
+  for (const seg of pathEnv.split(path.delimiter)) {
+    if (!seg) continue;
+    for (const ext of exts) {
+      const candidate = path.join(seg, `gsd-sdk${ext}`);
+      try {
+        const st = fs.statSync(candidate);
+        if (st.isFile()) {
+          if (process.platform === 'win32') return true;
+          if ((st.mode & 0o111) !== 0) return true;
+        }
+      } catch {
+        // missing / EACCES on dir — keep scanning.
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * #2775 helper: attempt to materialize the `gsd-sdk` shim at a user-writable
+ * PATH location. Returns the absolute path created on success, or null if no
+ * suitable location was usable.
+ *
+ * Strategy (POSIX): prefer ~/.local/bin (creating it if absent — many distros
+ * already have it on PATH via .profile). Fall back to the first PATH entry
+ * under HOME we can write to. Skip on Windows (npm install -g is the right
+ * primitive there; we don't try to fabricate a .cmd shim).
+ */
+function trySelfLinkGsdSdk(shimSrc) {
+  if (process.platform === 'win32') return null;
+  const path = require('path');
+  const fs = require('fs');
+  const home = os.homedir();
+  if (!home) return null;
+
+  const localBin = path.join(home, '.local', 'bin');
+  const pathCandidates = [];
+  const pathEnv = process.env.PATH || '';
+  for (const seg of pathEnv.split(path.delimiter)) {
+    if (!seg) continue;
+    const abs = path.resolve(seg);
+    if (abs.startsWith(home + path.sep) && !pathCandidates.includes(abs)) {
+      pathCandidates.push(abs);
+    }
+  }
+  // If ~/.local/bin is already on PATH, keep it first (preserves existing UX
+  // for the common case). Otherwise prefer PATH-backed HOME dirs first so we
+  // self-link somewhere actually on PATH, falling back to ~/.local/bin only
+  // when no on-PATH HOME dir is writable. (#2775 CodeRabbit follow-up)
+  const candidates = pathCandidates.includes(localBin)
+    ? [localBin, ...pathCandidates.filter((dir) => dir !== localBin)]
+    : [...pathCandidates, localBin];
+
+  for (const dir of candidates) {
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      const target = path.join(dir, 'gsd-sdk');
+      // Replace any existing entry — it may be stale (prior install of an
+      // older version pointing at a now-absent shim).
+      try { fs.unlinkSync(target); } catch {}
+      try {
+        fs.symlinkSync(shimSrc, target);
+      } catch {
+        // Filesystems that don't support symlinks (some FUSE mounts): write a
+        // tiny wrapper that `require()`s the real shim by absolute path. We
+        // cannot copyFileSync(shimSrc, target) — bin/gsd-sdk.js resolves the
+        // CLI via `path.resolve(__dirname, '..', 'sdk', 'dist', 'cli.js')`,
+        // and after a copy `__dirname` would be the link directory (e.g.
+        // ~/.local/bin), causing the resolved CLI path to be broken
+        // (~/.local/sdk/dist/cli.js). Wrapping via require() preserves
+        // __dirname resolution because the require runs against shimSrc's
+        // own location. (#2775 CodeRabbit follow-up)
+        fs.writeFileSync(
+          target,
+          `#!/usr/bin/env node\nrequire(${JSON.stringify(shimSrc)});\n`,
+        );
+        try { fs.chmodSync(target, 0o755); } catch {}
+      }
+      return target;
+    } catch {
+      // permission / EROFS — try next candidate.
+    }
+  }
+  return null;
 }
 
 /**

--- a/bin/install.js
+++ b/bin/install.js
@@ -4506,6 +4506,24 @@ function copyCommandsAsAntigravitySkills(srcDir, skillsDir, prefix, isGlobal = f
 }
 
 /**
+ * Single source of truth for user-owned artifacts inside get-shit-done/.
+ *
+ * These files are created/refreshed by user-facing workflows (e.g.
+ * /gsd-profile-user) and must be preserved across reinstalls. Critically, they
+ * MUST be excluded from gsd-file-manifest.json — otherwise saveLocalPatches()
+ * will compare a refreshed file against a stale manifest hash and emit a
+ * spurious "locally modified GSD file" warning (bug #2771).
+ *
+ * Invariant: a file is either distribution (manifest-tracked, diff'd against
+ * manifest) or user artifact (preserved across installs, never diff'd). Never
+ * both. Both preserveUserArtifacts call sites and writeManifest must agree on
+ * this list, which is why it lives here as a single constant.
+ *
+ * Paths are relative to the get-shit-done/ directory.
+ */
+const USER_OWNED_ARTIFACTS = ['USER-PROFILE.md'];
+
+/**
  * Save user-generated files from destDir to an in-memory map before a wipe.
  *
  * @param {string} destDir - Directory that is about to be wiped
@@ -5687,6 +5705,12 @@ function writeManifest(configDir, runtime = 'claude', options = {}) {
 
   const gsdHashes = generateManifest(gsdDir);
   for (const [rel, hash] of Object.entries(gsdHashes)) {
+    // Skip user-owned artifacts (e.g. USER-PROFILE.md). They are preserved
+    // across reinstalls by preserveUserArtifacts and must NOT be hashed into
+    // the manifest — otherwise saveLocalPatches() would flag every refresh
+    // as a "local patch" (bug #2771). Single source of truth:
+    // USER_OWNED_ARTIFACTS at top of file.
+    if (USER_OWNED_ARTIFACTS.includes(rel)) continue;
     manifest.files['get-shit-done/' + rel] = hash;
   }
   if (isGemini && fs.existsSync(commandsDir)) {
@@ -5755,6 +5779,14 @@ function saveLocalPatches(configDir) {
 
   let manifest;
   try { manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')); } catch { return []; }
+
+  // Normalize legacy manifests written before #2771 fix: strip user-owned artifacts
+  // that were incorrectly recorded so refreshes don't surface false patches warnings.
+  if (manifest.files) {
+    for (const artifact of USER_OWNED_ARTIFACTS) {
+      delete manifest.files[`get-shit-done/${artifact}`];
+    }
+  }
 
   const patchesDir = path.join(configDir, PATCHES_DIR_NAME);
   const pristineDir = path.join(configDir, 'gsd-pristine');
@@ -6109,7 +6141,7 @@ function install(isGlobal, runtime = 'claude') {
   // Preserve user-generated files before the wipe-and-copy so they survive re-install
   const skillSrc = path.join(src, 'get-shit-done');
   const skillDest = path.join(targetDir, 'get-shit-done');
-  const savedGsdArtifacts = preserveUserArtifacts(skillDest, ['USER-PROFILE.md']);
+  const savedGsdArtifacts = preserveUserArtifacts(skillDest, USER_OWNED_ARTIFACTS);
   copyWithPathReplacement(skillSrc, skillDest, pathPrefix, runtime, false, isGlobal);
   restoreUserArtifacts(skillDest, savedGsdArtifacts);
   if (verifyInstalled(skillDest, 'get-shit-done')) {
@@ -7532,6 +7564,7 @@ if (process.env.GSD_TEST_MODE) {
     validateHookFields,
     preserveUserArtifacts,
     restoreUserArtifacts,
+    USER_OWNED_ARTIFACTS,
     finishInstall,
     homePathCoveredByRc,
     maybeSuggestPathExport,

--- a/bin/install.js
+++ b/bin/install.js
@@ -6875,14 +6875,23 @@ function install(isGlobal, runtime = 'claude') {
         content = processAttribution(content, getCommitAttribution(runtime));
         // Convert frontmatter for runtime compatibility (agents need different handling)
         if (isOpencode) {
-          // Resolve per-agent model override from BOTH per-project
-          // `.planning/config.json` and `~/.gsd/defaults.json`, with
-          // per-project winning on conflict (#2256). Without the per-project
-          // probe, an override set in `.planning/config.json` was silently
-          // ignored and the child inherited OpenCode's default model.
+          // Resolve per-agent model for OpenCode agents.
+          // Precedence: model_overrides[agent] > model_profile_overrides.opencode.<tier> > omit.
+          // model_overrides (#2256): explicit per-agent override, highest precedence.
+          // model_profile_overrides (#2794): tier-based runtime resolver, same parity as Codex.
           const _ocAgentName = entry.name.replace(/\.md$/, '');
           const _ocModelOverrides = readGsdEffectiveModelOverrides(targetDir);
-          const _ocModelOverride = _ocModelOverrides?.[_ocAgentName] || null;
+          let _ocModelOverride = _ocModelOverrides?.[_ocAgentName] || null;
+          if (!_ocModelOverride) {
+            // Fall back to tier-based resolution via model_profile_overrides.opencode.<tier>.
+            const _ocRuntimeResolver = readGsdRuntimeProfileResolver(targetDir);
+            if (_ocRuntimeResolver) {
+              const _ocEntry = _ocRuntimeResolver.resolve(_ocAgentName);
+              if (_ocEntry?.model) {
+                _ocModelOverride = _ocEntry.model;
+              }
+            }
+          }
           content = convertClaudeToOpencodeFrontmatter(content, { isAgent: true, modelOverride: _ocModelOverride });
         } else if (isKilo) {
           content = convertClaudeToKiloFrontmatter(content, { isAgent: true });

--- a/bin/install.js
+++ b/bin/install.js
@@ -2089,6 +2089,10 @@ function generateCodexConfigBlock(agents, targetDir) {
 /**
  * Strip any managed GSD agent sections from a TOML string.
  *
+ * Used by the uninstall path (`stripGsdFromCodexConfig`). Removes only what GSD
+ * owns; user-authored `[agents.<name>]` and `[[agents]]` entries are preserved
+ * so uninstall returns the file to its pre-GSD shape.
+ *
  * Handles BOTH shapes so reinstall self-heals configs from all GSD versions:
  *   - Current (#2727): `[agents.gsd-*]` struct tables (Codex 0.120.0+).
  *   - Legacy (#2645): `[[agents]]` array-of-tables whose `name = "gsd-*"`.
@@ -2815,25 +2819,32 @@ function isLegacyGsdAgentsSection(body) {
 }
 
 function stripLeakedGsdCodexSections(content) {
+  // Defensive precedence (#2760): we own the `agents` namespace under our
+  // managed `gsd-*` names, and the legacy bare-table and sequence forms
+  // (`[agents]`, `[[agents]]`) are invalid in the current Codex schema —
+  // they trigger "invalid type: ..., expected struct AgentsToml" and break
+  // every Codex CLI invocation. They MUST never coexist with the new
+  // `[agents.<name>]` struct format we now emit, so install-time always
+  // purges them regardless of GSD marker presence. Users who had legitimate
+  // user-authored `[[agents]]` entries before are already broken on Codex
+  // ≥0.124 — purging is the only path to a loadable config.
   const leakedSections = getTomlTableSections(content)
     .filter((section) => {
       // Legacy [agents.gsd-<name>] map tables (pre-#2645).
       if (!section.array && section.path.startsWith('agents.gsd-')) return true;
 
-      // Legacy bare [agents] table with only the old max_threads/max_depth keys.
-      if (
-        !section.array &&
-        section.path === 'agents' &&
-        isLegacyGsdAgentsSection(content.slice(section.headerEnd, section.end))
-      ) return true;
+      // ANY bare [agents] single-bracket table — invalid in current Codex
+      // schema, always purged at install time (#2760). Previously gated
+      // on `isLegacyGsdAgentsSection`, which missed bare tables holding
+      // arbitrary user keys (`default = "..."`, etc.) that still produce
+      // the AgentsToml type error.
+      if (!section.array && section.path === 'agents') return true;
 
-      // Current [[agents]] array-of-tables whose name is gsd-*. Preserve
-      // user-authored [[agents]] entries (other names) untouched.
-      if (section.array && section.path === 'agents') {
-        const body = content.slice(section.headerEnd, section.end);
-        const nameMatch = body.match(/^[ \t]*name[ \t]*=[ \t]*["']([^"']+)["']/m);
-        if (nameMatch && /^gsd-/.test(nameMatch[1])) return true;
-      }
+      // ANY [[agents]] array-of-tables — invalid in current Codex schema,
+      // always purged at install time (#2760). Previously gated on
+      // `name = "gsd-..."` which preserved user-authored entries that are
+      // themselves rejected by Codex 0.124+.
+      if (section.array && section.path === 'agents') return true;
 
       return false;
     });
@@ -2862,15 +2873,17 @@ function stripLeakedGsdCodexSections(content) {
  *     [hooks.shell]
  *     command = "..."
  *
- * to the new array-of-tables format:
- *   [[hooks]]
- *   type = "shell"
+ * to the new array-of-tables format. #2760 CR5 finding 3 — emit the
+ * namespaced AoT shape directly so a mixed flat + namespaced layout never
+ * arises post-install:
+ *   [[hooks.shell]]
  *   command = "..."
  *
  * This function detects any non-array hooks sections in the config and
- * converts them to the [[hooks]] format, preserving all key-value pairs and
- * user comments. Bare [hooks] container sections (no key-value content) are
- * dropped. User-authored [[hooks]] array entries are left untouched.
+ * converts them to the namespaced `[[hooks.<TYPE>]]` array-of-tables form,
+ * preserving all key-value pairs and user comments. Bare [hooks] container
+ * sections (no key-value content) are dropped. User-authored AoT entries are
+ * left untouched.
  *
  * Returns the migrated content, or the original content unchanged if no
  * legacy hooks sections were found.
@@ -2901,8 +2914,15 @@ function migrateCodexHooksMapFormat(content) {
     const type = section.path.slice('hooks.'.length);
     const body = content.slice(section.headerEnd, section.end);
 
-    // Build [[hooks]] block: type line + original body lines
-    const block = `[[hooks]]${eol}type = "${type}"${eol}${body}`;
+    // #2760 CR5 finding 3 — emit the namespaced AoT form directly:
+    // `[[hooks.<TYPE>]]` (no synthetic `event` field — the namespace IS the
+    // event). Previously we emitted flat `[[hooks]]\nevent = "<TYPE>"`,
+    // which produced mixed flat + namespaced layouts when the user already
+    // had `[[hooks.<OTHER>]]` entries. With every migration emit using the
+    // namespaced shape, the managed-emit detector
+    // (`hasUserNamespacedAotHooks`) fires correctly and the install
+    // converges on a single hook layout.
+    const block = `[[hooks.${type}]]${eol}${body}`;
     newHooksBlocks.push(block);
   }
 
@@ -2953,6 +2973,446 @@ function migrateCodexHooksMapFormat(content) {
   }
 
   return result;
+}
+
+/**
+ * Detect whether the user already uses the namespaced AoT hooks form
+ * (`[[hooks.<EVENT>]]`) for the given event in the config. When true,
+ * the GSD-managed hook block must be emitted in the same shape so it
+ * coexists cleanly — mixing `[[hooks]]` (flat) with `[[hooks.SessionStart]]`
+ * (namespaced) in the same file confuses round-trip writers and can
+ * produce a config that Codex rejects (#2760, defect 3).
+ */
+function hasUserNamespacedAotHooks(content, event) {
+  const sections = getTomlTableSections(content);
+  return sections.some(
+    (section) => section.array && section.path === `hooks.${event}`
+  );
+}
+
+/**
+ * Parse a TOML value RHS expression starting at index `i` of `text`.
+ * Returns { value, end } on success or throws on parse failure.
+ *
+ * Supports the value forms GSD emits or that real Codex configs commonly use:
+ *   - basic strings ("…" with simple escapes)
+ *   - literal strings ('…')
+ *   - booleans (true / false)
+ *   - integers (optional sign, decimal digits)
+ *   - inline arrays of the above
+ *   - inline tables { k = v, … }
+ *
+ * This is intentionally not a complete TOML implementation — it is the
+ * minimal value grammar required to validate Codex config structure and to
+ * back behavioral assertions in tests (#2760).
+ */
+function parseTomlValue(text, i) {
+  // Skip leading whitespace.
+  while (i < text.length && (text[i] === ' ' || text[i] === '\t')) {
+    i += 1;
+  }
+  if (i >= text.length) {
+    throw new Error('expected value, got end of input');
+  }
+
+  const ch = text[i];
+
+  // Basic string
+  if (ch === '"') {
+    if (text.startsWith('"""', i)) {
+      const close = findMultilineBasicStringClose(text, i + 3);
+      if (close === -1) {
+        throw new Error('unterminated multi-line basic string');
+      }
+      const raw = text.slice(i + 3, close);
+      return { value: raw.replace(/^\r?\n/, ''), end: close + 3 };
+    }
+    let j = i + 1;
+    let out = '';
+    while (j < text.length) {
+      const c = text[j];
+      if (c === '\\') {
+        const next = text[j + 1];
+        if (next === 'n') { out += '\n'; j += 2; continue; }
+        if (next === 't') { out += '\t'; j += 2; continue; }
+        if (next === 'r') { out += '\r'; j += 2; continue; }
+        if (next === '\\') { out += '\\'; j += 2; continue; }
+        if (next === '"') { out += '"'; j += 2; continue; }
+        if (next === '/') { out += '/'; j += 2; continue; }
+        // Pass-through unrecognized escape (Codex/GSD don't use these).
+        out += next === undefined ? '' : next;
+        j += 2;
+        continue;
+      }
+      if (c === '"') {
+        return { value: out, end: j + 1 };
+      }
+      out += c;
+      j += 1;
+    }
+    throw new Error('unterminated basic string');
+  }
+
+  // Literal string
+  if (ch === '\'') {
+    if (text.startsWith('\'\'\'', i)) {
+      const close = text.indexOf('\'\'\'', i + 3);
+      if (close === -1) throw new Error('unterminated multi-line literal string');
+      return { value: text.slice(i + 3, close).replace(/^\r?\n/, ''), end: close + 3 };
+    }
+    const close = text.indexOf('\'', i + 1);
+    if (close === -1) throw new Error('unterminated literal string');
+    return { value: text.slice(i + 1, close), end: close + 1 };
+  }
+
+  // Boolean
+  if (text.startsWith('true', i) && !/[A-Za-z0-9_-]/.test(text[i + 4] || '')) {
+    return { value: true, end: i + 4 };
+  }
+  if (text.startsWith('false', i) && !/[A-Za-z0-9_-]/.test(text[i + 5] || '')) {
+    return { value: false, end: i + 5 };
+  }
+
+  // Inline array
+  if (ch === '[') {
+    const arr = [];
+    let j = i + 1;
+    while (true) {
+      while (j < text.length && /[\s\r\n]/.test(text[j])) j += 1;
+      if (j >= text.length) throw new Error('unterminated inline array');
+      if (text[j] === ']') return { value: arr, end: j + 1 };
+      if (text[j] === '#') {
+        const nl = text.indexOf('\n', j);
+        j = nl === -1 ? text.length : nl + 1;
+        continue;
+      }
+      const parsed = parseTomlValue(text, j);
+      arr.push(parsed.value);
+      j = parsed.end;
+      while (j < text.length && /[\s\r\n]/.test(text[j])) j += 1;
+      if (j < text.length && text[j] === ',') {
+        j += 1;
+        continue;
+      }
+      while (j < text.length && /[\s\r\n]/.test(text[j])) j += 1;
+      if (text[j] === ']') return { value: arr, end: j + 1 };
+      throw new Error(`expected , or ] in inline array at offset ${j}`);
+    }
+  }
+
+  // Inline table
+  if (ch === '{') {
+    const obj = {};
+    let j = i + 1;
+    while (true) {
+      while (j < text.length && /[\s\r\n]/.test(text[j])) j += 1;
+      if (text[j] === '}') return { value: obj, end: j + 1 };
+      const keyMatch = text.slice(j).match(/^([A-Za-z0-9_-]+|"[^"]*"|'[^']*')\s*=\s*/);
+      if (!keyMatch) throw new Error(`expected key in inline table at offset ${j}`);
+      let rawKey = keyMatch[1];
+      if ((rawKey.startsWith('"') && rawKey.endsWith('"')) || (rawKey.startsWith('\'') && rawKey.endsWith('\''))) {
+        rawKey = rawKey.slice(1, -1);
+      }
+      j += keyMatch[0].length;
+      const parsed = parseTomlValue(text, j);
+      obj[rawKey] = parsed.value;
+      j = parsed.end;
+      while (j < text.length && /[\s\r\n]/.test(text[j])) j += 1;
+      if (text[j] === ',') { j += 1; continue; }
+      if (text[j] === '}') return { value: obj, end: j + 1 };
+      throw new Error(`expected , or } in inline table at offset ${j}`);
+    }
+  }
+
+  // Number (integer with optional sign). Float / date / time / hex / oct / bin
+  // are NOT supported — we reject them explicitly instead of silently truncating
+  // an integer prefix off a `0.5` float or `1979-05-27` date. (#2760 CR4 finding 3)
+  const numMatch = text.slice(i).match(/^[+-]?\d[\d_]*/);
+  if (numMatch) {
+    const after = text[i + numMatch[0].length];
+    // Reject: float (`.`, `e`, `E`), date/time (`-`, `:`, `T`, `Z`), or any
+    // continuation digit/letter that suggests an unsupported numeric form.
+    if (after !== undefined && /[.eE:\-TZ]/.test(after)) {
+      throw new Error(
+        `unsupported TOML value at offset ${i}: floats, dates, and times are not supported (got ${text.slice(i, i + 20)})`
+      );
+    }
+    const digits = numMatch[0].replace(/_/g, '');
+    const n = Number(digits);
+    if (!Number.isFinite(n)) throw new Error(`invalid number: ${numMatch[0]}`);
+    return { value: n, end: i + numMatch[0].length };
+  }
+
+  throw new Error(`unsupported value at offset ${i}: ${text.slice(i, i + 20)}`);
+}
+
+/**
+ * Parse TOML content into a JavaScript object. Throws on malformed input.
+ *
+ * Handles `[table]`, `[[array.of.tables]]`, dotted key paths, and the value
+ * forms supported by parseTomlValue. Sufficient for validating Codex config
+ * structure and for behavioral test assertions in #2760 — not a general
+ * TOML implementation.
+ */
+function parseTomlToObject(content) {
+  const root = {};
+  const records = getTomlLineRecords(content);
+  // Tracks the *object* (not path) that subsequent key=value lines target.
+  let currentTable = root;
+
+  // #2760 CR5 finding 2 — track shape and definition status of every path so
+  // we can reject duplicate header redeclarations, shape mismatches, and
+  // duplicate keys per real TOML 1.0 semantics. Without this, walkPath
+  // silently reuses existing tables and assignment overwrites existing keys —
+  // a real TOML parser would refuse the file.
+  //
+  // pathShape: dotted path -> 'table' | 'array' | 'inline_parent' | 'key'
+  //   - 'table' — declared via [a.b]
+  //   - 'array' — declared via [[a.b]] (path is the array itself; each
+  //               element is its own implicit table)
+  //   - 'inline_parent' — created implicitly while walking parents
+  //   - 'key'   — assigned a scalar value
+  // declaredHeaders: set of dotted paths explicitly declared via [hdr] (not
+  //   [[arr]]) — used to reject duplicate [a] / [a] sections.
+  // tableKeys: dotted-path -> Set<string> of keys assigned in that exact
+  //   table instance. For [[arr]] elements we use a per-element marker.
+  const pathShape = new Map();
+  const declaredHeaders = new Set();
+  const tableKeys = new Map();
+  // currentTableId — string identifier for the current table instance, used
+  // as the key into tableKeys so that key uniqueness is per-table-instance
+  // (each [[arr]] element gets its own id).
+  let currentTableId = '__root__';
+  pathShape.set('__root__', 'table');
+  tableKeys.set('__root__', new Set());
+
+  function ensureKeySet(id) {
+    if (!tableKeys.has(id)) tableKeys.set(id, new Set());
+    return tableKeys.get(id);
+  }
+
+  function walkPath(segments, { creatingArrayElement = false } = {}) {
+    let node = root;
+    const parents = segments.slice(0, -1);
+    const last = segments[segments.length - 1];
+
+    for (let p = 0; p < parents.length; p += 1) {
+      const seg = parents[p];
+      const partialPath = parents.slice(0, p + 1).join('.');
+      if (node[seg] === undefined) {
+        node[seg] = {};
+        if (!pathShape.has(partialPath)) {
+          pathShape.set(partialPath, 'inline_parent');
+        }
+      } else if (Array.isArray(node[seg])) {
+        // Walk into the latest element of an array-of-tables.
+        node = node[seg][node[seg].length - 1];
+        continue;
+      } else if (typeof node[seg] !== 'object' || node[seg] === null) {
+        throw new Error(`path segment ${seg} is not a table`);
+      }
+      node = node[seg];
+    }
+
+    const fullPath = segments.join('.');
+
+    if (creatingArrayElement) {
+      const existingShape = pathShape.get(fullPath);
+      if (node[last] === undefined) {
+        node[last] = [];
+        pathShape.set(fullPath, 'array');
+      } else if (!Array.isArray(node[last])) {
+        throw new Error(
+          `duplicate or shape-mismatched table header at ${fullPath}: ` +
+          `cannot redefine as array of tables (previously seen as ${existingShape || 'table'})`
+        );
+      } else if (existingShape && existingShape !== 'array') {
+        throw new Error(
+          `duplicate or shape-mismatched table header at ${fullPath}: ` +
+          `previously seen as ${existingShape}, cannot extend as array of tables`
+        );
+      }
+      const elem = {};
+      node[last].push(elem);
+      const elemId = `${fullPath}[${node[last].length - 1}]`;
+      pathShape.set(elemId, 'array_element');
+      tableKeys.set(elemId, new Set());
+      currentTableId = elemId;
+      return elem;
+    }
+
+    // Plain [table] header.
+    if (node[last] === undefined) {
+      node[last] = {};
+      pathShape.set(fullPath, 'table');
+      declaredHeaders.add(fullPath);
+      tableKeys.set(fullPath, new Set());
+    } else if (Array.isArray(node[last])) {
+      throw new Error(
+        `duplicate or shape-mismatched table header at ${fullPath}: ` +
+          `previously declared as array of tables ([[${fullPath}]]), cannot redeclare as table ([${fullPath}])`
+      );
+    } else if (typeof node[last] !== 'object') {
+      throw new Error(`cannot redefine ${fullPath} as table`);
+    } else if (declaredHeaders.has(fullPath)) {
+      throw new Error(
+        `duplicate or shape-mismatched table header at ${fullPath}: ` +
+          `[${fullPath}] declared more than once`
+      );
+    } else {
+      // Implicitly created earlier (e.g., as a parent path); first explicit
+      // declaration is allowed.
+      pathShape.set(fullPath, 'table');
+      declaredHeaders.add(fullPath);
+      if (!tableKeys.has(fullPath)) tableKeys.set(fullPath, new Set());
+    }
+    currentTableId = fullPath;
+    return node[last];
+  }
+
+  for (let idx = 0; idx < records.length; idx += 1) {
+    const rec = records[idx];
+    if (rec.startsInMultilineString) continue;
+    if (rec.tableHeader) {
+      const segs = rec.tableHeader.segments;
+      currentTable = walkPath(segs, { creatingArrayElement: rec.tableHeader.array });
+      continue;
+    }
+
+    const trimmed = rec.text.trim();
+    if (trimmed === '' || trimmed.startsWith('#')) continue;
+
+    const equalsIndex = findTomlAssignmentEquals(rec.text);
+    if (equalsIndex === -1) continue;
+
+    const keyText = rec.text.slice(0, equalsIndex).trim();
+    const segments = parseTomlKeyPath(keyText);
+    if (!segments) {
+      throw new Error(`invalid TOML key on line ${idx + 1}: ${rec.text}`);
+    }
+
+    // Value RHS may span multiple lines (inline arrays, multi-line strings,
+    // inline tables). Parse from the absolute content offset right after `=`.
+    const valueStartAbs = rec.start + equalsIndex + 1;
+    const parsed = parseTomlValue(content, valueStartAbs);
+
+    // #2760 CR4 finding 3 — verify the full RHS was consumed. Anything other
+    // than whitespace + optional # comment between parsed.end and the next
+    // newline (or EOF) means the parser silently accepted a prefix and
+    // dropped trailing bytes. Reject so malformed TOML cannot slip past
+    // "parse before commit" guarantees.
+    let scan = parsed.end;
+    while (scan < content.length && (content[scan] === ' ' || content[scan] === '\t')) {
+      scan += 1;
+    }
+    if (scan < content.length && content[scan] !== '\n' && content[scan] !== '\r' && content[scan] !== '#') {
+      const lineEnd = content.indexOf('\n', scan);
+      const trailing = content.slice(scan, lineEnd === -1 ? content.length : lineEnd);
+      throw new Error(
+        `trailing bytes after value on line ${idx + 1}: ${JSON.stringify(trailing)}`
+      );
+    }
+
+    // Place value into currentTable under dotted key.
+    // #2760 CR5 finding 2 — reject duplicate keys per real TOML 1.0. Track
+    // the dotted key against the current table instance id; an exact repeat
+    // throws.
+    let target = currentTable;
+    for (let s = 0; s < segments.length - 1; s += 1) {
+      const seg = segments[s];
+      if (target[seg] === undefined) target[seg] = {};
+      else if (typeof target[seg] !== 'object' || Array.isArray(target[seg])) {
+        throw new Error(`cannot descend into non-table key ${seg}`);
+      }
+      target = target[seg];
+    }
+    const finalKey = segments[segments.length - 1];
+    const dottedKey = segments.join('.');
+    const keySet = ensureKeySet(currentTableId);
+    if (keySet.has(dottedKey) || Object.prototype.hasOwnProperty.call(target, finalKey)) {
+      throw new Error(
+        `duplicate key ${dottedKey} in ${currentTableId === '__root__' ? 'root table' : currentTableId}`
+      );
+    }
+    keySet.add(dottedKey);
+    target[finalKey] = parsed.value;
+  }
+
+  return root;
+}
+
+/**
+ * Validate that the post-install config.toml matches Codex's expected schema
+ * (#2760, fix 3). Returns { ok: true } on success, or { ok: false, reason }
+ * with a human-readable explanation of the offending section.
+ *
+ * Strategy: parse the bytes into a structured object first — malformed TOML
+ * fails validation immediately rather than slipping past a header-only scan.
+ * Then enforce the schema-shape rules against the parsed structure.
+ *
+ * Schema rules enforced:
+ *   - File MUST parse as TOML (no syntax errors).
+ *   - `agents` MUST be a struct table (`[agents.<name>]`) — never a bare
+ *     table value or an array of tables.
+ *   - `hooks.<Event>` MUST be an array of tables when present (Codex ≥0.124
+ *     rejects bare `[hooks.<Event>]` single-bracket maps).
+ */
+function validateCodexConfigSchema(content) {
+  let parsed;
+  try {
+    parsed = parseTomlToObject(content);
+  } catch (e) {
+    return {
+      ok: false,
+      reason: `TOML parse failed: ${e.message}`,
+    };
+  }
+
+  // Header-shape check: arrays-of-tables are visible in the parsed structure
+  // (as Array values) but bare-vs-struct distinction for `[agents]` requires
+  // looking at section headers too — `[agents]` with `default = "x"` parses
+  // to `{ agents: { default: 'x' } }`, indistinguishable from
+  // `[agents.foo]` writing into the same shape. Use header sections to
+  // disambiguate.
+  const sections = getTomlTableSections(content);
+
+  for (const section of sections) {
+    if (section.array && section.path === 'agents') {
+      return {
+        ok: false,
+        reason: '[[agents]] sequence form is invalid in current Codex schema (expected [agents.<name>] struct form)',
+      };
+    }
+
+    if (!section.array && section.path === 'agents') {
+      return {
+        ok: false,
+        reason: 'bare [agents] table is invalid in current Codex schema (expected [agents.<name>] struct form)',
+      };
+    }
+
+    if (!section.array && section.path.startsWith('hooks.')) {
+      return {
+        ok: false,
+        reason: `bare [${section.path}] table is invalid in current Codex schema (expected [[${section.path}]] array-of-tables)`,
+      };
+    }
+  }
+
+  // Structural confirmation against parsed object: any present hooks.<Event>
+  // must be an array.
+  if (parsed.hooks && typeof parsed.hooks === 'object' && !Array.isArray(parsed.hooks)) {
+    for (const [event, value] of Object.entries(parsed.hooks)) {
+      if (!Array.isArray(value)) {
+        return {
+          ok: false,
+          reason: `hooks.${event} must be an array of tables, got ${typeof value}`,
+        };
+      }
+    }
+  }
+
+  return { ok: true };
 }
 
 function normalizeCodexHooksLine(line, key) {
@@ -3093,13 +3553,37 @@ function rewriteTomlKeyLines(content, matches, key) {
 }
 
 /**
+ * Atomic write — write to <target>.tmp-<pid>-<n> first, then renameSync over
+ * the target. Eliminates the partial-write corruption window: an interrupted
+ * write leaves the temp file (which we clean up) but never truncates the
+ * original target. Used for any mutation of Codex config.toml so we cannot
+ * leave the user with a half-written file (#2760 fix 4).
+ */
+let __atomicWriteCounter = 0;
+function atomicWriteFileSync(target, data, options) {
+  __atomicWriteCounter += 1;
+  const tmp = `${target}.tmp-${process.pid}-${__atomicWriteCounter}`;
+  try {
+    fs.writeFileSync(tmp, data, options);
+    fs.renameSync(tmp, target);
+  } catch (e) {
+    // Best-effort cleanup of the partial temp file; never mask the real error.
+    try { fs.rmSync(tmp, { force: true }); } catch (_) { /* ignore */ }
+    throw e;
+  }
+}
+
+/**
  * Merge GSD config block into an existing or new config.toml.
  * Three cases: new file, existing with GSD marker, existing without marker.
+ *
+ * All writes go through atomicWriteFileSync so a mid-write failure leaves
+ * the original config.toml untouched (#2760 fix 4).
  */
 function mergeCodexConfig(configPath, gsdBlock) {
   // Case 1: No config.toml — create fresh
   if (!fs.existsSync(configPath)) {
-    fs.writeFileSync(configPath, gsdBlock + '\n');
+    atomicWriteFileSync(configPath, gsdBlock + '\n');
     return;
   }
 
@@ -3115,9 +3599,9 @@ function mergeCodexConfig(configPath, gsdBlock) {
       // Strip any GSD-managed sections that leaked above the marker from previous installs
       before = stripLeakedGsdCodexSections(before).trimEnd();
 
-      fs.writeFileSync(configPath, before + eol + eol + normalizedGsdBlock + eol);
+      atomicWriteFileSync(configPath, before + eol + eol + normalizedGsdBlock + eol);
     } else {
-      fs.writeFileSync(configPath, normalizedGsdBlock + eol);
+      atomicWriteFileSync(configPath, normalizedGsdBlock + eol);
     }
     return;
   }
@@ -3130,7 +3614,7 @@ function mergeCodexConfig(configPath, gsdBlock) {
     content = normalizedGsdBlock + eol;
   }
 
-  fs.writeFileSync(configPath, content);
+  atomicWriteFileSync(configPath, content);
 }
 
 /**
@@ -6412,9 +6896,36 @@ function install(isGlobal, runtime = 'claude') {
   }
 
   if (isCodex && !isMinimalMode(installMode)) {
-    // Generate Codex config.toml and per-agent .toml files.
-    // Skipped under --minimal — same rationale as filesystem agents above.
-    const agentCount = installCodexConfig(targetDir, agentsSrc);
+    // Capture pre-install snapshot of config.toml before ANY GSD mutation
+    // (#2760 fix 3). On post-write schema-validation failure OR any throw
+    // during the mutation sequence (write failure, merge throw, etc.) we
+    // restore these exact bytes so the user is never left with a broken
+    // Codex CLI (#2760 fix 4 — extends snapshot coverage to write-failure
+    // paths, paired with atomic temp-file writes in mergeCodexConfig and
+    // the final hooks-write below).
+    const codexConfigPathPreInstall = path.join(targetDir, 'config.toml');
+    const codexConfigPreInstallSnapshot = fs.existsSync(codexConfigPathPreInstall)
+      ? fs.readFileSync(codexConfigPathPreInstall)
+      : null;
+
+    const restoreCodexSnapshot = () => {
+      if (codexConfigPreInstallSnapshot !== null) {
+        try { fs.writeFileSync(codexConfigPathPreInstall, codexConfigPreInstallSnapshot); }
+        catch (_) { /* best-effort restore — surface the original error */ }
+      } else if (fs.existsSync(codexConfigPathPreInstall)) {
+        try { fs.rmSync(codexConfigPathPreInstall); } catch (_) { /* best-effort */ }
+      }
+    };
+
+    let agentCount;
+    try {
+      // Generate Codex config.toml and per-agent .toml files.
+      // Skipped under --minimal — same rationale as filesystem agents above.
+      agentCount = installCodexConfig(targetDir, agentsSrc);
+    } catch (e) {
+      restoreCodexSnapshot();
+      throw e;
+    }
     console.log(`  ${green}✓${reset} Generated config.toml with ${agentCount} agent roles`);
     console.log(`  ${green}✓${reset} Generated ${agentCount} agent .toml config files`);
 
@@ -6454,6 +6965,10 @@ function install(isGlobal, runtime = 'claude') {
 
     // Add Codex hooks (SessionStart for update checking) — requires codex_hooks feature flag
     const configPath = path.join(targetDir, 'config.toml');
+    // Use the pre-install snapshot captured before installCodexConfig ran so
+    // restore returns the file to its true pre-GSD state on validation
+    // failure (#2760 fix 3) — not to the post-agent-merge state.
+    const preWriteBackup = codexConfigPreInstallSnapshot;
     try {
       let configContent = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf-8') : '';
       const eol = detectLineEnding(configContent);
@@ -6470,13 +6985,22 @@ function install(isGlobal, runtime = 'claude') {
       const codexHooksFeature = ensureCodexHooksFeature(configContent);
       configContent = setManagedCodexHooksOwnership(codexHooksFeature.content, codexHooksFeature.ownership);
 
-      // Add SessionStart hook for update checking
+      // Add SessionStart hook for update checking. Default to top-level
+      // `[[hooks]]` AoT with `event` field — the form GSD has emitted since
+      // the Codex 0.124 migration (#2637). When the user already uses the
+      // namespaced AoT form `[[hooks.SessionStart]]` for their own hooks,
+      // emit our managed entry in that same shape so the two forms don't
+      // collide on round-trip (#2760, defect 3).
       const updateCheckScript = path.resolve(targetDir, 'hooks', 'gsd-check-update.js').replace(/\\/g, '/');
-      const hookBlock =
-        `${eol}# GSD Hooks${eol}` +
-        `[[hooks]]${eol}` +
-        `event = "SessionStart"${eol}` +
-        `command = "node ${updateCheckScript}"${eol}`;
+      const useNamespacedAot = hasUserNamespacedAotHooks(configContent, 'SessionStart');
+      const hookBlock = useNamespacedAot
+        ? `${eol}# GSD Hooks${eol}` +
+          `[[hooks.SessionStart]]${eol}` +
+          `command = "node ${updateCheckScript}"${eol}`
+        : `${eol}# GSD Hooks${eol}` +
+          `[[hooks]]${eol}` +
+          `event = "SessionStart"${eol}` +
+          `command = "node ${updateCheckScript}"${eol}`;
 
       // Migrate legacy gsd-update-check entries from prior installs (#1755 followup)
       // Remove stale hook blocks that used the inverted filename or wrong path.
@@ -6488,14 +7012,89 @@ function install(isGlobal, runtime = 'claude') {
         );
       }
 
+      // #2760 CR4 finding 2 — Strip ALL existing managed gsd-check-update
+      // hook blocks (top-level [[hooks]] AND namespaced [[hooks.SessionStart]])
+      // BEFORE evaluating the includes guard. Without this, an install that
+      // already has a legacy flat [[hooks]] block short-circuits the new
+      // namespaced AoT emit and stays stuck in the mixed layout this fix is
+      // designed to eliminate. Stripping first means every install converges
+      // on the right shape regardless of prior state.
+      if (configContent.includes('gsd-check-update')) {
+        configContent = configContent.replace(
+          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\]\]\r?\nevent = "SessionStart"\r?\ncommand = "node [^\r\n]*gsd-check-update\.js"\r?\n/gm,
+          (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
+        );
+        configContent = configContent.replace(
+          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\.SessionStart\]\]\r?\ncommand = "node [^\r\n]*gsd-check-update\.js"\r?\n/gm,
+          (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
+        );
+      }
+
       if (hasEnabledCodexHooksFeature(configContent) && !configContent.includes('gsd-check-update')) {
         configContent += hookBlock;
       }
 
-      fs.writeFileSync(configPath, configContent, 'utf-8');
+      // #2760 fix 3 — post-write schema validation. Parse the bytes we are
+      // about to commit and assert they match Codex's expected shape. If
+      // validation fails we restore the pre-install backup and abort so the
+      // user is never left with a Codex CLI that won't load.
+      // Test seam: tests can inject `__codexSchemaValidator` to force the
+      // validator to fail and exercise the restore-and-abort path.
+      const validatorFn = (typeof module !== 'undefined' && module.exports && module.exports.__codexSchemaValidator)
+        ? module.exports.__codexSchemaValidator
+        : validateCodexConfigSchema;
+      const validation = validatorFn(configContent);
+      if (!validation.ok) {
+        restoreCodexSnapshot();
+        throw new Error(
+          `post-write Codex schema validation failed: ${validation.reason}. ` +
+          `Restored ${preWriteBackup !== null ? 'pre-install backup' : 'empty state'}.`
+        );
+      }
+
+      // Atomic write (#2760 fix 4) — write to a sibling temp file, then
+      // renameSync over the target. A mid-write failure cannot truncate the
+      // existing config; the snapshot restore below is a second line of
+      // defense if even the rename fails.
+      try {
+        atomicWriteFileSync(configPath, configContent, 'utf-8');
+      } catch (writeErr) {
+        // #2760 CR4 finding 1 — write failure must be loud and fatal. Wrap
+        // with a `post-write` prefix the outer catch recognises so install
+        // aborts with a clear error rather than warn-and-continue (which
+        // produced "Done!" with no Codex agents configured).
+        restoreCodexSnapshot();
+        const wrapped = new Error(
+          `post-write Codex install failed: ${writeErr && writeErr.message ? writeErr.message : String(writeErr)}. ` +
+          `Restored ${preWriteBackup !== null ? 'pre-install backup' : 'empty state'}.`
+        );
+        throw wrapped;
+      }
       console.log(`  ${green}✓${reset} Configured Codex hooks (SessionStart)`);
     } catch (e) {
-      console.warn(`  ${yellow}⚠${reset}  Could not configure Codex hooks: ${e.message}`);
+      // #2760 — schema-validation and write failures must be loud and fatal
+      // so the user is never left with a config Codex refuses to load (or no
+      // Codex agents configured at all). The pre-install snapshot restore has
+      // already run for write-side throws via the inner catch above and via
+      // restoreCodexSnapshot in the validation branch.
+      if (e && typeof e.message === 'string' && e.message.startsWith('post-write')) {
+        console.error(`  ${red}✗${reset} ${e.message}`);
+        throw e;
+      }
+      // #2760 CR5 finding 1 — pre-write failures (migrateCodexHooksMapFormat,
+      // ensureCodexHooksFeature, config reads, configContent construction,
+      // etc.) must ALSO be fatal. Previously this branch downgraded to a
+      // console.warn, leaving the install to print "Done!" with no Codex
+      // hooks configured — same defect class as finding 1, different layer.
+      // Restore the pre-install snapshot and rethrow so the outer install
+      // pipeline aborts.
+      restoreCodexSnapshot();
+      const wrapped = new Error(
+        `Codex hook configuration failed (pre-write): ${e && e.message ? e.message : String(e)}. ` +
+          `Restored ${preWriteBackup !== null ? 'pre-install backup' : 'empty state'}.`
+      );
+      console.error(`  ${red}✗${reset} ${wrapped.message}`);
+      throw wrapped;
     }
 
     return { settingsPath: null, settings: null, statuslineCommand: null, runtime, configDir: targetDir };
@@ -7638,6 +8237,9 @@ if (process.env.GSD_TEST_MODE) {
     generateCodexConfigBlock,
     stripGsdFromCodexConfig,
     migrateCodexHooksMapFormat,
+    hasUserNamespacedAotHooks,
+    parseTomlToObject,
+    validateCodexConfigSchema,
     mergeCodexConfig,
     installCodexConfig,
     readGsdRuntimeProfileResolver,

--- a/bin/install.js
+++ b/bin/install.js
@@ -1123,21 +1123,21 @@ function convertClaudeCommandToCopilotSkill(content, skillName, isGlobal = false
 
 /**
  * Map a skill directory name (gsd-<cmd>) to the frontmatter `name:` used
- * by Claude Code as the skill identity. Workflows emit `Skill(skill="gsd:<cmd>")`
- * (colon form) and Claude Code resolves skills by frontmatter `name:`, not
- * directory name — so emit colon form here. Directory stays hyphenated for
- * Windows path safety. See #2643.
+ * by Claude Code as the skill identity. Emits the hyphen form (gsd-<cmd>)
+ * so Claude Code autocomplete shows the canonical invocation form, not the
+ * deprecated colon form. See #2808.
+ *
+ * Historical note: this previously returned `gsd:<cmd>` (colon) because
+ * workflows called Skill(skill="gsd:<cmd>"). Those calls have been updated
+ * to use hyphen form (#2808) so the colon rewrite is no longer needed.
  *
  * Codex must NOT use this helper: its adapter invokes skills as `$gsd-<cmd>`
- * (shell-var syntax) and a colon would terminate the variable name. Codex
- * keeps the hyphen form via `yamlQuote(skillName)` directly.
+ * (shell-var syntax) — hyphen form is already correct there.
  */
 function skillFrontmatterName(skillDirName) {
   if (typeof skillDirName !== 'string') return skillDirName;
-  // Idempotent on already-colon form.
-  if (skillDirName.includes(':')) return skillDirName;
-  // Only rewrite the first hyphen after the `gsd` prefix.
-  return skillDirName.replace(/^gsd-/, 'gsd:');
+  // Return the hyphen form as-is (gsd-<cmd>) — canonical since #2808.
+  return skillDirName;
 }
 
 /**

--- a/bin/install.js
+++ b/bin/install.js
@@ -2628,6 +2628,11 @@ function getTomlTableSections(content) {
 
   return headerLines.map((record, index) => ({
     path: record.tableHeader.path,
+    // segments preserves the true parsed key count so callers that need to
+    // distinguish a 2-segment path like hooks."before.tool" from a 3-segment
+    // path like hooks.SessionStart.hooks can do so without splitting on dots
+    // (which misclassifies quoted key names that contain dot characters).
+    segments: record.tableHeader.segments,
     array: record.tableHeader.array,
     start: record.start,
     headerEnd: record.end + record.eol.length,
@@ -2891,40 +2896,133 @@ function stripLeakedGsdCodexSections(content) {
 function migrateCodexHooksMapFormat(content) {
   const sections = getTomlTableSections(content);
 
-  // Find all non-array hooks sections: [hooks] or [hooks.TYPE]
-  const legacyHooksSections = sections.filter(
-    (section) => !section.array && (section.path === 'hooks' || section.path.startsWith('hooks.'))
+  // Find all non-array hooks sections: bare [hooks] container or [hooks.TYPE] event tables.
+  // Use section.segments (parsed key count) rather than section.path.startsWith() so that
+  // nested handler tables like [hooks.SessionStart.hooks] (3 segments) are not mistakenly
+  // included and re-emitted as an event named "SessionStart.hooks".
+  const legacyMapSections = sections.filter(
+    (section) => !section.array && (
+      section.path === 'hooks' ||
+      (section.path.startsWith('hooks.') && section.segments.length === 2)
+    )
   );
 
-  if (legacyHooksSections.length === 0) {
+  // Find flat [[hooks]] array-of-tables entries (path === 'hooks', array === true).
+  // These are incompatible with [[hooks.<EVENT>]] namespaced form — both cannot
+  // coexist in the same TOML file because `hooks` cannot be simultaneously an
+  // array and a table. Migrate each flat entry to [[hooks.<EVENT>]] form using
+  // the `event` key as the event name.
+  const flatAotSections = sections.filter(
+    (section) => section.array && section.path === 'hooks'
+  );
+
+  // Find [[hooks.TYPE]] namespaced AoT entries that carry handler fields
+  // (command, type, timeout, statusMessage) at event-entry level but have no
+  // [[hooks.TYPE.hooks]] sub-table. This is the pre-#2773 single-block shape
+  // that Codex 0.124.0+ rejects. Promote them to the two-level nested form.
+  // Entries that already have a [[hooks.TYPE.hooks]] sub-table are left untouched.
+  // Matcher-only entries (no handler fields) are intentionally valid and skipped.
+  const STALE_HANDLER_FIELD_PATTERN = /^\s*(?:command|type|timeout|statusMessage)\s*=/m;
+  const staleNamespacedAotSections = sections.filter((section) => {
+    if (!section.array) return false;
+    if (!section.path.startsWith('hooks.')) return false;
+    // [[hooks.TYPE.hooks]] sub-tables have 3 parsed segments — skip them.
+    // Use section.segments (true parsed key count) rather than splitting
+    // section.path on '.', which misclassifies quoted event names that contain
+    // dots (e.g. [[hooks."before.tool"]] has segments ['hooks','before.tool']
+    // but path 'hooks.before.tool' would split into 3 parts).
+    if (section.segments.length !== 2) return false;
+    // Must carry at least one handler field at event-entry level.
+    const body = content.slice(section.headerEnd, section.end);
+    if (!STALE_HANDLER_FIELD_PATTERN.test(body)) return false;
+    // Don't migrate when the nested [[hooks.TYPE.hooks]] sub-table already exists.
+    const subPath = section.path + '.hooks';
+    return !sections.some((s) => s.array && s.path === subPath);
+  });
+
+  if (legacyMapSections.length === 0 && flatAotSections.length === 0 && staleNamespacedAotSections.length === 0) {
     return content;
   }
 
   const eol = detectLineEnding(content);
 
-  // Build [[hooks]] blocks for each [hooks.TYPE] section (skipping bare [hooks])
-  const newHooksBlocks = [];
-  for (const section of legacyHooksSections) {
-    if (section.path === 'hooks') {
-      // Bare [hooks] container — drop it (no key-value content to convert)
-      continue;
+  // Helper: parse a hooks body into event-level and handler-level entries,
+  // returning { eventEntries, handlerEntries, hasExplicitType }.
+  // Event-level keys: matcher. Everything else is handler-level.
+  // The `event` key (used in flat [[hooks]] blocks) is consumed as the type
+  // name and excluded from both levels.
+  const EVENT_LEVEL_KEYS = new Set(['matcher']);
+  function parseHooksBody(body, skipKeys = new Set()) {
+    const bodyLines = body.split(/\r?\n/);
+    const eventEntries = [];
+    const handlerEntries = [];
+    let hasExplicitType = false;
+    for (const line of bodyLines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      // Use parseTomlKey so hyphenated keys (e.g. status-message) and quoted
+      // keys are recognised — the old /^([\w.]+)\s*=/ regex silently dropped them.
+      const parsed = parseTomlKey(trimmed);
+      if (!parsed) continue;
+      // Hook body keys are always single-segment; use segments[0] for the name.
+      const key = parsed.segments[0];
+      if (skipKeys.has(key)) continue;
+      if (key === 'type') {
+        hasExplicitType = true;
+        handlerEntries.push(trimmed);
+      } else if (EVENT_LEVEL_KEYS.has(key)) {
+        eventEntries.push(trimmed);
+      } else {
+        handlerEntries.push(trimmed);
+      }
     }
-
-    // Extract the type from the path: "hooks.shell" → "shell"
-    const type = section.path.slice('hooks.'.length);
-    const body = content.slice(section.headerEnd, section.end);
-
-    // #2760 CR5 finding 3 — emit the namespaced AoT form directly:
-    // `[[hooks.<TYPE>]]` (no synthetic `event` field — the namespace IS the
-    // event). Previously we emitted flat `[[hooks]]\nevent = "<TYPE>"`,
-    // which produced mixed flat + namespaced layouts when the user already
-    // had `[[hooks.<OTHER>]]` entries. With every migration emit using the
-    // namespaced shape, the managed-emit detector
-    // (`hasUserNamespacedAotHooks`) fires correctly and the install
-    // converges on a single hook layout.
-    const block = `[[hooks.${type}]]${eol}${body}`;
-    newHooksBlocks.push(block);
+    return { eventEntries, handlerEntries, hasExplicitType };
   }
+
+  // TOML key quoting: bare keys may only contain [A-Za-z0-9_-]. Event names
+  // containing spaces, dots, or other punctuation must be wrapped in double-
+  // quoted TOML strings with backslash and double-quote characters escaped.
+  // Using raw event names in [[hooks.${type}]] headers produces invalid TOML
+  // for any non-bare-key character (e.g. "Before Tool" → [[hooks.Before Tool]]).
+  function tomlBareKey(key) {
+    if (/^[A-Za-z0-9_-]+$/.test(key)) return key;
+    return '"' + key.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+  }
+
+  function buildNestedBlock(type, body, skipKeys = new Set()) {
+    const quotedType = tomlBareKey(type);
+    const { eventEntries, handlerEntries, hasExplicitType } = parseHooksBody(body, skipKeys);
+    const eventBody = eventEntries.length > 0 ? eventEntries.join(eol) + eol : '';
+    // If no handler fields were found (e.g. matcher-only entry), do not synthesise
+    // an empty [[hooks.TYPE.hooks]] block — that would produce structurally valid
+    // TOML but semantically broken output (a handler entry with no command).
+    if (handlerEntries.length === 0) {
+      return `[[hooks.${quotedType}]]${eol}${eventBody}`;
+    }
+    if (!hasExplicitType) handlerEntries.unshift('type = "command"');
+    const handlerBody = handlerEntries.join(eol) + eol;
+    return `[[hooks.${quotedType}]]${eol}${eventBody}${eol}[[hooks.${quotedType}.hooks]]${eol}${handlerBody}`;
+  }
+
+  // Extract the event name from a flat [[hooks]] section body.
+  // Returns null if no `event` key is found, if the value is an empty string, or if
+  // the quoting is unrecognised. Both TOML double-quoted ("...") and single-quoted
+  // ('...') strings are accepted. An empty event string (event = "" or event = '')
+  // is explicitly rejected — it cannot be meaningfully namespaced and is left untouched.
+  function extractFlatHookEventName(body) {
+    const TOML_EVENT_CAPTURE = /^\s*event\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'([^']*)')/m;
+    const m = body.match(TOML_EVENT_CAPTURE);
+    if (!m) return null;
+    const name = (m[1] ?? m[2] ?? '').trim();
+    return name || null;
+  }
+
+  const migratedFlatAotSections = flatAotSections.filter((section) => {
+    const body = content.slice(section.headerEnd, section.end);
+    return extractFlatHookEventName(body) !== null;
+  });
+
+  const legacyHooksSections = [...legacyMapSections, ...migratedFlatAotSections, ...staleNamespacedAotSections];
 
   // Remove all legacy hooks sections from the content
   let result = removeContentRanges(
@@ -2933,28 +3031,43 @@ function migrateCodexHooksMapFormat(content) {
   );
   result = collapseTomlBlankLines(result);
 
-  // Insert new [[hooks]] blocks at the position of the first legacy section
-  // (adjusted for removed content), or append if nothing remains before EOF.
-  if (newHooksBlocks.length > 0) {
-    const insertionText = newHooksBlocks.join('');
-    // Find a good insertion point: before the first remaining table section
-    // that came after our removed hooks, or just append.
-    const remainingSections = getTomlTableSections(result);
-    const firstHooksSection = legacyHooksSections[0];
-
-    // Find the first remaining section whose original start was after the legacy hooks block
-    const anchorSection = remainingSections.find((s) => {
-      // Use content position in the result string as a heuristic
-      // We insert before the first non-hooks section if any exists
-      return s.start > 0;
+  // Map-format blocks ([hooks.TYPE]) are inserted at the position of the first
+  // remaining table section (preserving their relative placement in the file).
+  // Flat AoT blocks ([[hooks]] with event = "...") are always APPENDED because
+  // flat [[hooks]] entries only appear at the END of a TOML file (AoT cannot
+  // precede a regular table), and inserting before the first table would push
+  // them above [features] / [model] etc., corrupting relative ordering.
+  const mapOnlyBlocks = legacyMapSections
+    .filter((s) => s.path !== 'hooks')   // skip bare [hooks] container
+    .map((s) => {
+      const type = s.path.slice('hooks.'.length);
+      const body = content.slice(s.headerEnd, s.end);
+      return buildNestedBlock(type, body);
     });
 
-    // Prefer to insert the new blocks right before the first remaining table
-    // that was originally positioned after the legacy hooks area, but since
-    // positions shift after removal, we simply append before the first table
-    // header or at end-of-file.
+  // Stale namespaced AoT blocks: [[hooks.TYPE]] entries with handler fields at
+  // event-entry level (no .hooks sub-table). Treated like map-format blocks —
+  // inserted before the first remaining table section.
+  const staleNamespacedAotBlocks = staleNamespacedAotSections.map((s) => {
+    const type = s.path.slice('hooks.'.length);
+    const body = content.slice(s.headerEnd, s.end);
+    return buildNestedBlock(type, body);
+  });
+
+  const flatAotBlocks = migratedFlatAotSections.map((s) => {
+    const body = content.slice(s.headerEnd, s.end);
+    const eventName = extractFlatHookEventName(body);
+    if (!eventName) return '';
+    return buildNestedBlock(eventName, body, new Set(['event']));
+  }).filter(Boolean);
+
+  // Insert map-format and stale-namespaced-AoT conversions before the first
+  // remaining table section (both share the same placement strategy).
+  const allMapStyleBlocks = [...mapOnlyBlocks, ...staleNamespacedAotBlocks];
+  if (allMapStyleBlocks.length > 0) {
+    const insertionText = allMapStyleBlocks.join('');
+    const remainingSections = getTomlTableSections(result);
     if (remainingSections.length > 0) {
-      // Find where to insert: after any leading top-level keys, before first table
       const firstTable = remainingSections[0];
       const before = result.slice(0, firstTable.start);
       const after = result.slice(firstTable.start);
@@ -2966,7 +3079,23 @@ function migrateCodexHooksMapFormat(content) {
         (needsTrailingGap ? eol : '') +
         after;
     } else {
-      // No remaining sections — append
+      const needsGap = result.length > 0 && !result.endsWith(eol + eol);
+      result = result + (needsGap ? eol : '') + insertionText;
+    }
+  }
+
+  // Insert flat-AoT conversions before the GSD managed marker (if present) so
+  // the migrated user hooks stay in the "user" portion of the file and are not
+  // swept away when stripGsdFromCodexConfig strips from the marker to EOF.
+  // If no marker exists, append at the end of the file.
+  if (flatAotBlocks.length > 0) {
+    const insertionText = flatAotBlocks.join('');
+    const markerIdx = result.indexOf(GSD_CODEX_MARKER);
+    if (markerIdx !== -1) {
+      const before = result.slice(0, markerIdx).trimEnd();
+      const after = result.slice(markerIdx);
+      result = before + eol + eol + insertionText + eol + after;
+    } else {
       const needsGap = result.length > 0 && !result.endsWith(eol + eol);
       result = result + (needsGap ? eol : '') + insertionText;
     }
@@ -3400,14 +3529,63 @@ function validateCodexConfigSchema(content) {
   }
 
   // Structural confirmation against parsed object: any present hooks.<Event>
-  // must be an array.
-  if (parsed.hooks && typeof parsed.hooks === 'object' && !Array.isArray(parsed.hooks)) {
-    for (const [event, value] of Object.entries(parsed.hooks)) {
-      if (!Array.isArray(value)) {
-        return {
-          ok: false,
-          reason: `hooks.${event} must be an array of tables, got ${typeof value}`,
-        };
+  // must be an array, and flat top-level [[hooks]] (parsed as Array on root)
+  // is rejected — Codex 0.124.0+ requires [[hooks.<Event>]] namespaced form.
+  if (parsed.hooks !== undefined) {
+    if (Array.isArray(parsed.hooks)) {
+      return {
+        ok: false,
+        reason: 'flat [[hooks]] array-of-tables is invalid in Codex 0.124.0+ (expected [[hooks.<Event>]] namespaced form)',
+      };
+    }
+    if (typeof parsed.hooks === 'object' && parsed.hooks !== null) {
+      for (const [event, value] of Object.entries(parsed.hooks)) {
+        // Skip the nested .hooks sub-array — it lives under hooks.<Event>[n].hooks
+        // and is validated separately below.
+        if (!Array.isArray(value)) {
+          return {
+            ok: false,
+            reason: `hooks.${event} must be an array of tables, got ${typeof value}`,
+          };
+        }
+        // Each entry in hooks.<Event> must either be a matcher-only filter (no
+        // handler fields) or carry a .hooks sub-array of handler tables.
+        // Entries with handler fields (command, type, timeout, statusMessage) at
+        // event-entry level but without a .hooks sub-table are the pre-#2773
+        // single-block shape that Codex 0.124.0+ rejects. migrateCodexHooksMapFormat
+        // converts these before validation runs; their presence here means migration
+        // failed to cover this entry — fail loudly rather than pass a broken config.
+        const HANDLER_FIELD_NAMES = new Set(['command', 'type', 'timeout', 'statusMessage']);
+        for (const entry of value) {
+          if (!entry || typeof entry !== 'object') continue;
+          if (entry.hooks === undefined) {
+            const strayKey = Object.keys(entry).find((k) => HANDLER_FIELD_NAMES.has(k));
+            if (strayKey) {
+              return {
+                ok: false,
+                reason: `hooks.${event}[] entry has handler field "${strayKey}" at event-entry level; ` +
+                  `Codex 0.124.0+ requires handler fields nested under [[hooks.${event}.hooks]]`,
+              };
+            }
+            continue;
+          }
+          if (!Array.isArray(entry.hooks)) {
+            return {
+              ok: false,
+              reason: `hooks.${event}[].hooks must be an array of handler tables, got ${typeof entry.hooks}`,
+            };
+          }
+          for (const handler of entry.hooks) {
+            if (handler && typeof handler === 'object' && handler.type !== undefined) {
+              if (handler.type !== 'command') {
+                return {
+                  ok: false,
+                  reason: `hooks.${event}[].hooks[].type must be "command", got "${handler.type}"`,
+                };
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -6973,62 +7151,64 @@ function install(isGlobal, runtime = 'claude') {
       let configContent = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf-8') : '';
       const eol = detectLineEnding(configContent);
 
-      // Migrate legacy [hooks] map format to [[hooks]] array-of-tables (#2637).
-      // Codex 0.124.0 requires [[hooks]] array-of-tables; old GSD installs wrote
-      // [hooks.shell] map tables which now cause a startup parse error.
+      // Strip ALL prior GSD-managed hook blocks BEFORE migration so the migration
+      // only touches user-authored hooks, not GSD-owned stale entries. Running
+      // strip after migration causes Shape 1 (legacy gsd-update-check filename)
+      // to be converted by migration before the strip regex can match it (#2698).
+      //
+      // Historical shapes stripped, in order:
+      //   Shape 1 — legacy gsd-update-check filename (pre-#1755): flat [[hooks]] + event
+      //   Shape 2 — flat [[hooks]] + event = "SessionStart" (#2637 era, never correct)
+      //   Shape 4 — correct two-block nested (strip before shape 3 to avoid orphaned header)
+      //   Shape 3 — single-block [[hooks.SessionStart]] without nested .hooks (#2760 era)
+      if (configContent.includes('gsd-update-check') || configContent.includes('gsd-check-update')) {
+        // Shape 1
+        configContent = configContent.replace(
+          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\]\]\r?\nevent = "SessionStart"\r?\ncommand = "node [^\r\n]*gsd-update-check\.js"\r?\n/gm,
+          (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
+        );
+        // Shape 2
+        configContent = configContent.replace(
+          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\]\]\r?\nevent = "SessionStart"\r?\ncommand = "node [^\r\n]*gsd-check-update\.js"\r?\n/gm,
+          (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
+        );
+        // Shape 4 — strip before shape 3 to avoid orphaned header
+        configContent = configContent.replace(
+          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\.SessionStart\]\]\r?\n\r?\n\[\[hooks\.SessionStart\.hooks\]\]\r?\ntype = "command"\r?\ncommand = "node [^\r\n]*(?:gsd-check-update|gsd-update-check)\.js"\r?\n/gm,
+          (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
+        );
+        // Shape 3
+        configContent = configContent.replace(
+          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\.SessionStart\]\]\r?\ncommand = "node [^\r\n]*(?:gsd-check-update|gsd-update-check)\.js"\r?\n/gm,
+          (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
+        );
+      }
+
+      // Migrate legacy [hooks] map format and flat [[hooks]] AoT entries to the
+      // namespaced [[hooks.<EVENT>]] form after stripping GSD-managed stale blocks.
+      // Running migration after strip ensures only user-authored hooks are migrated
+      // (#2698 regression: migration before strip converts stale GSD blocks before
+      // the strip regexes can match their original shape).
       const migratedContent = migrateCodexHooksMapFormat(configContent);
       if (migratedContent !== configContent) {
         configContent = migratedContent;
-        console.log(`  ${green}✓${reset} Migrated legacy Codex [hooks] map format to [[hooks]] array-of-tables`);
+        console.log(`  ${green}✓${reset} Migrated legacy Codex [hooks] format to two-level nested AoT`);
       }
 
       const codexHooksFeature = ensureCodexHooksFeature(configContent);
       configContent = setManagedCodexHooksOwnership(codexHooksFeature.content, codexHooksFeature.ownership);
 
-      // Add SessionStart hook for update checking. Default to top-level
-      // `[[hooks]]` AoT with `event` field — the form GSD has emitted since
-      // the Codex 0.124 migration (#2637). When the user already uses the
-      // namespaced AoT form `[[hooks.SessionStart]]` for their own hooks,
-      // emit our managed entry in that same shape so the two forms don't
-      // collide on round-trip (#2760, defect 3).
+      // Add SessionStart hook for update checking. Codex 0.124.0+ requires the
+      // two-level nested AoT schema: [[hooks.SessionStart]] for the event entry
+      // (holds optional matcher) and [[hooks.SessionStart.hooks]] for the handler
+      // (holds type, command, statusMessage, timeout). (#2637, #2760, #2773)
       const updateCheckScript = path.resolve(targetDir, 'hooks', 'gsd-check-update.js').replace(/\\/g, '/');
-      const useNamespacedAot = hasUserNamespacedAotHooks(configContent, 'SessionStart');
-      const hookBlock = useNamespacedAot
-        ? `${eol}# GSD Hooks${eol}` +
-          `[[hooks.SessionStart]]${eol}` +
-          `command = "node ${updateCheckScript}"${eol}`
-        : `${eol}# GSD Hooks${eol}` +
-          `[[hooks]]${eol}` +
-          `event = "SessionStart"${eol}` +
-          `command = "node ${updateCheckScript}"${eol}`;
-
-      // Migrate legacy gsd-update-check entries from prior installs (#1755 followup)
-      // Remove stale hook blocks that used the inverted filename or wrong path.
-      // Single \r?\n-aware regex handles LF, CRLF, and block-at-file-start (#2698).
-      if (configContent.includes('gsd-update-check')) {
-        configContent = configContent.replace(
-          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\]\]\r?\nevent = "SessionStart"\r?\ncommand = "node [^\r\n]*gsd-update-check\.js"\r?\n/gm,
-          (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
-        );
-      }
-
-      // #2760 CR4 finding 2 — Strip ALL existing managed gsd-check-update
-      // hook blocks (top-level [[hooks]] AND namespaced [[hooks.SessionStart]])
-      // BEFORE evaluating the includes guard. Without this, an install that
-      // already has a legacy flat [[hooks]] block short-circuits the new
-      // namespaced AoT emit and stays stuck in the mixed layout this fix is
-      // designed to eliminate. Stripping first means every install converges
-      // on the right shape regardless of prior state.
-      if (configContent.includes('gsd-check-update')) {
-        configContent = configContent.replace(
-          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\]\]\r?\nevent = "SessionStart"\r?\ncommand = "node [^\r\n]*gsd-check-update\.js"\r?\n/gm,
-          (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
-        );
-        configContent = configContent.replace(
-          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\.SessionStart\]\]\r?\ncommand = "node [^\r\n]*gsd-check-update\.js"\r?\n/gm,
-          (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
-        );
-      }
+      const hookBlock = `${eol}# GSD Hooks${eol}` +
+        `[[hooks.SessionStart]]${eol}` +
+        `${eol}` +
+        `[[hooks.SessionStart.hooks]]${eol}` +
+        `type = "command"${eol}` +
+        `command = "node ${updateCheckScript}"${eol}`;
 
       if (hasEnabledCodexHooksFeature(configContent) && !configContent.includes('gsd-check-update')) {
         configContent += hookBlock;

--- a/commands/gsd/add-backlog.md
+++ b/commands/gsd/add-backlog.md
@@ -54,7 +54,7 @@ the normal phase sequence and accumulate context over time.
 
 5. **Commit:**
    ```bash
-   gsd-sdk query commit "docs: add backlog item ${NEXT} — ${ARGUMENTS}" .planning/ROADMAP.md ".planning/phases/${NEXT}-${SLUG}/.gitkeep"
+   gsd-sdk query commit "docs: add backlog item ${NEXT} — ${ARGUMENTS}" --files .planning/ROADMAP.md ".planning/phases/${NEXT}-${SLUG}/.gitkeep"
    ```
 
 6. **Report:**

--- a/commands/gsd/review-backlog.md
+++ b/commands/gsd/review-backlog.md
@@ -47,7 +47,7 @@ milestone sequence or remove stale entries.
 
 6. **Commit changes:**
    ```bash
-   gsd-sdk query commit "docs: review backlog — promoted N, removed M" .planning/ROADMAP.md
+   gsd-sdk query commit "docs: review backlog — promoted N, removed M" --files .planning/ROADMAP.md
    ```
 
 7. **Report summary:**

--- a/commands/gsd/thread.md
+++ b/commands/gsd/thread.md
@@ -83,7 +83,7 @@ When SUBCMD=close and SLUG is set (already sanitized):
 
 3. Commit:
    ```bash
-   gsd-sdk query commit "docs: resolve thread — {SLUG}" ".planning/threads/{SLUG}.md"
+   gsd-sdk query commit "docs: resolve thread — {SLUG}" --files ".planning/threads/{SLUG}.md"
    ```
 
 4. Print:
@@ -191,7 +191,7 @@ updated: {today ISO date}
 
 5. Commit:
    ```bash
-   gsd-sdk query commit "docs: create thread — ${ARGUMENTS}" ".planning/threads/${SLUG}.md"
+   gsd-sdk query commit "docs: create thread — ${ARGUMENTS}" --files ".planning/threads/${SLUG}.md"
    ```
 
 6. Report:

--- a/docs/RELEASE-v1.39.0-rc.4.md
+++ b/docs/RELEASE-v1.39.0-rc.4.md
@@ -1,0 +1,84 @@
+# v1.39.0-rc.4 Release Notes
+
+Pre-release candidate. Published to npm under the `next` tag.
+
+```
+npx get-shit-done-cc@next
+```
+
+---
+
+## What's in this release
+
+### Added
+
+**`--minimal` install flag** (alias `--core-only`) (#2762)
+
+Writes only the six core skills needed to run the main workflow loop:
+`new-project`, `discuss-phase`, `plan-phase`, `execute-phase`, `help`, `update`.
+No `gsd-*` subagents are installed.
+
+| Mode | Cold-start system-prompt overhead |
+|------|-----------------------------------|
+| full (default) | ~12k tokens |
+| minimal | ~700 tokens |
+
+Useful for local LLMs with 32K–128K context windows. Sonnet 4.6 / Opus 4.7 users
+don't need it — the full surface is the right default for cloud models.
+
+The install manifest records `mode: "minimal" | "full"`. Run `gsd update` without
+`--minimal` at any time to expand to the full skill set.
+
+---
+
+### Fixed
+
+**Codex install no longer corrupts `~/.codex/config.toml`** (#2760)
+
+Four users confirmed the same breakage: the previous installer left
+`~/.codex/config.toml` in a state that Codex rejected on launch, with manual file
+cleanup as the only workaround.
+
+The installer now:
+
+- Strips legacy `[agents]` (single-bracket) and `[[agents]]` (sequence) blocks
+  unconditionally — both are invalid in the current Codex TOML schema, regardless of
+  whether a GSD marker is present.
+- Emits the GSD-managed hook in the shape the user's config already uses:
+  `[[hooks.<Event>]]` namespaced AoT if any existing hook uses that form, otherwise
+  top-level `[[hooks]]`.
+- Migrates any legacy `[hooks.<Event>]` (map format) to `[[hooks.<Event>]]` (array
+  format) during write.
+- Writes atomically via a temp file + `renameSync` — no partial writes.
+- Validates the post-write bytes with a strict TOML parser that rejects duplicate
+  keys, repeated table headers, trailing bytes after values, and unsupported value
+  types.
+- On any pre-write or write-time failure, restores the pre-install snapshot and aborts
+  with a clear error instead of warn-and-continue.
+
+---
+
+## Installing the pre-release
+
+```bash
+# npm
+npm install -g get-shit-done-cc@next
+
+# npx (one-shot)
+npx get-shit-done-cc@next
+```
+
+To pin to this exact RC:
+
+```bash
+npm install -g get-shit-done-cc@1.39.0-rc.4
+```
+
+---
+
+## What's next
+
+- Run `rc` again on the release branch to publish rc.5 if further fixes land before
+  finalization.
+- Run `finalize` on the release workflow to promote `1.39.0` to `latest` when the RC
+  is stable.

--- a/docs/RELEASE-v1.39.0-rc.5.md
+++ b/docs/RELEASE-v1.39.0-rc.5.md
@@ -2,7 +2,7 @@
 
 Pre-release candidate. Published to npm under the `next` tag.
 
-```
+```bash
 npx get-shit-done-cc@next
 ```
 

--- a/docs/RELEASE-v1.39.0-rc.5.md
+++ b/docs/RELEASE-v1.39.0-rc.5.md
@@ -1,0 +1,99 @@
+# v1.39.0-rc.5 Release Notes
+
+Pre-release candidate. Published to npm under the `next` tag.
+
+```
+npx get-shit-done-cc@next
+```
+
+---
+
+## What's in this release
+
+All fixes from rc.4, plus:
+
+### Fixed
+
+**Codex hooks migrator correctness hardening** (#2809)
+
+Five edge-cases in the `[[hooks.<Event>]]` → `[[hooks.<Event>.hooks]]` two-level nested
+schema migration path, discovered across five rounds of code review:
+
+| Finding | Fix |
+|---------|-----|
+| `parseHooksBody` used a bare regex (`/^([\w.]+)\s*=/`) that silently dropped hyphenated keys such as `status-message` and any quoted TOML key | Replaced with `parseTomlKey()`, the existing full TOML key parser |
+| `buildNestedBlock` unconditionally emitted `[[hooks.TYPE.hooks]]` even when no handler fields were present, producing an entry with `type = "command"` but no `command` | Added guard: matcher-only / handler-field-free sections emit only the event-entry block |
+| `legacyMapSections` filter used `section.path.startsWith('hooks.')` without checking the segment count, so three-segment tables like `[hooks.SessionStart.hooks]` were misclassified as event entries and re-emitted as bogus nested events | Now uses `section.segments.length === 2` (same fix previously applied to `staleNamespacedAotSections`) |
+| No regression test for quoted event names containing dots — `[[hooks."before.tool"]]` has a 2-segment path but 3 dot-parts, and a `split('.')` check would misclassify it | Regression test added; quoted-dot names are correctly treated as a single two-segment namespace |
+| Handler command path assertion in install tests used a regex (`/gsd-check-update\.js/`) rather than the exact absolute path | Strengthened to `assert.strictEqual` with `path.join(codexHome, 'hooks', 'gsd-check-update.js')` |
+
+---
+
+## What was in rc.4
+
+### Added
+
+**`--minimal` install flag** (alias `--core-only`) (#2762)
+
+Writes only the six core skills needed to run the main workflow loop:
+`new-project`, `discuss-phase`, `plan-phase`, `execute-phase`, `help`, `update`.
+No `gsd-*` subagents are installed.
+
+| Mode | Cold-start system-prompt overhead |
+|------|-----------------------------------|
+| full (default) | ~12k tokens |
+| minimal | ~700 tokens |
+
+Useful for local LLMs with 32K–128K context windows. Sonnet 4.6 / Opus 4.7 users
+don't need it — the full surface is the right default for cloud models.
+
+The install manifest records `mode: "minimal" | "full"`. Run `gsd update` without
+`--minimal` at any time to expand to the full skill set.
+
+### Fixed (rc.4)
+
+**Codex install no longer corrupts `~/.codex/config.toml`** (#2760)
+
+The installer now:
+
+- Strips legacy `[agents]` (single-bracket) and `[[agents]]` (sequence) blocks
+  unconditionally — both are invalid in the current Codex TOML schema, regardless of
+  whether a GSD marker is present.
+- Emits the GSD-managed hook in the shape the user's config already uses:
+  `[[hooks.<Event>]]` namespaced AoT if any existing hook uses that form, otherwise
+  top-level `[[hooks]]`.
+- Migrates any legacy `[hooks.<Event>]` (map format) to `[[hooks.<Event>]]` (array
+  format) during write.
+- Writes atomically via a temp file + `renameSync` — no partial writes.
+- Validates the post-write bytes with a strict TOML parser that rejects duplicate
+  keys, repeated table headers, trailing bytes after values, and unsupported value
+  types.
+- On any pre-write or write-time failure, restores the pre-install snapshot and aborts
+  with a clear error instead of warn-and-continue.
+
+---
+
+## Installing the pre-release
+
+```bash
+# npm
+npm install -g get-shit-done-cc@next
+
+# npx (one-shot)
+npx get-shit-done-cc@next
+```
+
+To pin to this exact RC:
+
+```bash
+npm install -g get-shit-done-cc@1.39.0-rc.5
+```
+
+---
+
+## What's next
+
+- Run `rc` again on the release branch to publish rc.6 if further fixes land before
+  finalization.
+- Run `finalize` on the release workflow to promote `1.39.0` to `latest` when the RC
+  is stable.

--- a/docs/zh-CN/references/git-integration.md
+++ b/docs/zh-CN/references/git-integration.md
@@ -51,7 +51,7 @@ Phases:
 提交内容：
 
 ```bash
-gsd-sdk query commit "docs: initialize [project-name] ([N] phases)" .planning/
+gsd-sdk query commit "docs: initialize [project-name] ([N] phases)" --files .planning/
 ```
 
 </format>
@@ -129,7 +129,7 @@ SUMMARY: .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md
 提交内容：
 
 ```bash
-gsd-sdk query commit "docs({phase}-{plan}): complete [plan-name] plan" .planning/phases/XX-name/{phase}-{plan}-PLAN.md .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md .planning/STATE.md .planning/ROADMAP.md
+gsd-sdk query commit "docs({phase}-{plan}): complete [plan-name] plan" --files .planning/phases/XX-name/{phase}-{plan}-PLAN.md .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md .planning/STATE.md .planning/ROADMAP.md
 ```
 
 **注意：** 代码文件不包含 - 已按任务提交。
@@ -149,7 +149,7 @@ Current: [task name]
 提交内容：
 
 ```bash
-gsd-sdk query commit "wip: [phase-name] paused at task [X]/[Y]" .planning/
+gsd-sdk query commit "wip: [phase-name] paused at task [X]/[Y]" --files .planning/
 ```
 
 </format>

--- a/docs/zh-CN/references/git-planning-commit.md
+++ b/docs/zh-CN/references/git-planning-commit.md
@@ -4,12 +4,12 @@
 
 ## 通过 CLI 提交
 
-先传提交说明，再传文件路径（位置参数）。`commit` 不要使用 `--files`（该标志仅用于 `commit-to-subrepo`）。
+先传提交说明，然后用 `--files` 显式传入文件路径。`commit` 与 `commit-to-subrepo` 都应使用 `--files` 来声明要提交的路径。
 
 对 `.planning/` 文件始终使用此方式 —— 它会自动处理 `commit_docs` 与 gitignore 检查：
 
 ```bash
-gsd-sdk query commit "docs({scope}): {description}" .planning/STATE.md .planning/ROADMAP.md
+gsd-sdk query commit "docs({scope}): {description}" --files .planning/STATE.md .planning/ROADMAP.md
 ```
 
 如果 `commit_docs` 为 `false` 或 `.planning/` 被 gitignore，CLI 会返回 `skipped`（带原因）。无需手动条件检查。
@@ -19,7 +19,7 @@ gsd-sdk query commit "docs({scope}): {description}" .planning/STATE.md .planning
 将 `.planning/` 文件变更合并到上次提交：
 
 ```bash
-gsd-sdk query commit "" .planning/codebase/*.md --amend
+gsd-sdk query commit "" --files .planning/codebase/*.md --amend
 ```
 
 ## 提交消息模式

--- a/docs/zh-CN/references/planning-config.md
+++ b/docs/zh-CN/references/planning-config.md
@@ -40,7 +40,7 @@
 
 ```bash
 # 提交时自动检查 commit_docs + gitignore：
-gsd-sdk query commit "docs: update state" .planning/STATE.md
+gsd-sdk query commit "docs: update state" --files .planning/STATE.md
 
 # 通过 state load 加载配置（返回 JSON）：
 INIT=$(gsd-sdk query state.load)
@@ -58,7 +58,7 @@ if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 **通过 CLI 提交（自动处理检查）：**
 
 ```bash
-gsd-sdk query commit "docs: update state" .planning/STATE.md
+gsd-sdk query commit "docs: update state" --files .planning/STATE.md
 ```
 
 CLI 在内部检查 `commit_docs` 配置和 gitignore 状态 —— 无需手动条件判断。

--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -484,7 +484,7 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
         const { 'keep-recent': keepRecent, 'dry-run': dryRun } = parseNamedArgs(args, ['keep-recent'], ['dry-run']);
         state.cmdStatePrune(cwd, { keepRecent: keepRecent || '3', dryRun: !!dryRun }, raw);
       } else if (subcommand === 'complete-phase') {
-        state.cmdStateCompletePhase(cwd, args, raw);
+        state.cmdStateCompletePhase(cwd, raw);
       } else if (subcommand === 'milestone-switch') {
         // Bug #2630: reset STATE.md frontmatter + Current Position for new milestone.
         // NB: the flag is `--milestone`, not `--version` — gsd-tools reserves

--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -884,6 +884,9 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
         case 'quick':
           init.cmdInitQuick(cwd, args.slice(2).join(' '), raw);
           break;
+        case 'ingest-docs':
+          init.cmdInitIngestDocs(cwd, raw);
+          break;
         case 'resume':
           init.cmdInitResume(cwd, raw);
           break;
@@ -918,7 +921,7 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
           init.cmdInitRemoveWorkspace(cwd, args[2], raw);
           break;
         default:
-          error(`Unknown init workflow: ${workflow}\nAvailable: execute-phase, plan-phase, new-project, new-milestone, quick, resume, verify-work, phase-op, todos, milestone-op, map-codebase, progress, manager, new-workspace, list-workspaces, remove-workspace`);
+          error(`Unknown init workflow: ${workflow}\nAvailable: execute-phase, plan-phase, new-project, new-milestone, quick, ingest-docs, resume, verify-work, phase-op, todos, milestone-op, map-codebase, progress, manager, new-workspace, list-workspaces, remove-workspace`);
       }
       break;
     }

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1380,8 +1380,10 @@ function extractCurrentMilestone(content, cwd) {
 
   const sectionStart = sectionMatch.index;
 
-  // Find the end: next milestone heading at same or higher level, or EOF
+  // Find the end: next milestone heading at same or higher level, or EOF.
   // Milestone headings look like: ## v2.0, ## Roadmap v2.0, ## ✅ v1.0, etc.
+  // Scan line-by-line so that heading-like lines inside fenced code blocks
+  // (``` or ~~~) are not mistaken for milestone boundaries. See #2787.
   const headingLevel = sectionMatch[1].match(/^(#{1,3})\s/)[1].length;
   const restContent = content.slice(sectionStart + sectionMatch[0].length);
   // Exclude phase headings (e.g. "### Phase 12: v1.0 Tech-Debt Closure") from
@@ -1389,15 +1391,31 @@ function extractCurrentMilestone(content, cwd) {
   // the title. Phase headings always start with the literal `Phase `. See #2619.
   const nextMilestonePattern = new RegExp(
     `^#{1,${headingLevel}}\\s+(?!Phase\\s+\\S)(?:.*v\\d+\\.\\d+|✅|📋|🚧)`,
-    'mi'
+    'i'
   );
-  const nextMatch = restContent.match(nextMilestonePattern);
 
-  let sectionEnd;
-  if (nextMatch) {
-    sectionEnd = sectionStart + sectionMatch[0].length + nextMatch.index;
-  } else {
-    sectionEnd = content.length;
+  let sectionEnd = content.length;
+  let fenceChar = null;
+  let fenceLen = 0;
+  let charOffset = 0;
+  for (const line of restContent.split('\n')) {
+    const fenceMatch = line.match(/^\s{0,3}((?:`{3,}|~{3,}))(.*)/);
+    if (fenceMatch) {
+      const char = fenceMatch[1][0];
+      const len = fenceMatch[1].length;
+      const trailing = fenceMatch[2] || '';
+      if (!fenceChar) {
+        fenceChar = char;
+        fenceLen = len;
+      } else if (char === fenceChar && len >= fenceLen && /^\s*$/.test(trailing)) {
+        fenceChar = null;
+        fenceLen = 0;
+      }
+    } else if (!fenceChar && nextMilestonePattern.test(line)) {
+      sectionEnd = sectionStart + sectionMatch[0].length + charOffset;
+      break;
+    }
+    charOffset += line.length + 1;
   }
 
   // Return everything before the current milestone section (non-milestone content

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -7,6 +7,11 @@ const path = require('path');
 const { execSync } = require('child_process');
 const { loadConfig, resolveModelInternal, findPhaseInternal, getRoadmapPhaseInternal, pathExistsInternal, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, stripShippedMilestones, extractCurrentMilestone, normalizePhaseName, planningPaths, planningDir, planningRoot, toPosixPath, output, error, checkAgentsInstalled, phaseTokenMatches } = require('./core.cjs');
 
+// Accept all bold/colon variants of the Requirements header (#2769):
+// **Requirements:** / **Requirements**: / **Requirements** : render the
+// same in markdown but differ textually.
+const REQUIREMENTS_HEADER_RE = /^\*\*Requirements:?\*\*[^\S\n]*:?[^\S\n]*([^\n]*)$/m;
+
 function getLatestCompletedMilestone(cwd) {
   const milestonesPath = path.join(planningRoot(cwd), 'MILESTONES.md');
   if (!fs.existsSync(milestonesPath)) return null;
@@ -102,7 +107,7 @@ function cmdInitExecutePhase(cwd, phase, raw, options = {}) {
       has_reviews: false,
     };
   }
-  const reqMatch = roadmapPhase?.section?.match(/^\*\*Requirements\*\*:[^\S\n]*([^\n]*)$/m);
+  const reqMatch = roadmapPhase?.section?.match(REQUIREMENTS_HEADER_RE);
   const reqExtracted = reqMatch
     ? reqMatch[1].replace(/[\[\]]/g, '').split(',').map(s => s.trim()).filter(Boolean).join(', ')
     : null;
@@ -235,7 +240,7 @@ function cmdInitPlanPhase(cwd, phase, raw, options = {}) {
       has_reviews: false,
     };
   }
-  const reqMatch = roadmapPhase?.section?.match(/^\*\*Requirements\*\*:[^\S\n]*([^\n]*)$/m);
+  const reqMatch = roadmapPhase?.section?.match(REQUIREMENTS_HEADER_RE);
   const reqExtracted = reqMatch
     ? reqMatch[1].replace(/[\[\]]/g, '').split(',').map(s => s.trim()).filter(Boolean).join(', ')
     : null;

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -562,6 +562,25 @@ function cmdInitQuick(cwd, description, raw) {
   output(withProjectRoot(cwd, result), raw);
 }
 
+/**
+ * Init handler for ingest-docs workflow (#2801).
+ *
+ * Returns the minimal set of fields that ingest-docs.md needs to detect
+ * whether a project/planning dir exists and choose new vs merge mode.
+ * Mirrors the initIngestDocs SDK handler in sdk/src/query/init.ts.
+ */
+function cmdInitIngestDocs(cwd, raw) {
+  const config = loadConfig(cwd);
+  const result = {
+    project_exists: pathExistsInternal(cwd, '.planning/PROJECT.md'),
+    planning_exists: fs.existsSync(planningRoot(cwd)),
+    has_git: fs.existsSync(path.join(cwd, '.git')),
+    project_path: '.planning/PROJECT.md',
+    commit_docs: config.commit_docs,
+  };
+  output(withProjectRoot(cwd, result), raw);
+}
+
 function cmdInitResume(cwd, raw) {
   const config = loadConfig(cwd);
 
@@ -1928,6 +1947,7 @@ module.exports = {
   cmdInitNewProject,
   cmdInitNewMilestone,
   cmdInitQuick,
+  cmdInitIngestDocs,
   cmdInitResume,
   cmdInitVerifyWork,
   cmdInitPhaseOp,

--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -868,7 +868,11 @@ function cmdPhaseComplete(cwd, phaseNum, raw) {
         );
 
         const sectionText = phaseSectionMatch ? phaseSectionMatch[1] : '';
-        const reqMatch = sectionText.match(/\*\*Requirements:\*\*\s*([^\n]+)/i);
+        // Accept all bold/colon variants (#2769) — the previous pattern only
+        // matched **Requirements:** (colon inside bold) and silently skipped
+        // **Requirements**: (colon outside), preventing the matching REQ-IDs
+        // from being ticked off in REQUIREMENTS.md on phase completion.
+        const reqMatch = sectionText.match(/\*\*Requirements:?\*\*[^\S\n]*:?[^\S\n]*([^\n]+)/i);
 
         let reqContent = fs.readFileSync(reqPath, 'utf-8');
 

--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -7,6 +7,35 @@ const path = require('path');
 const { escapeRegex, normalizePhaseName, planningPaths, withPlanningLock, output, error, findPhaseInternal, stripShippedMilestones, extractCurrentMilestone, replaceInCurrentMilestone, phaseTokenMatches, atomicWriteFileSync } = require('./core.cjs');
 
 /**
+ * Coerce an arbitrary YAML scalar/object into a string for cross-cutting
+ * truth aggregation. Handles:
+ *   - strings (passthrough)
+ *   - numbers / booleans (String() coercion — issue #2770: bare YAML ints
+ *     like `- 3` must be surfaced, not silently skipped)
+ *   - kv-shaped objects from parseMustHavesBlock continuation kv (issue
+ *     #2757) — extract the first meaningful string field
+ *
+ * Returns the empty string when no usable text can be derived; callers should
+ * skip empty results.
+ */
+function coerceTruthToString(t) {
+  if (t === null || t === undefined) return '';
+  if (typeof t === 'string') return t;
+  if (typeof t === 'number' || typeof t === 'boolean' || typeof t === 'bigint') {
+    return String(t);
+  }
+  if (typeof t === 'object') {
+    // Prefer common title-bearing keys produced by parseMustHavesBlock
+    for (const k of ['title', 'text', 'name', 'rule', 'path', 'provides']) {
+      const v = t[k];
+      if (typeof v === 'string' && v.trim()) return v;
+      if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+    }
+  }
+  return '';
+}
+
+/**
  * Search for a phase header (and its section) within the given content string.
  * Returns a result object if found (either a full match or a malformed_roadmap
  * checklist-only match), or null if the phase is not present at all.
@@ -412,16 +441,26 @@ function cmdRoadmapAnnotateDependencies(cwd, phaseNum, raw) {
   }
   const waves = [...waveGroups.keys()].sort((a, b) => a - b);
 
-  // Find cross-cutting truths: appear in 2+ plans (de-duplicated, case-insensitive)
+  // Find cross-cutting truths: appear in 2+ plans (de-duplicated, case-insensitive).
+  //
+  // Issue #2770: must **coerce, not skip**. A previous guard
+  // `if (typeof t !== 'string') continue` silently dropped numeric scalars
+  // (YAML ints like `- 3`) and kv-shaped truths (`- title: X`), so the
+  // cross-cutting analysis lost real constraints rather than crashing on
+  // `t.trim()`. We coerce primitives via `String(t)` and extract a sensible
+  // string field from object-shaped items produced by parseMustHavesBlock's
+  // continuation-kv path (issue #2757 produces those shapes for nested keys).
   const truthCounts = new Map();
   for (const { truths } of planData) {
     const seen = new Set();
     for (const t of truths) {
-      if (typeof t !== 'string') continue;
-      const key = t.trim().toLowerCase();
+      const text = coerceTruthToString(t);
+      if (!text) continue;
+      const trimmed = text.trim();
+      const key = trimmed.toLowerCase();
       if (!key || seen.has(key)) continue;
       seen.add(key);
-      truthCounts.set(key, (truthCounts.get(key) || { count: 0, text: t.trim() }));
+      if (!truthCounts.has(key)) truthCounts.set(key, { count: 0, text: trimmed });
       truthCounts.get(key).count++;
     }
   }

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -1689,7 +1689,7 @@ function cmdStatePrune(cwd, options, raw) {
  * that the phase execution is finished and the project is ready for the next phase.
  * Implements the `gsd state complete-phase` subcommand (issue #2735).
  */
-function cmdStateCompletePhase(cwd, args, raw) {
+function cmdStateCompletePhase(cwd, raw) {
   const statePath = planningPaths(cwd).state;
   if (!fs.existsSync(statePath)) {
     output({ error: 'STATE.md not found' }, raw);
@@ -1698,12 +1698,23 @@ function cmdStateCompletePhase(cwd, args, raw) {
 
   const today = new Date().toISOString().split('T')[0];
   const updated = [];
+  let resolvedPhase = '?';
 
   readModifyWriteStateMd(statePath, (content) => {
-    // Read the current phase number for descriptive messages
-    const currentPhase = stateExtractField(content, 'Current Phase') ||
-                         stateExtractField(content, 'Phase') ||
-                         '?';
+    // Read the current phase number for descriptive messages.
+    //
+    // The 'Phase' fallback can match the decorated body line under
+    // `## Current Position` (e.g. `Phase: 01 (Foo) — EXECUTING`), which would
+    // flow downstream into messy `Status: Phase 01 (Foo) — EXECUTING complete`
+    // output. Strip everything past the leading numeric/decimal token so the
+    // fallback path produces a clean phase identifier matching the canonical
+    // `Current Phase` field. CodeRabbit nitpick on PR #2761.
+    const rawPhase = stateExtractField(content, 'Current Phase') ||
+                     stateExtractField(content, 'Phase') ||
+                     '';
+    const phaseToken = rawPhase.match(/^\s*([\w.-]+)/);
+    const currentPhase = phaseToken ? phaseToken[1] : '?';
+    resolvedPhase = currentPhase;
 
     // Update Status field
     const statusValue = `Phase ${currentPhase} complete`;
@@ -1752,7 +1763,7 @@ function cmdStateCompletePhase(cwd, args, raw) {
   }, cwd);
 
   output(
-    { updated, phase: stateExtractField(fs.readFileSync(planningPaths(cwd).state, 'utf-8'), 'Current Phase') || '?' },
+    { updated, phase: resolvedPhase },
     raw,
     updated.length > 0 ? 'true' : 'false',
   );

--- a/get-shit-done/references/autonomous-smart-discuss.md
+++ b/get-shit-done/references/autonomous-smart-discuss.md
@@ -266,7 +266,7 @@ Write the file.
 **Commit:**
 
 ```bash
-gsd-sdk query commit "docs(${PADDED_PHASE}): smart discuss context" "${phase_dir}/${padded_phase}-CONTEXT.md"
+gsd-sdk query commit "docs(${PADDED_PHASE}): smart discuss context" --files "${phase_dir}/${padded_phase}-CONTEXT.md"
 ```
 
 Display confirmation:

--- a/get-shit-done/references/git-integration.md
+++ b/get-shit-done/references/git-integration.md
@@ -51,7 +51,7 @@ Phases:
 What to commit:
 
 ```bash
-gsd-sdk query commit "docs: initialize [project-name] ([N] phases)" .planning/
+gsd-sdk query commit "docs: initialize [project-name] ([N] phases)" --files .planning/
 ```
 
 </format>
@@ -133,7 +133,7 @@ SUMMARY: .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md
 What to commit:
 
 ```bash
-gsd-sdk query commit "docs({phase}-{plan}): complete [plan-name] plan" .planning/phases/XX-name/{phase}-{plan}-PLAN.md .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md .planning/STATE.md .planning/ROADMAP.md
+gsd-sdk query commit "docs({phase}-{plan}): complete [plan-name] plan" --files .planning/phases/XX-name/{phase}-{plan}-PLAN.md .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md .planning/STATE.md .planning/ROADMAP.md
 ```
 
 **Note:** Code files NOT included - already committed per-task.
@@ -153,7 +153,7 @@ Current: [task name]
 What to commit:
 
 ```bash
-gsd-sdk query commit "wip: [phase-name] paused at task [X]/[Y]" .planning/
+gsd-sdk query commit "wip: [phase-name] paused at task [X]/[Y]" --files .planning/
 ```
 
 </format>

--- a/get-shit-done/references/git-planning-commit.md
+++ b/get-shit-done/references/git-planning-commit.md
@@ -4,12 +4,12 @@ Commit planning artifacts via `gsd-sdk query commit`, which checks `commit_docs`
 
 ## Commit via CLI
 
-Pass the message first, then file paths (positional). Do not use `--files` for `commit` (that flag is only for `commit-to-subrepo`).
+Pass the message first, then file paths via `--files`. Both `commit` and `commit-to-subrepo` use `--files` to declare the paths to commit.
 
 Always use this for `.planning/` files — it handles `commit_docs` and gitignore checks automatically:
 
 ```bash
-gsd-sdk query commit "docs({scope}): {description}" .planning/STATE.md .planning/ROADMAP.md
+gsd-sdk query commit "docs({scope}): {description}" --files .planning/STATE.md .planning/ROADMAP.md
 ```
 
 The CLI will return `skipped` (with reason) if `commit_docs` is `false` or `.planning/` is gitignored. No manual conditional checks needed.
@@ -19,7 +19,7 @@ The CLI will return `skipped` (with reason) if `commit_docs` is `false` or `.pla
 To fold `.planning/` file changes into the previous commit:
 
 ```bash
-gsd-sdk query commit "" .planning/codebase/*.md --amend
+gsd-sdk query commit "" --files .planning/codebase/*.md --amend
 ```
 
 ## Commit Message Patterns

--- a/get-shit-done/references/planner-revision.md
+++ b/get-shit-done/references/planner-revision.md
@@ -55,7 +55,7 @@ Group by plan, dimension, severity.
 ### Step 6: Commit
 
 ```bash
-gsd-sdk query commit "fix($PHASE): revise plans based on checker feedback" .planning/phases/$PHASE-*/$PHASE-*-PLAN.md
+gsd-sdk query commit "fix($PHASE): revise plans based on checker feedback" --files .planning/phases/$PHASE-*/$PHASE-*-PLAN.md
 ```
 
 ### Step 7: Return Revision Summary

--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -58,7 +58,7 @@ Configuration options for `.planning/` directory behavior.
 
 ```bash
 # Commit with automatic commit_docs + gitignore checks:
-gsd-sdk query commit "docs: update state" .planning/STATE.md
+gsd-sdk query commit "docs: update state" --files .planning/STATE.md
 
 # Load config via state load (returns JSON):
 INIT=$(gsd-sdk query state.load)
@@ -76,7 +76,7 @@ if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 **Commit via CLI (handles checks automatically):**
 
 ```bash
-gsd-sdk query commit "docs: update state" .planning/STATE.md
+gsd-sdk query commit "docs: update state" --files .planning/STATE.md
 ```
 
 The CLI checks `commit_docs` config and gitignore status internally — no manual conditionals needed.

--- a/get-shit-done/workflows/add-todo.md
+++ b/get-shit-done/workflows/add-todo.md
@@ -121,7 +121,7 @@ If `.planning/STATE.md` exists:
 Commit the todo and any updated state:
 
 ```bash
-gsd-sdk query commit "docs: capture todo - [title]" .planning/todos/pending/[filename] .planning/STATE.md
+gsd-sdk query commit "docs: capture todo - [title]" --files .planning/todos/pending/[filename] .planning/STATE.md
 ```
 
 Tool respects `commit_docs` config and gitignore automatically.

--- a/get-shit-done/workflows/autonomous.md
+++ b/get-shit-done/workflows/autonomous.md
@@ -249,7 +249,7 @@ None — discuss phase skipped.
 Commit the minimal context:
 
 ```bash
-gsd-sdk query commit "docs(${PADDED_PHASE}): auto-generated context (discuss skipped)" "${phase_dir}/${padded_phase}-CONTEXT.md"
+gsd-sdk query commit "docs(${PADDED_PHASE}): auto-generated context (discuss skipped)" --files "${phase_dir}/${padded_phase}-CONTEXT.md"
 ```
 
 Proceed to 3b.

--- a/get-shit-done/workflows/autonomous.md
+++ b/get-shit-done/workflows/autonomous.md
@@ -262,7 +262,7 @@ The discuss step in `--auto` mode MUST NOT loop. If CONTEXT.md already exists af
 **If `INTERACTIVE` is set:** Run the standard discuss-phase skill inline (asks interactive questions, waits for user answers). This preserves user input on all design decisions while keeping plan+execute out of the main context:
 
 ```
-Skill(skill="gsd:discuss-phase", args="${PHASE_NUM}")
+Skill(skill="gsd-discuss-phase", args="${PHASE_NUM}")
 ```
 
 **If `INTERACTIVE` is NOT set:** Execute the smart_discuss step for this phase (batch table proposals, auto-optimized).
@@ -367,12 +367,12 @@ CODE_REVIEW_ENABLED=$(gsd-sdk query config-get workflow.code_review 2>/dev/null 
 If `"false"`: display "Code review skipped (workflow.code_review=false)" and proceed to 3d.
 
 ```
-Skill(skill="gsd:code-review", args="${PHASE_NUM}")
+Skill(skill="gsd-code-review", args="${PHASE_NUM}")
 ```
 
 Parse status from REVIEW.md frontmatter. If "clean" or "skipped": proceed to 3d. If findings found: auto-invoke:
-```
-Skill(skill="gsd:code-review-fix", args="${PHASE_NUM} --auto")
+```text
+Skill(skill="gsd-code-review-fix", args="${PHASE_NUM} --auto")
 ```
 
 **Error handling:** If either Skill fails, catch the error, display as non-blocking, and proceed to 3d.

--- a/get-shit-done/workflows/check-todos.md
+++ b/get-shit-done/workflows/check-todos.md
@@ -157,7 +157,7 @@ If todo was moved to done/, commit the change:
 
 ```bash
 git rm --cached .planning/todos/pending/[filename] 2>/dev/null || true
-gsd-sdk query commit "docs: start work on todo - [title]" .planning/todos/completed/[filename] .planning/STATE.md
+gsd-sdk query commit "docs: start work on todo - [title]" --files .planning/todos/completed/[filename] .planning/STATE.md
 ```
 
 Tool respects `commit_docs` config and gitignore automatically.

--- a/get-shit-done/workflows/cleanup.md
+++ b/get-shit-done/workflows/cleanup.md
@@ -124,7 +124,7 @@ Repeat for all milestones in the cleanup set.
 Commit the changes:
 
 ```bash
-gsd-sdk query commit "chore: archive phase directories from completed milestones" .planning/milestones/ .planning/phases/
+gsd-sdk query commit "chore: archive phase directories from completed milestones" --files .planning/milestones/ .planning/phases/
 ```
 
 </step>

--- a/get-shit-done/workflows/complete-milestone.md
+++ b/get-shit-done/workflows/complete-milestone.md
@@ -494,7 +494,7 @@ Append the extracted Backlog content verbatim to the end of the newly written RO
 **Safety commit — commit archive files BEFORE deleting any originals:**
 
 ```bash
-gsd-sdk query commit "chore: archive v[X.Y] milestone files" .planning/milestones/v[X.Y]-ROADMAP.md .planning/milestones/v[X.Y]-REQUIREMENTS.md .planning/milestones/v[X.Y]-MILESTONE-AUDIT.md .planning/MILESTONES.md .planning/PROJECT.md .planning/STATE.md .planning/ROADMAP.md
+gsd-sdk query commit "chore: archive v[X.Y] milestone files" --files .planning/milestones/v[X.Y]-ROADMAP.md .planning/milestones/v[X.Y]-REQUIREMENTS.md .planning/milestones/v[X.Y]-MILESTONE-AUDIT.md .planning/MILESTONES.md .planning/PROJECT.md .planning/STATE.md .planning/ROADMAP.md
 ```
 
 This creates a durable checkpoint in git history. If anything fails after this point, the working tree can be reconstructed from git.
@@ -563,7 +563,7 @@ If the "## Cross-Milestone Trends" section exists, update the tables with new da
 
 **Commit:**
 ```bash
-gsd-sdk query commit "docs: update retrospective for v${VERSION}" .planning/RETROSPECTIVE.md
+gsd-sdk query commit "docs: update retrospective for v${VERSION}" --files .planning/RETROSPECTIVE.md
 ```
 
 </step>

--- a/get-shit-done/workflows/diagnose-issues.md
+++ b/get-shit-done/workflows/diagnose-issues.md
@@ -179,7 +179,7 @@ Update status in frontmatter to "diagnosed".
 
 Commit the updated UAT.md:
 ```bash
-gsd-sdk query commit "docs({phase_num}): add root causes from diagnosis" ".planning/phases/XX-name/{phase_num}-UAT.md"
+gsd-sdk query commit "docs({phase_num}): add root causes from diagnosis" --files ".planning/phases/XX-name/{phase_num}-UAT.md"
 ```
 </step>
 

--- a/get-shit-done/workflows/discuss-phase-assumptions.md
+++ b/get-shit-done/workflows/discuss-phase-assumptions.md
@@ -552,7 +552,7 @@ Write file.
 Commit phase context and discussion log:
 
 ```bash
-gsd-sdk query commit "docs(${padded_phase}): capture phase context (assumptions mode)" "${phase_dir}/${padded_phase}-CONTEXT.md" "${phase_dir}/${padded_phase}-DISCUSSION-LOG.md"
+gsd-sdk query commit "docs(${padded_phase}): capture phase context (assumptions mode)" --files "${phase_dir}/${padded_phase}-CONTEXT.md" "${phase_dir}/${padded_phase}-DISCUSSION-LOG.md"
 ```
 
 Confirm: "Committed: docs(${padded_phase}): capture phase context (assumptions mode)"
@@ -570,7 +570,7 @@ gsd-sdk query state.record-session \
 Commit STATE.md:
 
 ```bash
-gsd-sdk query commit "docs(state): record phase ${PHASE} context session" .planning/STATE.md
+gsd-sdk query commit "docs(state): record phase ${PHASE} context session" --files .planning/STATE.md
 ```
 </step>
 

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -445,7 +445,7 @@ rm -f "${phase_dir}/${padded_phase}-DISCUSS-CHECKPOINT.json"
 
 Commit phase context and discussion log:
 ```bash
-gsd-sdk query commit "docs(${padded_phase}): capture phase context" "${phase_dir}/${padded_phase}-CONTEXT.md" "${phase_dir}/${padded_phase}-DISCUSSION-LOG.md"
+gsd-sdk query commit "docs(${padded_phase}): capture phase context" --files "${phase_dir}/${padded_phase}-CONTEXT.md" "${phase_dir}/${padded_phase}-DISCUSSION-LOG.md"
 ```
 
 Confirm: "Committed: docs(${padded_phase}): capture phase context"
@@ -459,7 +459,7 @@ gsd-sdk query state.record-session \
   --stopped-at "Phase ${PHASE} context gathered" \
   --resume-file "${phase_dir}/${padded_phase}-CONTEXT.md"
 
-gsd-sdk query commit "docs(state): record phase ${PHASE} context session" .planning/STATE.md
+gsd-sdk query commit "docs(state): record phase ${PHASE} context session" --files .planning/STATE.md
 ```
 </step>
 

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -636,10 +636,16 @@ increases monotonically across waves. `{status}` is `complete` (success),
    When executor agents ran in worktree isolation, their commits land on temporary branches in separate working trees. After the wave completes, merge these changes back and clean up:
 
    ```bash
-   # List worktrees created by this wave's agents
-   WORKTREES=$(git worktree list --porcelain | grep "^worktree " | grep -v "$(pwd)$" | sed 's/^worktree //')
-
-   for WT in $WORKTREES; do
+   # List worktrees created by this wave's agents.
+   # Inclusion-based filter (#2774): match ONLY agent-spawned worktrees under
+   # `.claude/worktrees/agent-` (the namespace Claude Code's `isolation="worktree"`
+   # uses). The previous exclusion filter (`grep -v "$(pwd)$"`) destroyed the parent
+   # workspace's `.git` whenever the workspace itself was a worktree (multi-workspace
+   # setups, and the cross-drive Windows case where `git worktree list` reports the
+   # registry path on a different drive than `$(pwd)`).
+   # Read line-by-line so worktree paths containing whitespace are preserved (#2774).
+   while IFS= read -r WT; do
+     [ -z "$WT" ] && continue
      # Get the branch name for this worktree
      WT_BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null)
      if [ -n "$WT_BRANCH" ] && [ "$WT_BRANCH" != "HEAD" ]; then
@@ -754,7 +760,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
        # Delete the temporary branch
        git branch -D "$WT_BRANCH" 2>/dev/null || true
      fi
-   done
+   done < <(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
    ```
 
    **If `workflow.use_worktrees` is `false`:** Agents ran on the main working tree — skip this step entirely.

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -812,7 +812,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
 
      # Only commit tracking files if they actually changed
      if ! git diff --quiet .planning/ROADMAP.md .planning/STATE.md 2>/dev/null; then
-       gsd-sdk query commit "docs(phase-${PHASE_NUMBER}): update tracking after wave ${N}" .planning/ROADMAP.md .planning/STATE.md
+       gsd-sdk query commit "docs(phase-${PHASE_NUMBER}): update tracking after wave ${N}" --files .planning/ROADMAP.md .planning/STATE.md
      fi
    elif [ "${TEST_EXIT}" -eq 124 ]; then
      echo "⚠ Skipping tracking update — test suite timed out. Plans remain in-progress. Run tests manually to confirm."
@@ -1162,7 +1162,7 @@ mv .planning/debug/{slug}.md .planning/debug/resolved/
 
 **6. Commit updated artifacts:**
 ```bash
-gsd-sdk query commit "docs(phase-${PARENT_PHASE}): resolve UAT gaps and debug sessions after ${PHASE_NUMBER} gap closure" .planning/phases/*${PARENT_PHASE}*/*-UAT.md .planning/debug/resolved/*.md
+gsd-sdk query commit "docs(phase-${PARENT_PHASE}): resolve UAT gaps and debug sessions after ${PHASE_NUMBER} gap closure" --files .planning/phases/*${PARENT_PHASE}*/*-UAT.md .planning/debug/resolved/*.md
 ```
 </step>
 
@@ -1405,7 +1405,7 @@ blocked: 0
 
 Commit the file:
 ```bash
-gsd-sdk query commit "test({phase_num}): persist human verification items as UAT" "{phase_dir}/{phase_num}-HUMAN-UAT.md"
+gsd-sdk query commit "test({phase_num}): persist human verification items as UAT" --files "{phase_dir}/{phase_num}-HUMAN-UAT.md"
 ```
 
 **Step B: Present to user:**
@@ -1477,7 +1477,7 @@ These items are tracked and will appear in `/gsd-progress` and `/gsd-audit-uat`.
 ```
 
 ```bash
-gsd-sdk query commit "docs(phase-{X}): complete phase execution" .planning/ROADMAP.md .planning/STATE.md .planning/REQUIREMENTS.md {phase_dir}/*-VERIFICATION.md
+gsd-sdk query commit "docs(phase-{X}): complete phase execution" --files .planning/ROADMAP.md .planning/STATE.md .planning/REQUIREMENTS.md {phase_dir}/*-VERIFICATION.md
 ```
 </step>
 
@@ -1527,7 +1527,7 @@ for TODO_FILE in "$PENDING_DIR"/*.md; do
 done
 
 if [ ${#CLOSED[@]} -gt 0 ]; then
-  gsd-sdk query commit "docs(phase-${PHASE_NUMBER}): auto-close ${#CLOSED[@]} todo(s) resolved by this phase" .planning/todos/completed/ .planning/STATE.md || true
+  gsd-sdk query commit "docs(phase-${PHASE_NUMBER}): auto-close ${#CLOSED[@]} todo(s) resolved by this phase" --files .planning/todos/completed/ .planning/STATE.md|| true
   echo "◆ Closed ${#CLOSED[@]} todo(s) resolved by Phase ${PHASE_NUMBER}:"
   for f in "${CLOSED[@]}"; do echo "  ✓ $f"; done
 fi
@@ -1552,7 +1552,7 @@ PROJECT.md falls behind silently over multiple phases.
 5. Commit the change:
 
 ```bash
-gsd-sdk query commit "docs(phase-{X}): evolve PROJECT.md after phase completion" .planning/PROJECT.md
+gsd-sdk query commit "docs(phase-{X}): evolve PROJECT.md after phase completion" --files .planning/PROJECT.md
 ```
 
 **Skip this step if** `.planning/PROJECT.md` does not exist.

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -1095,7 +1095,7 @@ If `CODE_REVIEW_ENABLED` is `"false"`: display "Code review skipped (workflow.co
 
 **Invoke review:**
 ```
-Skill(skill="gsd:code-review", args="${PHASE_NUMBER}")
+Skill(skill="gsd-code-review", args="${PHASE_NUMBER}")
 ```
 
 **Check results using deterministic path (not glob):**

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -84,16 +84,21 @@ Read worktree config:
 USE_WORKTREES=$(gsd-sdk query config-get workflow.use_worktrees 2>/dev/null || echo "true")
 ```
 
-If the project uses git submodules, worktree isolation is skipped regardless of the `workflow.use_worktrees` config — the executor commit protocol cannot correctly handle submodule commits inside isolated worktrees. Sequential execution handles submodules transparently.
+If the project uses git submodules, worktree isolation is unsafe **only when a plan touches a submodule path** — the executor commit protocol cannot correctly handle submodule commits inside isolated worktrees. The previous behavior unconditionally disabled worktree isolation whenever `.gitmodules` existed, which penalised every plan in a submodule project even when the plan was nowhere near a submodule. Compute submodule paths once and intersect them per-plan with the plan's declared `files_modified` frontmatter.
 
 ```bash
+# Parse submodule paths from .gitmodules once (empty if no .gitmodules).
+# SUBMODULE_PATHS is a newline-separated list of repo-relative paths.
 if [ -f .gitmodules ]; then
-  echo "[worktree] Submodule project detected (.gitmodules exists) — falling back to sequential execution"
-  USE_WORKTREES=false
+  SUBMODULE_PATHS=$(git config --file .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null | awk '{print $2}')
+else
+  SUBMODULE_PATHS=""
 fi
 ```
 
-When `USE_WORKTREES` is `false`, all executor agents run without `isolation="worktree"` — they execute sequentially on the main working tree instead of in parallel worktrees.
+`SUBMODULE_PATHS` is exported to the `execute_waves` step, where the per-plan decision actually happens (see "Per-plan worktree decision" sub-step inside `execute_waves`). The decision is per-plan because different plans in the same wave can touch different files — only plans whose paths intersect a submodule must drop worktree isolation; plans nowhere near a submodule keep parallel isolation.
+
+When `USE_WORKTREES` (project-level) is `false`, all executor agents run without `isolation="worktree"` — they execute sequentially on the main working tree instead of in parallel worktrees. The per-plan decision below has no effect when worktrees are project-disabled.
 
 Read context window size for adaptive prompt enrichment:
 
@@ -418,6 +423,12 @@ increases monotonically across waves. `{status}` is `complete` (success),
    - Bad: "Executing terrain generation plan"
    - Good: "Procedural terrain generator using Perlin noise — creates height maps, biome zones, and collision meshes. Required before vehicle physics can interact with ground."
 
+2.5. **Per-plan worktree decision (run for each plan in this wave BEFORE its dispatch):**
+
+   Read and execute `get-shit-done/workflows/execute-phase/steps/per-plan-worktree-gate.md` for each plan. It extracts `PLAN_FILES` from the plan's JSON, intersects against `SUBMODULE_PATHS` (with normalization, bidirectional matching, and glob-prefix handling), and sets `USE_WORKTREES_FOR_PLAN` to `false` when the plan touches a submodule path. Append `plan_id` to a `WAVE_WORKTREE_PLANS` accumulator when `USE_WORKTREES_FOR_PLAN != false`.
+
+   The dispatch branches in step 3 below MUST gate on `USE_WORKTREES_FOR_PLAN` for the current plan, not on the project-level `USE_WORKTREES`.
+
 3. **Spawn executor agents:**
 
    **Emit a plan-start heartbeat (literal line, no tool call) immediately before
@@ -431,7 +442,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
    For 200k models, this keeps orchestrator context lean (~10-15%).
    For 1M+ models (Opus 4.6, Sonnet 4.6), richer context can be passed directly.
 
-   **Worktree mode** (`USE_WORKTREES` is not `false`):
+   **Worktree mode** (`USE_WORKTREES_FOR_PLAN` is not `false` — evaluated per-plan in step 2.5):
 
    Before spawning, capture the current HEAD:
    ```bash
@@ -562,7 +573,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
 
    > **ORCHESTRATOR RULE — CODEX RUNTIME**: After calling Task() above to spawn executor agent(s), stop working on this task immediately. Do not read more files, edit code, or run tests related to this task while the subagent is active. Wait for the subagent to return its result. This prevents duplicate work, conflicting edits, and wasted context. Only resume when the subagent result is available.
 
-   **Sequential mode** (`USE_WORKTREES` is `false`):
+   **Sequential mode** (`USE_WORKTREES_FOR_PLAN` is `false` — either project-level `USE_WORKTREES=false`, or per-plan submodule intersection forced it false in step 2.5):
 
    Omit `isolation="worktree"` from the Task call. Replace the `<parallel_execution>` block with:
 
@@ -585,7 +596,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
        </success_criteria>
    ```
 
-   When worktrees are disabled, execute plans **one at a time within each wave** (sequential) regardless of the `PARALLELIZATION` setting — multiple agents writing to the same working tree concurrently would cause conflicts.
+   When worktrees are disabled for a plan (per-plan or project-level), that plan's executor runs on the main working tree. If **any** plan in the current wave dropped to sequential mode, execute the affected plan(s) **one at a time** to avoid concurrent writes to the main working tree — plans in the same wave that retained worktree isolation can still run in parallel alongside the sequential ones, but two non-worktree plans in the same wave must serialize. When the project-level `USE_WORKTREES=false`, all plans in the wave serialize regardless of the `PARALLELIZATION` setting.
 
 4. **Wait for all agents in wave to complete.**
 
@@ -763,9 +774,11 @@ increases monotonically across waves. `{status}` is `complete` (success),
    done < <(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
    ```
 
-   **If `workflow.use_worktrees` is `false`:** Agents ran on the main working tree — skip this step entirely.
+   **If no plan in this wave used worktree isolation** (project-level `USE_WORKTREES=false` OR every plan in the wave had `USE_WORKTREES_FOR_PLAN=false` — i.e. `WAVE_WORKTREE_PLANS` from step 2.5 is empty): all agents ran on the main working tree — skip this step entirely.
 
-   **If no worktrees found:** Skip silently — agents may have been spawned without worktree isolation.
+   **If at least one plan used worktrees but others did not:** still run this cleanup — it iterates over actual `git worktree list` output and only merges back the worktrees that were created, leaving sequential plans' commits on the main tree untouched.
+
+   **If no worktrees found at runtime:** Skip silently — agents may have been spawned without worktree isolation, or the orchestrator already cleaned them up.
 
 5.6. **Post-merge build & test gate:**
 
@@ -780,9 +793,9 @@ increases monotonically across waves. `{status}` is `complete` (success),
 
    Read and execute `get-shit-done/workflows/execute-phase/steps/post-merge-gate.md`.
 
-5.7. **Post-wave shared artifact update (worktree mode only, skip if tests failed):**
+5.7. **Post-wave shared artifact update (when at least one plan used worktrees, skip if tests failed):**
 
-   When executor agents ran with `isolation="worktree"`, they skipped STATE.md and ROADMAP.md updates to avoid last-merge-wins overwrites. The orchestrator is the single writer for these files. After worktrees are merged back, update shared artifacts once.
+   When **any** executor agent in this wave ran with `isolation="worktree"`, that agent skipped STATE.md and ROADMAP.md updates to avoid last-merge-wins overwrites. The orchestrator is the single writer for these files. After worktrees are merged back, update shared artifacts once for every completed plan in the wave (worktree-mode plans **and** sequential plans that ran on the main tree but deferred to the orchestrator for tracking writes).
 
    **Only update tracking when tests passed (TEST_EXIT=0).**
    If tests failed or timed out, skip the tracking update — plans should
@@ -810,7 +823,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
 
    Where `WAVE_PLAN_IDS` is the space-separated list of plan IDs that completed in this wave.
 
-   **If `workflow.use_worktrees` is `false`:** Sequential agents already updated STATE.md and ROADMAP.md themselves — skip this step.
+   **If no plan in this wave used worktrees** (project-level `USE_WORKTREES=false` OR `WAVE_WORKTREE_PLANS` is empty): sequential agents already updated STATE.md and ROADMAP.md themselves — skip this step.
 
 5.8. **Handle test gate failures (when `WAVE_FAILURE_COUNT > 0`):**
 

--- a/get-shit-done/workflows/execute-phase/steps/per-plan-worktree-gate.md
+++ b/get-shit-done/workflows/execute-phase/steps/per-plan-worktree-gate.md
@@ -1,0 +1,94 @@
+# Per-plan worktree decision (#2772)
+
+Run this for **each plan in the current wave** before its `Task()` dispatch. The output `USE_WORKTREES_FOR_PLAN` gates the dispatch branch (worktree mode vs sequential mode) for that plan only — other plans in the same wave can still take the worktree path.
+
+`SUBMODULE_PATHS` is computed once in the `initialize` step (parsed from `.gitmodules`).
+
+`PLAN_FILES` is the whitespace-separated list of paths the plan declared it will touch, extracted from the `phase-plan-index` JSON loaded in `discover_and_group_plans`:
+
+```bash
+# plan_json is the JSON object for this plan from PLAN_INDEX.plans[]
+# files_modified is an array of strings (repo-relative paths or globs)
+PLAN_FILES=$(jq -r '.files_modified // [] | join(" ")' <<<"$plan_json")
+plan_id=$(jq -r '.id' <<<"$plan_json")
+```
+
+Then run the per-plan gate:
+
+```bash
+USE_WORKTREES_FOR_PLAN="$USE_WORKTREES"
+
+if [ -n "$SUBMODULE_PATHS" ] && [ "$USE_WORKTREES_FOR_PLAN" != "false" ]; then
+  if [ -z "$PLAN_FILES" ]; then
+    # Fallback: planned paths are unknown/unparseable — fall back to the safe
+    # behavior (disable worktree isolation for this plan) and log why.
+    echo "[worktree] Plan ${plan_id}: files_modified missing/unparseable — disabling worktree isolation as a safety fallback (submodule project)"
+    USE_WORKTREES_FOR_PLAN=false
+  else
+    # Compute intersection with glob-safe normalization. Both sides are
+    # normalized (strip leading "./", strip trailing "/") and matched
+    # bidirectionally so a globby planned path like "vendor/**/*.c" still
+    # matches submodule "vendor/foo", and "./vendor/foo/bar.c" matches
+    # submodule "vendor/foo".
+    INTERSECT=""
+    set -f  # disable globbing while iterating literal patterns
+    for sm_raw in $SUBMODULE_PATHS; do
+      # Normalize submodule path: strip ./ prefix and trailing /
+      sm="${sm_raw#./}"
+      sm="${sm%/}"
+      [ -z "$sm" ] && continue
+      for pf_raw in $PLAN_FILES; do
+        # Normalize planned path the same way
+        pf="${pf_raw#./}"
+        pf="${pf%/}"
+        [ -z "$pf" ] && continue
+        matched=0
+        # Direction 1: planned path is the submodule or lies inside it
+        case "$pf" in
+          "$sm"|"$sm"/*) matched=1 ;;
+        esac
+        # Direction 2: submodule lies inside the planned path (e.g. plan
+        # declares "vendor" or a glob expanding to a directory containing
+        # the submodule).
+        if [ "$matched" -eq 0 ]; then
+          case "$sm" in
+            "$pf"|"$pf"/*) matched=1 ;;
+          esac
+        fi
+        # Direction 3: planned path uses a glob — strip glob wildcards
+        # and check whether the resulting prefix overlaps the submodule
+        # path in either direction.
+        if [ "$matched" -eq 0 ]; then
+          case "$pf" in
+            *'*'*|*'?'*|*'['*)
+              # Take the literal prefix before the first glob metachar.
+              prefix="${pf%%[*?[]*}"
+              prefix="${prefix%/}"
+              if [ -n "$prefix" ]; then
+                case "$sm" in
+                  "$prefix"|"$prefix"/*) matched=1 ;;
+                esac
+                if [ "$matched" -eq 0 ]; then
+                  case "$prefix" in
+                    "$sm"|"$sm"/*) matched=1 ;;
+                  esac
+                fi
+              fi
+              ;;
+          esac
+        fi
+        if [ "$matched" -eq 1 ]; then
+          INTERSECT="$INTERSECT $pf_raw"
+        fi
+      done
+    done
+    set +f
+    if [ -n "$INTERSECT" ]; then
+      echo "[worktree] Plan ${plan_id}: planned paths intersect submodule paths (${INTERSECT# }) — disabling worktree isolation for this plan"
+      USE_WORKTREES_FOR_PLAN=false
+    fi
+  fi
+fi
+```
+
+After running this for the plan, the dispatch branches in `execute_waves` step 3 MUST gate on `USE_WORKTREES_FOR_PLAN` for the current plan, not on the project-level `USE_WORKTREES`. Track which plans in this wave actually used worktrees (append `plan_id` to a `WAVE_WORKTREE_PLANS` accumulator when `USE_WORKTREES_FOR_PLAN != false`) — the post-wave cleanup step (5.5) uses this to decide whether worktree-merge cleanup is needed at all.

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -440,9 +440,9 @@ IS_WORKTREE=$([ -f .git ] && echo "true" || echo "false")
 
 # In parallel mode: exclude STATE.md and ROADMAP.md (orchestrator commits these)
 if [ "$IS_WORKTREE" = "true" ]; then
-  gsd-sdk query commit "docs({phase}-{plan}): complete [plan-name] plan" .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md .planning/REQUIREMENTS.md
+  gsd-sdk query commit "docs({phase}-{plan}): complete [plan-name] plan" --files .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md .planning/REQUIREMENTS.md
 else
-  gsd-sdk query commit "docs({phase}-{plan}): complete [plan-name] plan" .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md .planning/STATE.md .planning/ROADMAP.md .planning/REQUIREMENTS.md
+  gsd-sdk query commit "docs({phase}-{plan}): complete [plan-name] plan" --files .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md .planning/STATE.md .planning/ROADMAP.md .planning/REQUIREMENTS.md
 fi
 ```
 </step>
@@ -458,7 +458,7 @@ git diff --name-only ${FIRST_TASK}^..HEAD 2>/dev/null || true
 Update only structural changes: new src/ dir → STRUCTURE.md | deps → STACK.md | file pattern → CONVENTIONS.md | API client → INTEGRATIONS.md | config → STACK.md | renamed → update paths. Skip code-only/bugfix/content changes.
 
 ```bash
-gsd-sdk query commit "" .planning/codebase/*.md --amend
+gsd-sdk query commit "" --files .planning/codebase/*.md --amend
 ```
 </step>
 

--- a/get-shit-done/workflows/explore.md
+++ b/get-shit-done/workflows/explore.md
@@ -115,7 +115,7 @@ For each selected output, write the file:
 
 Commit if `commit_docs` is enabled:
 ```bash
-gsd-sdk query commit "docs: capture exploration — {topic_slug}" {file_list}
+gsd-sdk query commit "docs: capture exploration — {topic_slug}" --files {file_list}
 ```
 
 ## Step 6: Close

--- a/get-shit-done/workflows/import.md
+++ b/get-shit-done/workflows/import.md
@@ -220,7 +220,7 @@ Update `.planning/STATE.md` if appropriate (e.g., increment total plan count).
 
 Commit the imported plan and updated files:
 ```bash
-gsd-sdk query commit "docs({phase}): import plan from {basename FILEPATH}" .planning/phases/{phase}/{plan}-PLAN.md .planning/ROADMAP.md
+gsd-sdk query commit "docs({phase}): import plan from {basename FILEPATH}" --files .planning/phases/{phase}/{plan}-PLAN.md .planning/ROADMAP.md
 ```
 
 Display completion:

--- a/get-shit-done/workflows/ingest-docs.md
+++ b/get-shit-done/workflows/ingest-docs.md
@@ -289,7 +289,7 @@ Preview the merge diff to the user and gate via approve-revise-abort before writ
 Commit the ingest results:
 
 ```bash
-gsd-sdk query commit "docs: ingest {N} docs from {SCAN_PATH} (#2387)" \
+gsd-sdk query commit "docs: ingest {N} docs from {SCAN_PATH} (#2387)" --files \
   .planning/PROJECT.md \
   .planning/REQUIREMENTS.md \
   .planning/ROADMAP.md \

--- a/get-shit-done/workflows/ingest-docs.md
+++ b/get-shit-done/workflows/ingest-docs.md
@@ -52,7 +52,7 @@ If `PATH_NOT_FOUND` or `MANIFEST_NOT_FOUND`: display error and exit.
 Run the init query:
 
 ```bash
-INIT=$(gsd-sdk query init.ingest-docs)
+INIT=$(gsd-tools init ingest-docs)
 ```
 
 Parse `project_exists`, `planning_exists`, `has_git`, `project_path` from INIT.
@@ -289,7 +289,7 @@ Preview the merge diff to the user and gate via approve-revise-abort before writ
 Commit the ingest results:
 
 ```bash
-gsd-sdk query commit "docs: ingest {N} docs from {SCAN_PATH} (#2387)" --files \
+gsd-tools commit "docs: ingest {N} docs from {SCAN_PATH} (#2387)" --files \
   .planning/PROJECT.md \
   .planning/REQUIREMENTS.md \
   .planning/ROADMAP.md \

--- a/get-shit-done/workflows/map-codebase.md
+++ b/get-shit-done/workflows/map-codebase.md
@@ -378,7 +378,7 @@ Continue to commit_codebase_map.
 Commit the codebase map:
 
 ```bash
-gsd-sdk query commit "docs: map existing codebase" .planning/codebase/*.md
+gsd-sdk query commit "docs: map existing codebase" --files .planning/codebase/*.md
 ```
 
 Continue to offer_next.

--- a/get-shit-done/workflows/milestone-summary.md
+++ b/get-shit-done/workflows/milestone-summary.md
@@ -189,7 +189,7 @@ mkdir -p .planning/reports
 
 Write the summary, then commit:
 ```bash
-gsd-sdk query commit "docs(v${VERSION}): generate milestone summary for onboarding" \
+gsd-sdk query commit "docs(v${VERSION}): generate milestone summary for onboarding" --files \
   ".planning/reports/MILESTONE_SUMMARY-v${VERSION}.md"
 ```
 

--- a/get-shit-done/workflows/new-milestone.md
+++ b/get-shit-done/workflows/new-milestone.md
@@ -212,7 +212,7 @@ gsd-sdk query phases.clear --confirm
 ```
 
 ```bash
-gsd-sdk query commit "docs: start milestone v[X.Y] [Name]" .planning/PROJECT.md .planning/STATE.md
+gsd-sdk query commit "docs: start milestone v[X.Y] [Name]" --files .planning/PROJECT.md .planning/STATE.md
 ```
 
 ## 7. Load Context and Resolve Models
@@ -444,7 +444,7 @@ If "adjust": Return to scoping.
 
 **Commit requirements:**
 ```bash
-gsd-sdk query commit "docs: define milestone v[X.Y] requirements" .planning/REQUIREMENTS.md
+gsd-sdk query commit "docs: define milestone v[X.Y] requirements" --files .planning/REQUIREMENTS.md
 ```
 
 ## 10. Create Roadmap
@@ -530,7 +530,7 @@ Success criteria:
 
 **Commit roadmap** (after approval):
 ```bash
-gsd-sdk query commit "docs: create milestone v[X.Y] roadmap ([N] phases)" .planning/ROADMAP.md .planning/STATE.md .planning/REQUIREMENTS.md
+gsd-sdk query commit "docs: create milestone v[X.Y] roadmap ([N] phases)" --files .planning/ROADMAP.md .planning/STATE.md .planning/REQUIREMENTS.md
 ```
 
 ## 10.5. Link Pending Todos to Roadmap Phases
@@ -573,7 +573,7 @@ files: [existing]
 
 **If any todos were linked:**
 ```bash
-gsd-sdk query commit "docs: tag [count] pending todos with resolves_phase after milestone v[X.Y] roadmap" .planning/todos/pending/*.md
+gsd-sdk query commit "docs: tag [count] pending todos with resolves_phase after milestone v[X.Y] roadmap" --files .planning/todos/pending/*.md
 ```
 
 Print a summary:

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -236,7 +236,7 @@ gsd-sdk query config-new-project '{"mode":"yolo","granularity":"[selected]","par
 
 ```bash
 mkdir -p .planning
-gsd-sdk query commit "chore: add project config" .planning/config.json
+gsd-sdk query commit "chore: add project config" --files .planning/config.json
 ```
 
 **Persist auto-advance chain flag to config (survives context compaction):**
@@ -447,7 +447,7 @@ Do not compress. Capture everything gathered.
 
 ```bash
 mkdir -p .planning
-gsd-sdk query commit "docs: initialize project" .planning/PROJECT.md
+gsd-sdk query commit "docs: initialize project" --files .planning/PROJECT.md
 ```
 
 ## 5. Workflow Preferences
@@ -666,7 +666,7 @@ gsd-sdk query config-new-project '{"mode":"[yolo|interactive]","granularity":"[s
 **Commit config.json:**
 
 ```bash
-gsd-sdk query commit "chore: add project config" .planning/config.json
+gsd-sdk query commit "chore: add project config" --files .planning/config.json
 ```
 
 ## 5.1. Sub-Repo Detection
@@ -1114,7 +1114,7 @@ If "adjust": Return to scoping.
 **Commit requirements:**
 
 ```bash
-gsd-sdk query commit "docs: define v1 requirements" .planning/REQUIREMENTS.md
+gsd-sdk query commit "docs: define v1 requirements" --files .planning/REQUIREMENTS.md
 ```
 
 ## 8. Create Roadmap
@@ -1266,7 +1266,7 @@ This ensures new projects get the default GSD workflow-enforcement guidance and 
 **Commit roadmap (after approval or auto mode):**
 
 ```bash
-gsd-sdk query commit "docs: create roadmap ([N] phases)" .planning/ROADMAP.md .planning/STATE.md .planning/REQUIREMENTS.md "$INSTRUCTION_FILE"
+gsd-sdk query commit "docs: create roadmap ([N] phases)" --files .planning/ROADMAP.md .planning/STATE.md .planning/REQUIREMENTS.md "$INSTRUCTION_FILE"
 ```
 
 ## 9. Done

--- a/get-shit-done/workflows/pause-work.md
+++ b/get-shit-done/workflows/pause-work.md
@@ -207,7 +207,7 @@ timestamp=$(gsd-sdk query current-timestamp full --raw)
 
 <step name="commit">
 ```bash
-gsd-sdk query commit "wip: [context-name] paused at [X]/[Y]" [handoff-path] .planning/HANDOFF.json
+gsd-sdk query commit "wip: [context-name] paused at [X]/[Y]" --files [handoff-path] .planning/HANDOFF.json
 ```
 </step>
 

--- a/get-shit-done/workflows/plan-milestone-gaps.md
+++ b/get-shit-done/workflows/plan-milestone-gaps.md
@@ -146,7 +146,7 @@ mkdir -p ".planning/phases/{NN}-{name}"
 ## 9. Commit Roadmap and Requirements Update
 
 ```bash
-gsd-sdk query commit "docs(roadmap): add gap closure phases {N}-{M}" .planning/ROADMAP.md .planning/REQUIREMENTS.md
+gsd-sdk query commit "docs(roadmap): add gap closure phases {N}-{M}" --files .planning/ROADMAP.md .planning/REQUIREMENTS.md
 ```
 
 ## 10. Offer Next Steps

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -201,7 +201,7 @@ Use full relative paths. Group by topic area.]
 
 5. Commit:
 ```bash
-gsd-sdk query commit "docs(${padded_phase}): generate context from PRD" "${phase_dir}/${padded_phase}-CONTEXT.md"
+gsd-sdk query commit "docs(${padded_phase}): generate context from PRD" --files "${phase_dir}/${padded_phase}-CONTEXT.md"
 ```
 
 6. Set `context_content` to the generated CONTEXT.md content and continue to step 5 (Handle Research).
@@ -925,7 +925,7 @@ For each plan entry extracted from `PLAN-OUTLINE.md`:
 
 5. **Commit per-plan:**
    ```bash
-   gsd-sdk query commit "docs(${PADDED_PHASE}): plan ${plan_id} (chunked)" "${PHASE_DIR}/${plan_id}-PLAN.md"
+   gsd-sdk query commit "docs(${PADDED_PHASE}): plan ${plan_id} (chunked)" --files "${PHASE_DIR}/${plan_id}-PLAN.md"
    ```
 
 After all N plans are written and committed, treat this as `## PLANNING COMPLETE` and continue
@@ -1263,7 +1263,7 @@ After the script returns, check that the bounced file still has valid YAML front
 
 6. **Commit surviving bounced plans:** If at least one plan survived both the frontmatter validation and the checker re-run, commit the changes:
 ```bash
-gsd-sdk query commit "refactor(${padded_phase}): bounce plans through external refinement" "${PHASE_DIR}/*-PLAN.md"
+gsd-sdk query commit "refactor(${padded_phase}): bounce plans through external refinement" --files "${PHASE_DIR}/*-PLAN.md"
 ```
 
 Display summary:

--- a/get-shit-done/workflows/plant-seed.md
+++ b/get-shit-done/workflows/plant-seed.md
@@ -143,7 +143,7 @@ Related code and decisions found in the current codebase:
 
 <step name="commit_seed">
 ```bash
-gsd-sdk query commit "docs: plant seed — {$IDEA}" .planning/seeds/SEED-{PADDED}-{slug}.md
+gsd-sdk query commit "docs: plant seed — {$IDEA}" --files .planning/seeds/SEED-{PADDED}-{slug}.md
 ```
 </step>
 

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -970,7 +970,7 @@ if [ "$COMMIT_DOCS" = "false" ]; then
 else
   git add ${file_list} 2>/dev/null
 fi
-gsd-sdk query commit "docs(quick-${quick_id}): ${DESCRIPTION}" ${file_list}
+gsd-sdk query commit "docs(quick-${quick_id}): ${DESCRIPTION}" --files ${file_list}
 ```
 
 Get final commit hash:

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -647,9 +647,16 @@ ${AGENT_SKILLS_EXECUTOR}
 After executor returns:
 1. **Worktree cleanup:** If the executor ran with `isolation="worktree"`, merge the worktree branch back and clean up:
    ```bash
-   # Find worktrees created by the executor
-   WORKTREES=$(git worktree list --porcelain | grep "^worktree " | grep -v "$(pwd)$" | sed 's/^worktree //')
-   for WT in $WORKTREES; do
+   # Find worktrees created by the executor.
+   # Inclusion-based filter (#2774): match ONLY agent-spawned worktrees under
+   # `.claude/worktrees/agent-` (the namespace Claude Code's `isolation="worktree"`
+   # uses). The previous exclusion filter (`grep -v "$(pwd)$"`) destroyed the parent
+   # workspace's `.git` whenever the workspace itself was a worktree (multi-workspace
+   # setups, and the cross-drive Windows case where `git worktree list` reports the
+   # registry path on a different drive than `$(pwd)`).
+   # Read line-by-line so worktree paths containing whitespace are preserved (#2774).
+   while IFS= read -r WT; do
+     [ -z "$WT" ] && continue
      WT_BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null)
      if [ -n "$WT_BRANCH" ] && [ "$WT_BRANCH" != "HEAD" ]; then
        # --- Orchestrator file protection (#1756) ---
@@ -725,7 +732,7 @@ After executor returns:
        fi
        git branch -D "$WT_BRANCH" 2>/dev/null || true
      fi
-   done
+   done < <(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
    ```
    If `workflow.use_worktrees` is `false`, skip this step.
 2. Verify summary exists at `${QUICK_DIR}/${quick_id}-SUMMARY.md`

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -152,14 +152,23 @@ Parse JSON for: `planner_model`, `executor_model`, `checker_model`, `verifier_mo
 USE_WORKTREES=$(gsd-sdk query config-get workflow.use_worktrees 2>/dev/null || echo "true")
 ```
 
-If the project uses git submodules, worktree isolation is skipped:
+If the project uses git submodules, worktree isolation is unsafe **only when the quick task touches a submodule path**. The previous behavior unconditionally disabled worktree isolation whenever `.gitmodules` existed, which penalised every quick task in a submodule project even when the task was nowhere near a submodule. Parse submodule paths from `.gitmodules` so the executor can act on actual submodule paths rather than the mere file's existence:
 
 ```bash
+# Parse submodule paths from .gitmodules once (empty if no .gitmodules).
+# SUBMODULE_PATHS is a newline-separated list of repo-relative paths used as
+# a fail-loud commit-time guard inside the quick-task executor — if the
+# executor stages any path that falls inside SUBMODULE_PATHS, it must abort
+# the commit and surface the conflict rather than silently corrupting the
+# submodule state.
 if [ -f .gitmodules ]; then
-  echo "[worktree] Submodule project detected (.gitmodules exists) — falling back to sequential execution"
-  USE_WORKTREES=false
+  SUBMODULE_PATHS=$(git config --file .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null | awk '{print $2}')
+else
+  SUBMODULE_PATHS=""
 fi
 ```
+
+Quick mode does not have a pre-declared `files_modified` list (the task is freeform), so use a fail-loud guard at commit time: when the executor stages files for the quick-task commit, if any staged path falls inside a `SUBMODULE_PATHS` entry, abort with a clear error explaining that worktree-isolated commits cannot safely span submodule boundaries — the user can re-run with `workflow.use_worktrees=false` to fall back to sequential execution on the main tree. If `SUBMODULE_PATHS` is empty (no `.gitmodules` in the repo), worktree isolation proceeds normally.
 
 **If `roadmap_exists` is false:** Error — Quick mode requires an active project with ROADMAP.md. Run `/gsd-new-project` first.
 
@@ -627,9 +636,44 @@ This corrects a known issue where EnterWorktree creates branches from main inste
 
 ${AGENT_SKILLS_EXECUTOR}
 
+<submodule_commit_guard>
+SUBMODULE_PATHS for this project: ${SUBMODULE_PATHS}
+
+If SUBMODULE_PATHS is non-empty, you MUST run this fail-loud guard immediately
+before EVERY git commit you create during this quick task (after \`git add\`,
+before \`git commit\`). Quick mode does not have a pre-declared files_modified
+list, so the guard runs at commit time:
+
+\`\`\`bash
+SUBMODULE_PATHS=\"${SUBMODULE_PATHS}\"
+if [ -n \"\$SUBMODULE_PATHS\" ]; then
+  STAGED=\$(git diff --cached --name-only)
+  for sm_raw in \$SUBMODULE_PATHS; do
+    sm=\"\${sm_raw#./}\"
+    sm=\"\${sm%/}\"
+    [ -z \"\$sm\" ] && continue
+    for f_raw in \$STAGED; do
+      f=\"\${f_raw#./}\"
+      f=\"\${f%/}\"
+      case \"\$f\" in
+        \"\$sm\"|\"\$sm\"/*)
+          echo \"ABORT: staged path \$f_raw falls inside submodule \$sm — worktree-isolated commits cannot safely span submodule boundaries. Re-run with workflow.use_worktrees=false.\" >&2
+          exit 1 ;;
+      esac
+    done
+  done
+fi
+\`\`\`
+
+If the guard aborts, do NOT attempt the commit, do NOT remove the staged files,
+and do NOT continue subsequent tasks. Surface the abort message in your
+SUMMARY.md and stop — the user must rerun with worktrees disabled.
+</submodule_commit_guard>
+
 <constraints>
 - Execute all tasks in the plan
 - Commit each task atomically (code changes only)
+- Run the <submodule_commit_guard> bash block before every \`git commit\` if SUBMODULE_PATHS is non-empty
 - Create summary at: ${QUICK_DIR}/${quick_id}-SUMMARY.md
 - Do NOT commit docs artifacts (SUMMARY.md, STATE.md, PLAN.md) — the orchestrator handles the docs commit in Step 8
 - Do NOT update ROADMAP.md (quick tasks are separate from planned phases)

--- a/get-shit-done/workflows/remove-phase.md
+++ b/get-shit-done/workflows/remove-phase.md
@@ -103,7 +103,7 @@ Extract from result: `removed`, `directory_deleted`, `renamed_directories`, `ren
 Stage and commit the removal:
 
 ```bash
-gsd-sdk query commit "chore: remove phase {target} ({original-phase-name})" .planning/
+gsd-sdk query commit "chore: remove phase {target} ({original-phase-name})" --files .planning/
 ```
 
 The commit message preserves the historical record of what was removed.

--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -410,7 +410,7 @@ plans_reviewed: [{list of PLAN.md files}]
 
 Commit:
 ```bash
-gsd-sdk query commit "docs: cross-AI review for phase {N}" {phase_dir}/{padded_phase}-REVIEWS.md
+gsd-sdk query commit "docs: cross-AI review for phase {N}" --files {phase_dir}/{padded_phase}-REVIEWS.md
 ```
 </step>
 

--- a/get-shit-done/workflows/ship.md
+++ b/get-shit-done/workflows/ship.md
@@ -257,7 +257,7 @@ gsd-sdk query state.update "Status" "Phase ${PHASE_NUMBER} shipped — PR #${PR_
 
 If `commit_docs` is true:
 ```bash
-gsd-sdk query commit "docs(${padded_phase}): ship phase ${PHASE_NUMBER} — PR #${PR_NUMBER}" .planning/STATE.md
+gsd-sdk query commit "docs(${padded_phase}): ship phase ${PHASE_NUMBER} — PR #${PR_NUMBER}" --files .planning/STATE.md
 ```
 </step>
 

--- a/get-shit-done/workflows/sketch-wrap-up.md
+++ b/get-shit-done/workflows/sketch-wrap-up.md
@@ -232,7 +232,7 @@ If this routing line already exists (append mode), leave it as-is.
 Commit all artifacts (if `COMMIT_DOCS` is true):
 
 ```bash
-gsd-sdk query commit "docs(sketch-wrap-up): package [N] sketch findings into project skill" .planning/sketches/WRAP-UP-SUMMARY.md
+gsd-sdk query commit "docs(sketch-wrap-up): package [N] sketch findings into project skill" --files .planning/sketches/WRAP-UP-SUMMARY.md
 ```
 </step>
 

--- a/get-shit-done/workflows/sketch.md
+++ b/get-shit-done/workflows/sketch.md
@@ -296,7 +296,7 @@ Iterate until satisfied.
 
 **h.** Commit (if `COMMIT_DOCS` is true):
 ```bash
-gsd-sdk query commit "docs(sketch-NNN): [winning direction] — [key visual insight]" .planning/sketches/NNN-descriptive-name/ .planning/sketches/MANIFEST.md
+gsd-sdk query commit "docs(sketch-NNN): [winning direction] — [key visual insight]" --files .planning/sketches/NNN-descriptive-name/ .planning/sketches/MANIFEST.md
 ```
 
 **i.** Report:

--- a/get-shit-done/workflows/spike-wrap-up.md
+++ b/get-shit-done/workflows/spike-wrap-up.md
@@ -246,7 +246,7 @@ Patterns and stack choices established across spike sessions. New spikes follow 
 Commit all artifacts (if `COMMIT_DOCS` is true):
 
 ```bash
-gsd-sdk query commit "docs(spike-wrap-up): package [N] spike findings into project skill" .planning/spikes/WRAP-UP-SUMMARY.md .planning/spikes/CONVENTIONS.md
+gsd-sdk query commit "docs(spike-wrap-up): package [N] spike findings into project skill" --files .planning/spikes/WRAP-UP-SUMMARY.md .planning/spikes/CONVENTIONS.md
 ```
 </step>
 

--- a/get-shit-done/workflows/spike.md
+++ b/get-shit-done/workflows/spike.md
@@ -334,7 +334,7 @@ tags: [tag1, tag2]
 
 **i.** Commit (if `COMMIT_DOCS` is true):
 ```bash
-gsd-sdk query commit "docs(spike-NNN): [VERDICT] — [key finding]" .planning/spikes/NNN-descriptive-name/ .planning/spikes/MANIFEST.md
+gsd-sdk query commit "docs(spike-NNN): [VERDICT] — [key finding]" --files .planning/spikes/NNN-descriptive-name/ .planning/spikes/MANIFEST.md
 ```
 
 **j.** Report:
@@ -388,7 +388,7 @@ Only include patterns that repeated across 2+ spikes or were explicitly chosen b
 
 Commit (if `COMMIT_DOCS` is true):
 ```bash
-gsd-sdk query commit "docs(spikes): update conventions" .planning/spikes/CONVENTIONS.md
+gsd-sdk query commit "docs(spikes): update conventions" --files .planning/spikes/CONVENTIONS.md
 ```
 </step>
 

--- a/get-shit-done/workflows/ui-phase.md
+++ b/get-shit-done/workflows/ui-phase.md
@@ -298,7 +298,7 @@ Dimensions: 6/6 passed
 ## 11. Commit (if configured)
 
 ```bash
-gsd-sdk query commit "docs(${padded_phase}): UI design contract" "${PHASE_DIR}/${PADDED_PHASE}-UI-SPEC.md"
+gsd-sdk query commit "docs(${padded_phase}): UI design contract" --files "${PHASE_DIR}/${PADDED_PHASE}-UI-SPEC.md"
 ```
 
 ## 12. Update State

--- a/get-shit-done/workflows/ui-review.md
+++ b/get-shit-done/workflows/ui-review.md
@@ -176,7 +176,7 @@ tools is detected at runtime.
 ## 5. Commit (if configured)
 
 ```bash
-gsd-sdk query commit "docs(${padded_phase}): UI audit review" "${PHASE_DIR}/${PADDED_PHASE}-UI-REVIEW.md"
+gsd-sdk query commit "docs(${padded_phase}): UI audit review" --files "${PHASE_DIR}/${PADDED_PHASE}-UI-REVIEW.md"
 ```
 
 </process>

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -539,6 +539,11 @@ for dir in .claude .config/opencode .opencode .gemini .config/kilo .kilo .codex;
   rm -f "./$dir/cache/gsd-update-check.json"
   rm -f "$HOME/$dir/cache/gsd-update-check.json"
 done
+
+# Clear the shared tool-agnostic cache written by gsd-check-update.js hook (#2784).
+# The hook uses ~/.cache/gsd/gsd-update-check.json regardless of runtime; clear it
+# so the statusline stops showing the stale "⬆ /gsd-update" indicator after update.
+rm -f "$HOME/.cache/gsd/gsd-update-check.json"
 ```
 
 The SessionStart hook (`gsd-check-update.js`) writes to the detected runtime's cache directory, so preferred/env-derived paths and default paths must all be cleared to prevent stale update indicators.

--- a/get-shit-done/workflows/verify-work.md
+++ b/get-shit-done/workflows/verify-work.md
@@ -391,7 +391,7 @@ Clear Current Test section:
 
 Commit the UAT file:
 ```bash
-gsd-sdk query commit "test({phase_num}): complete UAT - {passed} passed, {issues} issues" ".planning/phases/XX-name/{phase_num}-UAT.md"
+gsd-sdk query commit "test({phase_num}): complete UAT - {passed} passed, {issues} issues" --files ".planning/phases/XX-name/{phase_num}-UAT.md"
 ```
 
 Present summary:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "get-shit-done-cc",
-  "version": "1.38.5",
+  "version": "1.39.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "get-shit-done-cc",
-      "version": "1.38.5",
+      "version": "1.39.0-rc.4",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.114.tgz",
-      "integrity": "sha512-plJ+j17jew9tDMHir/90hXrwoB8cZ9GrIyG19zIJcFyQ8pVhRXjZRJCtF2ElfPoiwkxMmNu1Klqyui4xP4shPg==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.119.tgz",
+      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.81.0",
@@ -36,23 +36,23 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.114",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.114",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.114",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.114",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.114",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.114",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.114",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.114"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.119"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.114.tgz",
-      "integrity": "sha512-0/6LWrNilWpmiX6Xrj5plsBmCrCdKGERgAlKUZQEJZplnfuweFAJu7WXZB4KBaUpGlPO91zB/yqDh6kp5aZFbA==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.119.tgz",
+      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
       "cpu": [
         "arm64"
       ],
@@ -63,9 +63,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.114.tgz",
-      "integrity": "sha512-sOHxq1rEO/KZg2iEZILTPn62lMRRMPqtxKx41uGLi3xjVDrAej6Ury9dDZjYBKkK9n4kBylXV0Oom2CZ14dDYw==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.119.tgz",
+      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
       "cpu": [
         "x64"
       ],
@@ -76,9 +76,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.114.tgz",
-      "integrity": "sha512-j/SfEoN6+fyEsp8EuPe+xKcGfsZtaBmdUUH+YSRk5H/lYgy38yNsDhdt+AJMQcdMKfHsiwZ3Y9Ajoe9G9wNwHQ==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.119.tgz",
+      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
       "cpu": [
         "arm64"
       ],
@@ -92,9 +92,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.114.tgz",
-      "integrity": "sha512-Mhd7bumTwWvkgjSJnYvCgyt8DfmLiUoK92mfvAKxHX7i5YSw+h5Kprqh2Cap+2SBbpwZvnwIoEYGCxhGwE5ddg==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.119.tgz",
+      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
       "cpu": [
         "arm64"
       ],
@@ -108,9 +108,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.114.tgz",
-      "integrity": "sha512-wbaExKDleLlm2zHEhb74GKMLVhtO0IUmFhdimQcdL6CdTkmDE8ZJi53tYWE9+jq+XWNRXoM2yEmKPzXoUmsJng==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.119.tgz",
+      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
       "cpu": [
         "x64"
       ],
@@ -124,9 +124,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.114.tgz",
-      "integrity": "sha512-c1URsameGHAcghen+mY6jvr2oypiAPHXJIdP4huxR25zPdXWv2x+BCy+vcRVeajsq4VmFzAyQJwaM+BXkmXjAw==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.119.tgz",
+      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
       "cpu": [
         "x64"
       ],
@@ -140,9 +140,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.114.tgz",
-      "integrity": "sha512-qeWdUpQymcKCA92osPmffG4QogrOSvuffPvm6c2OlMDjCPYs8vKG7bSe1Vq5tP9tfBszKPVJWBDh+2ANkNissQ==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.119.tgz",
+      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
       "cpu": [
         "arm64"
       ],
@@ -153,9 +153,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.114.tgz",
-      "integrity": "sha512-nVr43WwsKvWA6rojw15qBS/f31srukdLxy1KwKzpftlpmkzQ9Lh8uhIafOmoIPzz67f8VJ8JqHE0caA5YrhX9A==",
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.119.tgz",
+      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
       "cpu": [
         "x64"
       ],
@@ -217,9 +217,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
-      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -315,9 +315,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -787,9 +787,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -1020,9 +1020,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1157,9 +1157,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -1207,9 +1207,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1288,13 +1288,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode, Gemini and Codex by TÂCHES.",
   "bin": {
     "get-shit-done-cc": "bin/install.js",
-    "gsd-sdk": "bin/gsd-sdk.js"
+    "gsd-sdk": "bin/gsd-sdk.js",
+    "gsd-tools": "bin/gsd-sdk.js"
   },
   "files": [
     "bin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-shit-done-cc",
-  "version": "1.38.5",
+  "version": "1.39.0-rc.4",
   "description": "A meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode, Gemini and Codex by TÂCHES.",
   "bin": {
     "get-shit-done-cc": "bin/install.js",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/sdk",
-  "version": "0.1.0",
+  "version": "1.39.0-rc.4",
   "description": "GSD SDK — programmatic interface for running GSD plans via the Agent SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/sdk/src/cli.ts
+++ b/sdk/src/cli.ts
@@ -341,6 +341,17 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
     return;
   }
 
+  // Fall back to GSD_WORKSTREAM env var when --ws is not supplied (#2791).
+  // gsd-tools.cjs resolves the active workstream via this env var; parity
+  // means gsd-sdk query commands see the same .planning/ path as gsd-tools.
+  if (args.ws === undefined && process.env.GSD_WORKSTREAM) {
+    const envWs = process.env.GSD_WORKSTREAM;
+    if (validateWorkstreamName(envWs)) {
+      args = { ...args, ws: envWs };
+    }
+    // If the env var contains an invalid name, silently ignore it (same as CJS).
+  }
+
   // Multi-repo project-root resolution (issue #2623).
   //
   // When the user launches `gsd-sdk` from inside a `sub_repos`-listed child repo,

--- a/sdk/src/query/config-query.ts
+++ b/sdk/src/query/config-query.ts
@@ -80,9 +80,22 @@ export function getAgentToModelMapForProfile(normalizedProfile: string): Record<
  * @throws GSDError with Validation classification if key missing or not found
  */
 export const configGet: QueryHandler = async (args, projectDir, workstream) => {
-  const keyPath = args[0];
+  // Support --default <value> flag (#2803): return this value (exit 0) when the
+  // key is absent, mirroring gsd-tools.cjs config-get behavior from #1893.
+  const defaultIdx = args.indexOf('--default');
+  let defaultValue: string | undefined;
+  let filteredArgs = args;
+  if (defaultIdx !== -1) {
+    if (defaultIdx + 1 >= args.length) {
+      throw new GSDError('Usage: config-get <key.path> [--default <value>]', ErrorClassification.Validation);
+    }
+    defaultValue = String(args[defaultIdx + 1]);
+    filteredArgs = [...args.slice(0, defaultIdx), ...args.slice(defaultIdx + 2)];
+  }
+
+  const keyPath = filteredArgs[0];
   if (!keyPath) {
-    throw new GSDError('Usage: config-get <key.path>', ErrorClassification.Validation);
+    throw new GSDError('Usage: config-get <key.path> [--default <value>]', ErrorClassification.Validation);
   }
 
   const paths = planningPaths(projectDir, workstream);
@@ -106,11 +119,13 @@ export const configGet: QueryHandler = async (args, projectDir, workstream) => {
     if (current === undefined || current === null || typeof current !== 'object') {
       // UNIX convention (cf. `git config --get`): missing key exits 1, not 10.
       // See issue #2544 — callers use `if ! gsd-sdk query config-get k; then` patterns.
+      if (defaultValue !== undefined) return { data: defaultValue };
       throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.Execution);
     }
     current = (current as Record<string, unknown>)[key];
   }
   if (current === undefined) {
+    if (defaultValue !== undefined) return { data: defaultValue };
     throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.Execution);
   }
 

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -351,6 +351,40 @@ describe('initPlanPhase', () => {
     const data = result.data as Record<string, unknown>;
     expect(data.error).toBeDefined();
   });
+
+  // #2769: extractReqIds must accept all bold/colon variants of the
+  // Requirements header. The forms render identically in markdown but differ
+  // textually; the previous regex only matched **Requirements**: (colon
+  // outside bold) and silently returned null for **Requirements:** (colon
+  // inside bold) and **Requirements** : (spaced).
+  describe.each([
+    { name: 'colon inside bold', header: '**Requirements:** RV-01, RV-02' },
+    { name: 'colon outside bold', header: '**Requirements**: RV-01, RV-02' },
+    { name: 'space before colon', header: '**Requirements** : RV-01, RV-02' },
+  ])('phase_req_ids extraction (#2769)', ({ name, header }) => {
+    it(`parses Requirements header with ${name}`, async () => {
+      // Overwrite ROADMAP.md so phase 9 carries the variant header.
+      await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), [
+        '# Roadmap',
+        '',
+        '## v3.0: SDK-First Migration',
+        '',
+        '### Phase 9: Foundation',
+        '',
+        '**Goal:** Build foundation',
+        header,
+        '',
+        '### Phase 10: Read-Only Queries',
+        '',
+        '**Goal:** Implement queries',
+        '',
+      ].join('\n'));
+
+      const result = await initPlanPhase(['9'], tmpDir);
+      const data = result.data as Record<string, unknown>;
+      expect(data.phase_req_ids).toBe('RV-01, RV-02');
+    });
+  });
 });
 
 describe('initNewMilestone', () => {

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -203,7 +203,12 @@ async function getPhaseInfoForVerifyWork(
  */
 function extractReqIds(roadmapPhase: Record<string, unknown> | null): string | null {
   const section = roadmapPhase?.section as string | undefined;
-  const reqMatch = section?.match(/^\*\*Requirements\*\*:[^\S\n]*([^\n]*)$/m);
+  // Accept all bold/colon variants of the Requirements header. The forms
+  //   **Requirements:**  (colon inside bold)
+  //   **Requirements**:  (colon outside bold)
+  //   **Requirements** : (space before outside colon)
+  // render identically in markdown but differ textually. Issue #2769.
+  const reqMatch = section?.match(/^\*\*Requirements:?\*\*[^\S\n]*:?[^\S\n]*([^\n]*)$/m);
   const reqExtracted = reqMatch
     ? reqMatch[1].replace(/[\[\]]/g, '').split(',').map((s: string) => s.trim()).filter(Boolean).join(', ')
     : null;

--- a/sdk/src/query/roadmap-update-plan-progress.ts
+++ b/sdk/src/query/roadmap-update-plan-progress.ts
@@ -15,7 +15,23 @@ import { GSDError, ErrorClassification } from '../errors.js';
 import type { QueryHandler } from './utils.js';
 
 export const roadmapUpdatePlanProgress: QueryHandler = async (args, projectDir, workstream) => {
-  const phaseNum = args[0];
+  // Support --phase <N> flag form in addition to positional (fixes #2796).
+  // execute-phase.md:228 passes --phase so positional-only parsing silently
+  // took the literal string "--phase" as the phase value.
+  const phaseIdx = args.indexOf('--phase');
+  let phaseNum: string;
+  const phaseFlagValue = phaseIdx !== -1 ? args[phaseIdx + 1] : undefined;
+  if (
+    phaseIdx !== -1 &&
+    phaseFlagValue !== undefined &&
+    !String(phaseFlagValue).startsWith('--')
+  ) {
+    phaseNum = String(phaseFlagValue);
+  } else {
+    // Positional: skip any leading flag tokens in case of mixed invocations.
+    const positional = args.filter((a) => !String(a).startsWith('--'));
+    phaseNum = positional[0] ? String(positional[0]) : '';
+  }
   if (!phaseNum) {
     throw new GSDError('phase number required for roadmap update-plan-progress', ErrorClassification.Validation);
   }

--- a/sdk/src/query/uat.ts
+++ b/sdk/src/query/uat.ts
@@ -188,11 +188,62 @@ function parseUatItems(content: string): Record<string, unknown>[] {
   return items;
 }
 
+/**
+ * Parse frontmatter human_verification: YAML array entries into audit items.
+ *
+ * Fixes #2788: when gsd-verifier encodes human items in YAML frontmatter
+ * rather than the body, parseVerificationItems was returning [] because it
+ * only searched the body for a "## Human Verification" heading.
+ */
+function parseVerificationFrontmatterItems(fm: Record<string, unknown>): Record<string, unknown>[] {
+  const items: Record<string, unknown>[] = [];
+  const hvArray = fm.human_verification;
+  if (!Array.isArray(hvArray)) return items;
+
+  let i = 0;
+  for (const entry of hvArray) {
+    i++;
+    if (typeof entry === 'string') {
+      const name = entry.trim();
+      if (name.length > 0) {
+        items.push({ test: i, name, result: 'human_needed', category: 'human_uat' });
+      }
+    } else if (typeof entry === 'object' && entry !== null) {
+      const obj = entry as Record<string, unknown>;
+      // Accept any string property as the item name; prefer 'test' key.
+      const name = (obj.test as string | undefined) || (obj.name as string | undefined) || '';
+      if (name) {
+        const item: Record<string, unknown> = {
+          test: i,
+          name: String(name).trim(),
+          result: 'human_needed',
+          category: 'human_uat',
+        };
+        if (obj.expected) item.expected = String(obj.expected).trim();
+        if (obj.why_human) item.why_human = String(obj.why_human).trim();
+        items.push(item);
+      }
+    }
+  }
+  return items;
+}
+
 /** Port of `parseVerificationItems` from `uat.cjs`. */
-function parseVerificationItems(content: string, status: string): Record<string, unknown>[] {
+function parseVerificationItems(content: string, status: string, fm?: Record<string, unknown>): Record<string, unknown>[] {
   const items: Record<string, unknown>[] = [];
   if (status === 'human_needed') {
-    const hvSection = content.match(/##\s*Human Verification.*?\n([\s\S]*?)(?=\n##\s|\n---\s|$)/i);
+    // Check frontmatter human_verification: array first (#2788).
+    // gsd-verifier writes items here; body-section fallback is secondary.
+    if (fm) {
+      const fmItems = parseVerificationFrontmatterItems(fm);
+      if (fmItems.length > 0) return fmItems;
+    }
+
+    // Body fallback: match ## human_verification or ## Human Verification
+    // (case-insensitive, underscore or space, with optional parenthetical).
+    const hvSection = content.match(
+      /##\s*human[_\s-]verification[^\n]*\n([\s\S]*?)(?=\n##\s|\n---\s|$)/i
+    );
     if (hvSection) {
       const lines = hvSection[1].split('\n');
       for (const line of lines) {
@@ -273,7 +324,7 @@ export const auditUat: QueryHandler = async (_args, projectDir, workstream) => {
       const fm = extractFrontmatter(content);
       const status = (fm.status || 'unknown') as string;
       if (status === 'human_needed' || status === 'gaps_found') {
-        const items = parseVerificationItems(content, status);
+        const items = parseVerificationItems(content, status, fm);
         if (items.length > 0) {
           results.push({
             phase: phaseNum,

--- a/tests/bug-2643-skill-frontmatter-name.test.cjs
+++ b/tests/bug-2643-skill-frontmatter-name.test.cjs
@@ -3,12 +3,15 @@
 process.env.GSD_TEST_MODE = '1';
 
 /**
- * Bug #2643: workflows emit Skill(skill="gsd:<cmd>") but flat-skills install
- * registers `gsd-<cmd>` as the frontmatter `name:`. Claude Code uses the
- * frontmatter name (not dir name) as the skill identity — so the emitted
- * `name:` must match the colon form used by workflow Skill() calls.
+ * Bug #2643 / #2808: skill frontmatter name parity.
  *
- * The directory name stays hyphenated for Windows path safety.
+ * Original (#2643): workflows emitted Skill(skill="gsd:<cmd>") and the
+ * installer registered colon form in SKILL.md name: to match.
+ *
+ * Updated (#2808): workflows now use Skill(skill="gsd-<cmd>") (hyphen),
+ * and the installer emits name: gsd-<cmd> (hyphen). Claude Code autocomplete
+ * now shows the canonical hyphen form instead of the deprecated colon form.
+ * The directory name (gsd-<cmd>) is unchanged.
  */
 
 const { test, describe } = require('node:test');
@@ -37,7 +40,15 @@ function collectFiles(dir, results) {
   return results;
 }
 
-function extractSkillNames(content) {
+function extractSkillNamesHyphen(content) {
+  const names = new Set();
+  const rx = /Skill\(skill=['"]gsd-([a-z0-9-]+)['"]/gi;
+  let m;
+  while ((m = rx.exec(content)) !== null) names.add('gsd-' + m[1]);
+  return names;
+}
+
+function extractSkillNamesColon(content) {
   const names = new Set();
   const rx = /Skill\(skill=['"]gsd:([a-z0-9-]+)['"]/gi;
   let m;
@@ -45,28 +56,58 @@ function extractSkillNames(content) {
   return names;
 }
 
-describe('skill frontmatter name parity (#2643)', () => {
-  test('skillFrontmatterName helper emits colon form', () => {
+describe('skill frontmatter name parity (#2643 / #2808)', () => {
+  test('skillFrontmatterName helper emits hyphen form (#2808)', () => {
     assert.strictEqual(typeof skillFrontmatterName, 'function');
-    assert.strictEqual(skillFrontmatterName('gsd-execute-phase'), 'gsd:execute-phase');
-    assert.strictEqual(skillFrontmatterName('gsd-plan-phase'), 'gsd:plan-phase');
-    assert.strictEqual(skillFrontmatterName('gsd:next'), 'gsd:next');
+    assert.strictEqual(skillFrontmatterName('gsd-execute-phase'), 'gsd-execute-phase');
+    assert.strictEqual(skillFrontmatterName('gsd-plan-phase'), 'gsd-plan-phase');
+    assert.strictEqual(skillFrontmatterName('gsd-next'), 'gsd-next');
   });
 
-  test('convertClaudeCommandToClaudeSkill emits name: gsd:<cmd>', () => {
+  test('convertClaudeCommandToClaudeSkill emits name: gsd-<cmd> (hyphen)', () => {
     const input = '---\nname: old\ndescription: test\n---\n\nBody.';
     const result = convertClaudeCommandToClaudeSkill(input, 'gsd-execute-phase');
-    assert.match(result, /^---\nname: gsd:execute-phase\n/);
+    // Parse the frontmatter block structurally: extract the name: field value.
+    const frontmatterMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    assert.ok(frontmatterMatch, 'output must have a frontmatter block delimited by ---');
+    const frontmatterLines = frontmatterMatch[1].split('\n');
+    const nameEntry = frontmatterLines.find((l) => l.startsWith('name:'));
+    assert.ok(nameEntry, 'frontmatter must contain a name: field');
+    const nameValue = nameEntry.replace(/^name:\s*/, '').trim();
+    assert.strictEqual(
+      nameValue,
+      'gsd-execute-phase',
+      `frontmatter name: must be 'gsd-execute-phase' (hyphen form), got '${nameValue}'`
+    );
   });
 
-  test('every workflow Skill(skill="gsd:<cmd>") resolves to an emitted skill name', () => {
+  test('no workflow uses deprecated Skill(skill="gsd:<cmd>") colon form', () => {
+    const workflowFiles = collectFiles(WORKFLOWS_DIR);
+    const colonRefs = [];
+    for (const f of workflowFiles) {
+      const src = fs.readFileSync(f, 'utf-8');
+      for (const n of extractSkillNamesColon(src)) {
+        colonRefs.push(path.basename(f) + ': ' + n);
+      }
+    }
+    assert.deepStrictEqual(
+      colonRefs,
+      [],
+      'deprecated colon-form Skill() calls found (update to hyphen): ' + colonRefs.join(', ')
+    );
+  });
+
+  test('every workflow Skill(skill="gsd-<cmd>") resolves to an emitted skill name', () => {
     const workflowFiles = collectFiles(WORKFLOWS_DIR);
     const referenced = new Set();
     for (const f of workflowFiles) {
       const src = fs.readFileSync(f, 'utf-8');
-      for (const n of extractSkillNames(src)) referenced.add(n);
+      for (const n of extractSkillNamesHyphen(src)) referenced.add(n);
     }
-    assert.ok(referenced.size > 0, 'expected at least one Skill(skill="gsd:<cmd>") reference');
+    assert.ok(
+      referenced.size > 0,
+      `expected at least one Skill(skill="gsd-<cmd>") reference in workflows under ${WORKFLOWS_DIR}`
+    );
 
     const emitted = new Set();
     const cmdFiles = fs.readdirSync(COMMANDS_DIR).filter(f => f.endsWith('.md'));

--- a/tests/bug-2760-codex-install-defensive.test.cjs
+++ b/tests/bug-2760-codex-install-defensive.test.cjs
@@ -1,0 +1,978 @@
+/**
+ * Regression: issue #2760 — Codex install path corrupts existing config.toml.
+ *
+ * Three defects, three fixes (defensive triple):
+ *
+ *   Defect 3 (confirmed real) — Hooks AoT downgrade. When the user already has
+ *     `[[hooks.SessionStart]]` (namespaced AoT) entries in their config, GSD
+ *     used to append a `[[hooks]]` (top-level AoT) block that confuses
+ *     round-trip writers and produces a config Codex refuses to load.
+ *     Fix: detect the user's preferred shape and emit GSD's hook in the same
+ *     namespaced form so both coexist cleanly.
+ *
+ *   Defects 1+2 (defensive) — Strip-step robustness. Pre-existing legacy
+ *     `[agents]` (single-bracket) and `[[agents]]` (sequence) blocks are
+ *     invalid in current Codex schema and break Codex even though GSD now
+ *     emits the correct `[agents.<name>]` struct form. Fix: install-time
+ *     stripping always purges these forms regardless of GSD marker presence
+ *     so reinstall self-heals files where the marker was edited out or never
+ *     existed (third-party tools).
+ *
+ *   Fix 3 (defensive) — Post-write validation. Parse the bytes we are about
+ *     to commit, assert they match Codex's expected schema (no bare/sequence
+ *     `agents`, no bare `hooks.<Event>`); on failure, restore the pre-install
+ *     backup and abort so the user never gets a broken Codex CLI.
+ */
+
+// Scope GSD_TEST_MODE to module load only — restore prior value (or unset) so
+// downstream tests in the same node process never see test-only behaviour
+// leak through (#2760 CR4 finding 5).
+const previousGsdTestMode = process.env.GSD_TEST_MODE;
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const {
+  install,
+  validateCodexConfigSchema,
+  hasUserNamespacedAotHooks,
+  stripGsdFromCodexConfig,
+  installCodexConfig,
+  parseTomlToObject,
+} = require('../bin/install.js');
+
+if (previousGsdTestMode === undefined) {
+  delete process.env.GSD_TEST_MODE;
+} else {
+  process.env.GSD_TEST_MODE = previousGsdTestMode;
+}
+
+function runCodexInstall(codexHome, cwd = path.join(__dirname, '..')) {
+  const previousCodeHome = process.env.CODEX_HOME;
+  const previousCwd = process.cwd();
+  process.env.CODEX_HOME = codexHome;
+  try {
+    process.chdir(cwd);
+    return install(true, 'codex');
+  } finally {
+    process.chdir(previousCwd);
+    if (previousCodeHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodeHome;
+    }
+  }
+}
+
+function readCodexConfig(codexHome) {
+  return fs.readFileSync(path.join(codexHome, 'config.toml'), 'utf8');
+}
+
+function writeCodexConfig(codexHome, content) {
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.writeFileSync(path.join(codexHome, 'config.toml'), content, 'utf8');
+}
+
+describe('#2760 defect 3 — Hooks AoT preservation across install/uninstall/reinstall', () => {
+  let tmpDir;
+  let codexHome;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2760-d3-'));
+    codexHome = path.join(tmpDir, 'codex-home');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('preserves both pre-existing [[hooks.SessionStart]] entries and adds GSD entry in namespaced form', () => {
+    const userConfig = [
+      '[[hooks.SessionStart]]',
+      'command = "echo first user hook"',
+      '',
+      '[[hooks.SessionStart]]',
+      'command = "echo second user hook"',
+      '',
+    ].join('\n');
+    writeCodexConfig(codexHome, userConfig);
+
+    runCodexInstall(codexHome);
+    const afterInstall = readCodexConfig(codexHome);
+    const parsed = parseTomlToObject(afterInstall);
+
+    // hooks.SessionStart must be an array-of-tables (namespaced AoT form).
+    assert.ok(
+      parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
+      'hooks.SessionStart must be an array-of-tables, got: '
+        + (parsed.hooks ? typeof parsed.hooks.SessionStart : 'no hooks table')
+    );
+
+    const commands = parsed.hooks.SessionStart.map((entry) => entry.command);
+
+    // Both pre-existing user hook entries survive in the parsed structure.
+    assert.ok(
+      commands.includes('echo first user hook'),
+      'first user [[hooks.SessionStart]] entry preserved in parsed structure: ' + JSON.stringify(commands)
+    );
+    assert.ok(
+      commands.includes('echo second user hook'),
+      'second user [[hooks.SessionStart]] entry preserved in parsed structure: ' + JSON.stringify(commands)
+    );
+
+    // GSD's managed entry is emitted in the same namespaced AoT shape so it
+    // does not collide with the user's preferred form.
+    assert.ok(
+      commands.some((cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)),
+      'GSD entry must appear in hooks.SessionStart array (not top-level [[hooks]]): '
+        + JSON.stringify(commands)
+    );
+
+    // Top-level [[hooks]] AoT must not coexist when namespaced form is in use —
+    // mixing forms is what produces the round-trip break this fix prevents.
+    assert.ok(
+      !Array.isArray(parsed.hooks) || parsed.hooks.length === 0,
+      'no top-level [[hooks]] AoT entries when namespaced form is in use'
+    );
+  });
+
+  test('selects top-level [[hooks]] form when user has no namespaced hooks (status-quo behavior)', () => {
+    writeCodexConfig(codexHome, '');
+    runCodexInstall(codexHome);
+    const content = readCodexConfig(codexHome);
+    const parsed = parseTomlToObject(content);
+
+    // Top-level hooks must be an array-of-tables; the GSD entry must be one
+    // of those tables and carry event = "SessionStart".
+    assert.ok(
+      Array.isArray(parsed.hooks),
+      'fresh install must produce top-level [[hooks]] AoT, got: ' + typeof parsed.hooks
+    );
+    assert.ok(
+      parsed.hooks.some((h) => h && h.event === 'SessionStart'),
+      'top-level [[hooks]] AoT must contain an entry with event = "SessionStart": '
+        + JSON.stringify(parsed.hooks)
+    );
+  });
+});
+
+describe('#2760 fix 2 — Strip purges invalid legacy [agents] / [[agents]] regardless of marker', () => {
+  let tmpDir;
+  let codexHome;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2760-f2-'));
+    codexHome = path.join(tmpDir, 'codex-home');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('strips bare [agents] single-bracket block (no GSD marker, arbitrary user keys)', () => {
+    writeCodexConfig(codexHome, [
+      '[agents]',
+      'default = "custom-agent"',
+      'extra_key = "value"',
+      '',
+      '[model]',
+      'name = "o3"',
+      '',
+    ].join('\n'));
+
+    runCodexInstall(codexHome);
+    const content = readCodexConfig(codexHome);
+    const parsed = parseTomlToObject(content);
+
+    // Bare [agents] would have left { default, extra_key } as scalar leaves
+    // on parsed.agents. After strip + struct emit, every key under agents
+    // must itself be a table (the gsd-* struct form).
+    assert.ok(
+      parsed.agents && typeof parsed.agents === 'object' && !Array.isArray(parsed.agents),
+      'agents must be a table-of-tables in parsed structure, got: ' + typeof parsed.agents
+    );
+    assert.equal(parsed.agents.default, undefined, 'bare [agents] default key must be stripped');
+    assert.equal(parsed.agents.extra_key, undefined, 'bare [agents] extra_key must be stripped');
+    const gsdAgents = Object.keys(parsed.agents).filter((k) => k.startsWith('gsd-'));
+    assert.ok(
+      gsdAgents.length > 0 && gsdAgents.every((k) => typeof parsed.agents[k] === 'object'),
+      'agents.gsd-* struct form must be present: ' + JSON.stringify(Object.keys(parsed.agents))
+    );
+
+    // User's unrelated [model] section preserved structurally.
+    assert.ok(
+      parsed.model && parsed.model.name === 'o3',
+      'unrelated user [model] section preserved with name = "o3", got: ' + JSON.stringify(parsed.model)
+    );
+  });
+
+  test('strips [[agents]] sequence-form block without GSD marker (third-party / marker-edited-out)', () => {
+    writeCodexConfig(codexHome, [
+      '[[agents]]',
+      'name = "user-helper"',
+      'description = "third-party agent"',
+      '',
+      '[[agents]]',
+      'name = "another-helper"',
+      'description = "second one"',
+      '',
+      '[projects."/tmp/x"]',
+      'trust_level = "trusted"',
+      '',
+    ].join('\n'));
+
+    runCodexInstall(codexHome);
+    const content = readCodexConfig(codexHome);
+    const parsed = parseTomlToObject(content);
+
+    // [[agents]] sequence form would parse to Array — after strip it must be
+    // a table-of-tables with gsd-* struct keys.
+    assert.ok(
+      parsed.agents && typeof parsed.agents === 'object' && !Array.isArray(parsed.agents),
+      'agents must be a table-of-tables in parsed structure (sequence form must be stripped), got: '
+        + (Array.isArray(parsed.agents) ? 'array' : typeof parsed.agents)
+    );
+    const gsdAgents = Object.keys(parsed.agents).filter((k) => k.startsWith('gsd-'));
+    assert.ok(
+      gsdAgents.length > 0,
+      'agents.gsd-* struct form must be present: ' + JSON.stringify(Object.keys(parsed.agents))
+    );
+
+    // User's unrelated [projects."/tmp/x"] section preserved structurally.
+    assert.ok(
+      parsed.projects && parsed.projects['/tmp/x'] && parsed.projects['/tmp/x'].trust_level === 'trusted',
+      'unrelated user [projects."/tmp/x"] section preserved with trust_level = "trusted", got: '
+        + JSON.stringify(parsed.projects)
+    );
+  });
+});
+
+// concurrency: false — the third test mutates installModule.__codexSchemaValidator,
+// a module-level test seam. Other tests in this file (and in bug-2153, etc.)
+// also call runCodexInstall() and would observe the injected validator if
+// node:test ran them in parallel. Serializing this describe block keeps the
+// seam mutation invisible to siblings.
+describe('#2760 fix 3 — Post-write Codex schema validation', { concurrency: false }, () => {
+  test('passes a clean config produced by GSD install', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2760-f3a-'));
+    try {
+      const codexHome = path.join(tmpDir, 'codex-home');
+      runCodexInstall(codexHome);
+      const content = readCodexConfig(codexHome);
+      const result = validateCodexConfigSchema(content);
+      assert.equal(result.ok, true, 'GSD-emitted config passes schema validation');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects bare [agents] and bare [hooks.SessionStart] in arbitrary content', () => {
+    const bareAgents = [
+      '[agents]',
+      'default = "x"',
+      '',
+    ].join('\n');
+    const bareHooks = [
+      '[hooks.SessionStart]',
+      'command = "x"',
+      '',
+    ].join('\n');
+    const sequenceAgents = [
+      '[[agents]]',
+      'name = "x"',
+      '',
+    ].join('\n');
+
+    assert.equal(validateCodexConfigSchema(bareAgents).ok, false, 'bare [agents] rejected');
+    assert.equal(validateCodexConfigSchema(bareHooks).ok, false, 'bare [hooks.SessionStart] rejected');
+    assert.equal(validateCodexConfigSchema(sequenceAgents).ok, false, '[[agents]] sequence rejected');
+  });
+
+  test('aborts install and restores pre-install backup when post-write validation fails', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2760-f3b-'));
+    const installModule = require('../bin/install.js');
+    try {
+      const codexHome = path.join(tmpDir, 'codex-home');
+      // Pre-install file the user wants protected.
+      const preInstall = [
+        '# user file',
+        '[model]',
+        'name = "o3"',
+        '',
+      ].join('\n');
+      writeCodexConfig(codexHome, preInstall);
+
+      // Force the post-write validator to fail via the documented test seam.
+      // This simulates the writer producing legacy-form output that Codex
+      // would reject — install MUST abort, restore the pre-install bytes,
+      // and surface a clear error.
+      installModule.__codexSchemaValidator = () => ({
+        ok: false,
+        reason: 'simulated invalid output for test',
+      });
+
+      let threw = false;
+      try {
+        runCodexInstall(codexHome);
+      } catch (e) {
+        threw = true;
+        assert.match(
+          e.message,
+          /post-write Codex schema validation failed/,
+          'thrown error names the validation failure'
+        );
+        assert.match(e.message, /simulated invalid output for test/, 'thrown error includes reason');
+      }
+      assert.equal(threw, true, 'install threw when validator failed');
+
+      const afterInstall = fs.readFileSync(path.join(codexHome, 'config.toml'), 'utf8');
+      assert.equal(
+        afterInstall,
+        preInstall,
+        'pre-install file restored verbatim after validation failure'
+      );
+    } finally {
+      delete installModule.__codexSchemaValidator;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('#2760 — hasUserNamespacedAotHooks helper', () => {
+  test('detects [[hooks.SessionStart]] AoT entries', () => {
+    const content = [
+      '[[hooks.SessionStart]]',
+      'command = "x"',
+      '',
+    ].join('\n');
+    assert.equal(hasUserNamespacedAotHooks(content, 'SessionStart'), true);
+  });
+
+  test('returns false when only top-level [[hooks]] entries exist', () => {
+    const content = [
+      '[[hooks]]',
+      'event = "SessionStart"',
+      'command = "x"',
+      '',
+    ].join('\n');
+    assert.equal(hasUserNamespacedAotHooks(content, 'SessionStart'), false);
+  });
+
+  test('returns false when only single-bracket [hooks.SessionStart] exists', () => {
+    const content = [
+      '[hooks.SessionStart]',
+      'command = "x"',
+      '',
+    ].join('\n');
+    assert.equal(hasUserNamespacedAotHooks(content, 'SessionStart'), false);
+  });
+});
+
+// concurrency: false — these tests monkey-patch fs.writeFileSync, a global
+// shared with every other suite running in parallel. Serializing prevents
+// stray writes from sibling tests landing in the stub.
+describe('#2760 fix 4 — Write-failure rollback (atomic write + snapshot restore)', { concurrency: false }, () => {
+  let tmpDir;
+  let codexHome;
+  let originalWriteFileSync;
+  // #2760 CR5 finding 5 — symmetric snapshot/restore for fs.renameSync. The
+  // first test below monkey-patches renameSync; without a beforeEach/afterEach
+  // pair, only the local `finally` restores it, which is fragile to future
+  // edits that add early-return paths.
+  let originalRenameSync;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2760-f4-'));
+    codexHome = path.join(tmpDir, 'codex-home');
+    originalWriteFileSync = fs.writeFileSync;
+    originalRenameSync = fs.renameSync;
+  });
+
+  afterEach(() => {
+    fs.renameSync = originalRenameSync;
+    fs.writeFileSync = originalWriteFileSync;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('pre-install config bytes survive when fs.renameSync throws over configPath', () => {
+    const preInstall = [
+      '# user file',
+      '[model]',
+      'name = "o3"',
+      '',
+    ].join('\n');
+    writeCodexConfig(codexHome, preInstall);
+
+    // After fs is restored we'll re-read the file. Capture the byte buffer
+    // exactly so the comparison is bit-for-bit.
+    const preInstallBytes = fs.readFileSync(path.join(codexHome, 'config.toml'));
+
+    const configPath = path.join(codexHome, 'config.toml');
+    const tempPattern = new RegExp('^' + configPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\.tmp-');
+
+    // Stub: allow writes to atomic temp files (which renameSync overwrites
+    // the target, never truncating it directly) but throw on any direct
+    // write to the canonical configPath. This simulates either:
+    //   (a) an older code path doing a non-atomic write, or
+    //   (b) a downstream module bypassing atomicWriteFileSync.
+    // Either way the snapshot must be restored. We let the temp write go
+    // through, then make renameSync throw to simulate the partial write
+    // never landing.
+    // #2760 CR5 finding 5 — fs.renameSync is restored by the suite-level
+    // afterEach; no local finally needed.
+    fs.renameSync = (src, dst) => {
+      if (dst === configPath) {
+        throw new Error('simulated rename failure mid-install');
+      }
+      return originalRenameSync(src, dst);
+    };
+
+    let threw = false;
+    let thrownErr = null;
+    try {
+      runCodexInstall(codexHome);
+    } catch (e) {
+      threw = true;
+      thrownErr = e;
+      assert.ok(/rename failure|simulated|post-write/.test(e.message),
+        'thrown error must surface the simulated failure or its post-write wrapper: ' + e.message);
+    }
+    // #2760 CR5 finding 4 — tighten contract per finding #1: ALL pre-write
+    // and write failures must be fatal. This test previously accepted either
+    // throw OR warn — sibling tests already require throw, so lock parity.
+    assert.equal(threw, true, 'rename failure must be fatal: ' + (thrownErr && thrownErr.message));
+
+    const afterBytes = fs.readFileSync(path.join(codexHome, 'config.toml'));
+    assert.deepStrictEqual(
+      afterBytes,
+      preInstallBytes,
+      'pre-install config.toml bytes must survive a mid-install write/rename failure'
+    );
+
+    // And the parsed structure of the surviving file must still be the
+    // user's [model] section, not a half-written GSD block.
+    const parsed = parseTomlToObject(afterBytes.toString('utf8'));
+    assert.equal(parsed.model && parsed.model.name, 'o3',
+      'surviving file must still be the user pre-install content');
+    assert.equal(parsed.agents, undefined,
+      'no GSD agents block may have leaked into the surviving file');
+
+    // No stray .tmp-* siblings left behind in the codex home.
+    const stray = fs.readdirSync(codexHome).filter((f) => tempPattern.test(path.join(codexHome, f)));
+    assert.equal(stray.length, 0,
+      'atomic write must clean up its temp file on failure: ' + stray.join(', '));
+  });
+
+  test('pre-install config bytes survive when fs.writeFileSync throws on the .tmp- target', () => {
+    const preInstall = [
+      '# user file',
+      '[model]',
+      'name = "o3"',
+      '',
+    ].join('\n');
+    writeCodexConfig(codexHome, preInstall);
+
+    const preInstallBytes = fs.readFileSync(path.join(codexHome, 'config.toml'));
+    const configPath = path.join(codexHome, 'config.toml');
+    const tempPattern = new RegExp('^' + configPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\.tmp-');
+
+    // Stub: fault writes targeting the atomic temp file (the pre-rename branch
+    // of atomicWriteFileSync). Other writes (agent .toml files in CODEX_HOME)
+    // pass through. This exercises the failure path where the temp write itself
+    // throws, not the rename — the case the prior test left untested.
+    // #2760 CR5 finding 5 — fs.writeFileSync is restored by the suite-level
+    // afterEach (via originalWriteFileSync); no local finally needed.
+    const captured = originalWriteFileSync;
+    fs.writeFileSync = function patchedWriteFileSync(target, data, options) {
+      if (typeof target === 'string' && tempPattern.test(target)) {
+        throw new Error('simulated writeFileSync failure on .tmp- target');
+      }
+      return captured.call(this, target, data, options);
+    };
+
+    let threw = false;
+    try {
+      runCodexInstall(codexHome);
+    } catch (e) {
+      threw = true;
+      assert.ok(/simulated writeFileSync failure|post-write Codex install failed|pre-write/.test(e.message),
+        'thrown error must surface the simulated failure or its post-write wrapper: ' + e.message);
+    }
+    // Per #2760 CR4 finding 1 / CR5 finding 1, write failures must abort install (not warn).
+    assert.equal(threw, true, 'install must throw when atomic temp-write fails');
+
+    const afterBytes = fs.readFileSync(path.join(codexHome, 'config.toml'));
+    assert.deepStrictEqual(
+      afterBytes,
+      preInstallBytes,
+      'pre-install config.toml bytes must survive a temp-write failure'
+    );
+
+    const parsed = parseTomlToObject(afterBytes.toString('utf8'));
+    assert.equal(parsed.model && parsed.model.name, 'o3',
+      'surviving file must still be the user pre-install content');
+    assert.equal(parsed.agents, undefined,
+      'no GSD agents block may have leaked into the surviving file');
+
+    const stray = fs.readdirSync(codexHome).filter((f) => tempPattern.test(path.join(codexHome, f)));
+    assert.equal(stray.length, 0,
+      'atomic write must clean up its temp file on failure: ' + stray.join(', '));
+  });
+});
+
+// concurrency: false — these tests rely on the same install path and module-
+// level pre-install snapshot that the fix-3/fix-4 suites exercise. Serializing
+// keeps state mutations from leaking across parallel siblings.
+describe('#2760 CR4 finding 2 — Legacy flat [[hooks]] block migrates to namespaced AoT on reinstall', { concurrency: false }, () => {
+  let tmpDir;
+  let codexHome;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2760-cr4-f2-'));
+    codexHome = path.join(tmpDir, 'codex-home');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('pre-install legacy flat [[hooks]] gsd-check-update + user namespaced [[hooks.SessionStart]] → post-install converges on namespaced AoT', () => {
+    // Reproduce the upgrade scenario:
+    //   - User has [[hooks.SessionStart]] entry of their own (signal that GSD
+    //     should emit in the namespaced shape).
+    //   - A previous GSD install left the legacy flat [[hooks]] managed block
+    //     for gsd-check-update. The pre-CR4 strip step would short-circuit
+    //     the namespaced emit and leave the user stuck in the mixed layout.
+    const userPlusLegacy = [
+      '[[hooks.SessionStart]]',
+      'command = "echo user hook"',
+      '',
+      '# GSD Hooks',
+      '[[hooks]]',
+      'event = "SessionStart"',
+      'command = "node /old/path/hooks/gsd-check-update.js"',
+      '',
+    ].join('\n');
+    writeCodexConfig(codexHome, userPlusLegacy);
+
+    runCodexInstall(codexHome);
+    const afterInstall = readCodexConfig(codexHome);
+    const parsed = parseTomlToObject(afterInstall);
+
+    // After CR4 finding 2: the legacy flat [[hooks]] managed block is stripped
+    // and the GSD entry is re-emitted in the namespaced AoT shape so the two
+    // forms do not coexist.
+    assert.ok(
+      parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
+      'hooks.SessionStart must be an array-of-tables, got: '
+        + (parsed.hooks ? typeof parsed.hooks.SessionStart : 'no hooks table')
+    );
+
+    const namespacedCommands = parsed.hooks.SessionStart.map((entry) => entry.command);
+    assert.ok(
+      namespacedCommands.includes('echo user hook'),
+      'user [[hooks.SessionStart]] entry preserved: ' + JSON.stringify(namespacedCommands)
+    );
+    assert.ok(
+      namespacedCommands.some((cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)),
+      'GSD entry must appear in hooks.SessionStart array (namespaced AoT form): '
+        + JSON.stringify(namespacedCommands)
+    );
+
+    // The legacy top-level [[hooks]] AoT must NOT coexist with the namespaced
+    // form after migration. parseTomlToObject distinguishes via Array.isArray.
+    assert.ok(
+      !Array.isArray(parsed.hooks) || parsed.hooks.length === 0,
+      'no top-level [[hooks]] AoT entries may remain after legacy migration: '
+        + JSON.stringify(parsed.hooks)
+    );
+
+    // No duplicate gsd-check-update entries — exactly one managed entry.
+    const gsdEntries = namespacedCommands.filter(
+      (cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)
+    );
+    assert.equal(gsdEntries.length, 1,
+      'exactly one gsd-check-update entry after migration, got: ' + gsdEntries.length);
+  });
+});
+
+describe('#2760 CR4 finding 3 — parseTomlToObject rejects malformed input that previously slipped through', () => {
+  test('rejects float values (timeout = 0.5)', () => {
+    const content = [
+      '[server]',
+      'timeout = 0.5',
+      '',
+    ].join('\n');
+    assert.throws(
+      () => parseTomlToObject(content),
+      /unsupported TOML value|trailing bytes/,
+      'float values must be rejected, not silently truncated to int prefix'
+    );
+  });
+
+  test('rejects date values (created = 1979-05-27)', () => {
+    const content = [
+      '[meta]',
+      'created = 1979-05-27',
+      '',
+    ].join('\n');
+    assert.throws(
+      () => parseTomlToObject(content),
+      /unsupported TOML value|trailing bytes/,
+      'date values must be rejected, not silently truncated'
+    );
+  });
+
+  test('rejects trailing garbage after a string value (key = "x" junk)', () => {
+    const content = [
+      '[section]',
+      'key = "x" junk',
+      '',
+    ].join('\n');
+    assert.throws(
+      () => parseTomlToObject(content),
+      /trailing bytes/,
+      'trailing bytes after a complete value must be rejected'
+    );
+  });
+
+  test('accepts trailing whitespace and # comment after a value', () => {
+    const content = [
+      '[section]',
+      'key = "x"   # an inline comment',
+      'flag = true',
+      'count = 7   ',
+      '',
+    ].join('\n');
+    const parsed = parseTomlToObject(content);
+    assert.equal(parsed.section.key, 'x');
+    assert.equal(parsed.section.flag, true);
+    assert.equal(parsed.section.count, 7);
+  });
+});
+
+// concurrency: false — see the fix-3 suite above for the same rationale.
+describe('#2760 CR4 finding 1 — atomicWriteFileSync failure aborts install (post-write fatal)', { concurrency: false }, () => {
+  let tmpDir;
+  let codexHome;
+  let originalRenameSync;
+  let originalConsoleLog;
+  let consoleOutput;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2760-cr4-f1-'));
+    codexHome = path.join(tmpDir, 'codex-home');
+    originalRenameSync = fs.renameSync;
+    originalConsoleLog = console.log;
+    consoleOutput = [];
+    console.log = (...args) => { consoleOutput.push(args.join(' ')); };
+  });
+
+  afterEach(() => {
+    fs.renameSync = originalRenameSync;
+    console.log = originalConsoleLog;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('install throws and never prints "Done!" when atomicWriteFileSync fails on configPath', () => {
+    const preInstall = [
+      '# user file',
+      '[model]',
+      'name = "o3"',
+      '',
+    ].join('\n');
+    writeCodexConfig(codexHome, preInstall);
+
+    const configPath = path.join(codexHome, 'config.toml');
+    // Only fault the hook-block atomic rename — earlier writes to config.toml
+    // happen via mergeCodexConfig (agent-block emit). We want to exercise the
+    // post-write Codex install branch specifically. Detect by reading the temp
+    // file's contents and only faulting when the hook block is present.
+    fs.renameSync = (src, dst) => {
+      if (dst === configPath) {
+        let isHookWrite = false;
+        try {
+          const data = fs.readFileSync(src, 'utf8');
+          isHookWrite = /gsd-check-update\.js/.test(data);
+        } catch (_) { /* ignore */ }
+        if (isHookWrite) {
+          throw new Error('simulated rename failure');
+        }
+      }
+      return originalRenameSync(src, dst);
+    };
+
+    let threw = false;
+    let thrownMessage = '';
+    try {
+      runCodexInstall(codexHome);
+    } catch (e) {
+      threw = true;
+      thrownMessage = e.message;
+    }
+
+    assert.equal(threw, true, 'install must throw when atomic write fails');
+    assert.match(
+      thrownMessage,
+      /post-write Codex install failed/,
+      'thrown error must use the post-write prefix so the outer catch treats it as fatal'
+    );
+
+    // Critical: install must NOT have printed any "Done!" success banner.
+    const printedDone = consoleOutput.some(
+      (line) => typeof line === 'string' && /Done!/i.test(line)
+    );
+    assert.equal(printedDone, false,
+      'install must NOT print "Done!" after a write failure: ' + JSON.stringify(consoleOutput.filter((l) => /Done|✓/.test(l))));
+
+    // And the user's pre-install bytes are intact (snapshot restore).
+    const after = fs.readFileSync(configPath, 'utf8');
+    assert.equal(after, preInstall, 'pre-install bytes preserved after fatal abort');
+  });
+});
+
+// concurrency: false — patches module.exports.__codexSchemaValidator, a
+// shared test seam. Serializing prevents stray patches from sibling tests.
+describe('#2760 CR5 finding 1 — pre-write failures abort install (outer catch fatal)', { concurrency: false }, () => {
+  let tmpDir;
+  let codexHome;
+  let originalConsoleLog;
+  let consoleOutput;
+  const installModule = require('../bin/install.js');
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2760-cr5-f1-'));
+    codexHome = path.join(tmpDir, 'codex-home');
+    originalConsoleLog = console.log;
+    consoleOutput = [];
+    console.log = (...args) => { consoleOutput.push(args.join(' ')); };
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    delete installModule.__codexSchemaValidator;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('pre-write throw (validator throws, not returns {ok:false}) is fatal and restores snapshot', () => {
+    // A validator that THROWS (vs returning {ok:false}) bypasses the
+    // validation branch and exits the inner try via the catch at the outer
+    // level. Pre-CR5, that catch downgraded to console.warn and let the
+    // install print "Done!" with no Codex hooks. Post-CR5 it must rethrow.
+    const preInstall = [
+      '# user file',
+      '[model]',
+      'name = "o3"',
+      '',
+    ].join('\n');
+    writeCodexConfig(codexHome, preInstall);
+
+    installModule.__codexSchemaValidator = () => {
+      throw new Error('synthetic validator-throw simulating a pre-write helper failure');
+    };
+
+    let threw = false;
+    let thrownMsg = '';
+    try {
+      runCodexInstall(codexHome);
+    } catch (e) {
+      threw = true;
+      thrownMsg = e.message;
+    }
+
+    assert.equal(threw, true,
+      'install must rethrow when a pre-write step throws (CR5 finding 1)');
+    assert.match(thrownMsg, /pre-write|synthetic validator-throw/,
+      'thrown error must surface the pre-write wrapper or original message: ' + thrownMsg);
+
+    const printedDone = consoleOutput.some(
+      (line) => typeof line === 'string' && /Done!/i.test(line)
+    );
+    assert.equal(printedDone, false,
+      'install must NOT print "Done!" after a pre-write failure: ' +
+      JSON.stringify(consoleOutput.filter((l) => /Done|✓/.test(l))));
+
+    // Pre-install bytes intact (snapshot restored).
+    const after = fs.readFileSync(path.join(codexHome, 'config.toml'), 'utf8');
+    assert.equal(after, preInstall,
+      'pre-install bytes must survive a pre-write helper throw');
+  });
+});
+
+describe('#2760 CR5 finding 2 — parseTomlToObject rejects duplicate keys and shape-mismatched headers', () => {
+  test('rejects duplicate scalar key in same table ([a]\\nx=1\\nx=2)', () => {
+    const content = [
+      '[a]',
+      'x = 1',
+      'x = 2',
+      '',
+    ].join('\n');
+    assert.throws(
+      () => parseTomlToObject(content),
+      /duplicate key/,
+      'real TOML 1.0 rejects duplicate keys in the same table'
+    );
+  });
+
+  test('rejects duplicate scalar key in root table', () => {
+    const content = [
+      'x = 1',
+      'x = 2',
+      '',
+    ].join('\n');
+    assert.throws(
+      () => parseTomlToObject(content),
+      /duplicate key/,
+      'duplicate root-table keys must be rejected'
+    );
+  });
+
+  test('rejects re-declared [a] table header ([a] then [a] again)', () => {
+    const content = [
+      '[a]',
+      'x = 1',
+      '',
+      '[a]',
+      'y = 2',
+      '',
+    ].join('\n');
+    assert.throws(
+      () => parseTomlToObject(content),
+      /duplicate or shape-mismatched table header/,
+      'real TOML 1.0 rejects re-declaring the same [a] header twice'
+    );
+  });
+
+  test('rejects [[arr]] then [arr] for same path (array-of-tables → table)', () => {
+    const content = [
+      '[[arr]]',
+      'x = 1',
+      '',
+      '[arr]',
+      'y = 2',
+      '',
+    ].join('\n');
+    assert.throws(
+      () => parseTomlToObject(content),
+      /duplicate or shape-mismatched table header/,
+      'cannot redeclare an array-of-tables path as a plain table'
+    );
+  });
+
+  test('accepts repeated [[arr]] (genuine array-of-tables)', () => {
+    const content = [
+      '[[arr]]',
+      'x = 1',
+      '',
+      '[[arr]]',
+      'x = 2',
+      '',
+    ].join('\n');
+    const parsed = parseTomlToObject(content);
+    assert.ok(Array.isArray(parsed.arr));
+    assert.strictEqual(parsed.arr.length, 2);
+    assert.strictEqual(parsed.arr[0].x, 1);
+    assert.strictEqual(parsed.arr[1].x, 2);
+  });
+
+  test('accepts disjoint nested headers (not duplicates)', () => {
+    const content = [
+      '[a.b]',
+      'x = 1',
+      '',
+      '[a.c]',
+      'y = 2',
+      '',
+    ].join('\n');
+    const parsed = parseTomlToObject(content);
+    assert.strictEqual(parsed.a.b.x, 1);
+    assert.strictEqual(parsed.a.c.y, 2);
+  });
+});
+
+// concurrency: false — drives the same install pipeline as the other f-suites.
+describe('#2760 CR5 finding 3 — migration emits namespaced AoT (no flat/namespaced mixing)', { concurrency: false }, () => {
+  let tmpDir;
+  let codexHome;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2760-cr5-f3-'));
+    codexHome = path.join(tmpDir, 'codex-home');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('user has [[hooks.AfterTool]] AND legacy [hooks.SessionStart] → post-install both namespaced, no flat AoT', () => {
+    // Reproduces the mixed-form scenario from finding 3:
+    //  - User pre-config has both a namespaced AoT entry [[hooks.AfterTool]]
+    //    AND a legacy single-bracket [hooks.SessionStart].
+    //  - Pre-CR5 migration converts the legacy section to flat [[hooks]]
+    //    with event="SessionStart", leaving a mixed flat+namespaced layout.
+    //  - Post-CR5 migration emits [[hooks.SessionStart]] directly so both
+    //    of the user's hooks coexist in the namespaced shape, and the
+    //    GSD-managed entry converges on namespaced too.
+    const userPlusLegacy = [
+      '[[hooks.AfterTool]]',
+      'command = "x"',
+      '',
+      '[hooks.SessionStart]',
+      'command = "y"',
+      '',
+    ].join('\n');
+    writeCodexConfig(codexHome, userPlusLegacy);
+
+    runCodexInstall(codexHome);
+    const after = readCodexConfig(codexHome);
+    const parsed = parseTomlToObject(after);
+
+    // The pre-existing [[hooks.AfterTool]] entry is preserved.
+    assert.ok(
+      parsed.hooks && Array.isArray(parsed.hooks.AfterTool),
+      'pre-existing [[hooks.AfterTool]] must remain a namespaced AoT array'
+    );
+    assert.ok(
+      parsed.hooks.AfterTool.some((entry) => entry.command === 'x'),
+      'user AfterTool entry must be preserved: ' + JSON.stringify(parsed.hooks.AfterTool)
+    );
+
+    // The migrated SessionStart entry is now namespaced AoT, not flat
+    // [[hooks]] with event="SessionStart".
+    assert.ok(
+      parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
+      'migrated SessionStart must be namespaced AoT (not flat [[hooks]])'
+    );
+    const ssCommands = parsed.hooks.SessionStart.map((e) => e.command);
+    assert.ok(
+      ssCommands.includes('y'),
+      'user SessionStart command "y" must be preserved in namespaced array: ' +
+        JSON.stringify(ssCommands)
+    );
+    // GSD's managed gsd-check-update entry also lives in the namespaced array.
+    assert.ok(
+      ssCommands.some((cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)),
+      'managed gsd-check-update entry must appear in hooks.SessionStart array: ' +
+        JSON.stringify(ssCommands)
+    );
+
+    // No flat top-level [[hooks]] AoT may remain.
+    assert.ok(
+      !Array.isArray(parsed.hooks) || parsed.hooks.length === 0,
+      'no flat top-level [[hooks]] AoT entries may remain after migration: ' +
+        JSON.stringify(parsed.hooks)
+    );
+
+    // No synthetic event field on the migrated SessionStart entries — the
+    // namespace IS the event.
+    for (const entry of parsed.hooks.SessionStart) {
+      assert.equal(entry.event, undefined,
+        'no synthetic event field — namespace [[hooks.SessionStart]] encodes the event: ' +
+          JSON.stringify(entry));
+    }
+  });
+});

--- a/tests/bug-2760-codex-install-defensive.test.cjs
+++ b/tests/bug-2760-codex-install-defensive.test.cjs
@@ -90,12 +90,59 @@ describe('#2760 defect 3 — Hooks AoT preservation across install/uninstall/rei
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('preserves both pre-existing [[hooks.SessionStart]] entries and adds GSD entry in namespaced form', () => {
+  test('fresh install emits the two-level nested AoT schema (#2773)', () => {
+    // Codex 0.124.0+ requires [[hooks.SessionStart]] + [[hooks.SessionStart.hooks]]
+    // with type = "command". Neither the flat [[hooks]] + event field form nor
+    // the single-block [[hooks.SessionStart]] form without .hooks is accepted.
+    writeCodexConfig(codexHome, '');
+    runCodexInstall(codexHome);
+    const content = readCodexConfig(codexHome);
+    const parsed = parseTomlToObject(content);
+
+    // hooks must be an object (namespaced), NOT a flat array.
+    assert.ok(
+      parsed.hooks && !Array.isArray(parsed.hooks) && typeof parsed.hooks === 'object',
+      'hooks must be a namespaced object, not a flat array: got ' + JSON.stringify(parsed.hooks)
+    );
+    // hooks.SessionStart must be an array-of-tables.
+    assert.ok(
+      Array.isArray(parsed.hooks.SessionStart),
+      'hooks.SessionStart must be array-of-tables: got ' + typeof parsed.hooks.SessionStart
+    );
+    // Each event entry must have a .hooks sub-array.
+    const eventEntry = parsed.hooks.SessionStart[0];
+    assert.ok(
+      eventEntry && Array.isArray(eventEntry.hooks),
+      'hooks.SessionStart[0].hooks must be an array of handlers: got ' + JSON.stringify(eventEntry)
+    );
+    // The handler must have type = "command" and reference gsd-check-update.js.
+    const handler = eventEntry.hooks[0];
+    assert.strictEqual(handler.type, 'command', 'handler type must be "command"');
+    assert.ok(
+      typeof handler.command === 'string' && /gsd-check-update\.js/.test(handler.command),
+      'handler command must reference gsd-check-update.js: got ' + handler.command
+    );
+    // No flat [[hooks]] entries must exist alongside the namespaced form.
+    assert.ok(
+      !Array.isArray(parsed.hooks),
+      'flat [[hooks]] AoT must not coexist with namespaced [[hooks.SessionStart]]'
+    );
+  });
+
+  test('preserves user [[hooks.SessionStart]] entries and adds GSD nested handler', () => {
+    // Users may have their own [[hooks.SessionStart]] entries using the new schema.
+    // GSD must append its own two-level block without disturbing theirs.
     const userConfig = [
       '[[hooks.SessionStart]]',
+      '',
+      '[[hooks.SessionStart.hooks]]',
+      'type = "command"',
       'command = "echo first user hook"',
       '',
       '[[hooks.SessionStart]]',
+      '',
+      '[[hooks.SessionStart.hooks]]',
+      'type = "command"',
       'command = "echo second user hook"',
       '',
     ].join('\n');
@@ -105,58 +152,110 @@ describe('#2760 defect 3 — Hooks AoT preservation across install/uninstall/rei
     const afterInstall = readCodexConfig(codexHome);
     const parsed = parseTomlToObject(afterInstall);
 
-    // hooks.SessionStart must be an array-of-tables (namespaced AoT form).
     assert.ok(
       parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
-      'hooks.SessionStart must be an array-of-tables, got: '
-        + (parsed.hooks ? typeof parsed.hooks.SessionStart : 'no hooks table')
+      'hooks.SessionStart must remain an array-of-tables after install'
     );
 
-    const commands = parsed.hooks.SessionStart.map((entry) => entry.command);
-
-    // Both pre-existing user hook entries survive in the parsed structure.
-    assert.ok(
-      commands.includes('echo first user hook'),
-      'first user [[hooks.SessionStart]] entry preserved in parsed structure: ' + JSON.stringify(commands)
-    );
-    assert.ok(
-      commands.includes('echo second user hook'),
-      'second user [[hooks.SessionStart]] entry preserved in parsed structure: ' + JSON.stringify(commands)
+    // Collect all handler commands across all event entries.
+    const allCommands = parsed.hooks.SessionStart.flatMap((entry) =>
+      Array.isArray(entry.hooks) ? entry.hooks.map((h) => h.command) : []
     );
 
-    // GSD's managed entry is emitted in the same namespaced AoT shape so it
-    // does not collide with the user's preferred form.
     assert.ok(
-      commands.some((cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)),
-      'GSD entry must appear in hooks.SessionStart array (not top-level [[hooks]]): '
-        + JSON.stringify(commands)
+      allCommands.includes('echo first user hook'),
+      'first user hook preserved: ' + JSON.stringify(allCommands)
     );
-
-    // Top-level [[hooks]] AoT must not coexist when namespaced form is in use —
-    // mixing forms is what produces the round-trip break this fix prevents.
     assert.ok(
-      !Array.isArray(parsed.hooks) || parsed.hooks.length === 0,
-      'no top-level [[hooks]] AoT entries when namespaced form is in use'
+      allCommands.includes('echo second user hook'),
+      'second user hook preserved: ' + JSON.stringify(allCommands)
     );
+    assert.ok(
+      allCommands.some((cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)),
+      'GSD handler must appear in hooks.SessionStart[].hooks: ' + JSON.stringify(allCommands)
+    );
+    assert.ok(!Array.isArray(parsed.hooks), 'no flat [[hooks]] entries');
   });
 
-  test('selects top-level [[hooks]] form when user has no namespaced hooks (status-quo behavior)', () => {
-    writeCodexConfig(codexHome, '');
+  test('reinstall replaces flat [[hooks]] + event form with nested schema', () => {
+    // Upgrade path: user has a config written by GSD 1.38.x (flat [[hooks]] form).
+    const legacyConfig = [
+      '[features]',
+      'codex_hooks = true',
+      '',
+      '# GSD Hooks',
+      '[[hooks]]',
+      'event = "SessionStart"',
+      'command = "node /old/path/to/gsd-check-update.js"',
+      '',
+    ].join('\n');
+    writeCodexConfig(codexHome, legacyConfig);
+
     runCodexInstall(codexHome);
     const content = readCodexConfig(codexHome);
     const parsed = parseTomlToObject(content);
 
-    // Top-level hooks must be an array-of-tables; the GSD entry must be one
-    // of those tables and carry event = "SessionStart".
-    assert.ok(
-      Array.isArray(parsed.hooks),
-      'fresh install must produce top-level [[hooks]] AoT, got: ' + typeof parsed.hooks
+    // Old flat form must be gone.
+    assert.ok(!Array.isArray(parsed.hooks), 'flat [[hooks]] must be stripped on upgrade');
+    // New nested form must be present.
+    assert.ok(Array.isArray(parsed.hooks && parsed.hooks.SessionStart), 'new [[hooks.SessionStart]] must be present');
+    const handler = parsed.hooks.SessionStart[0].hooks[0];
+    assert.strictEqual(handler.type, 'command');
+    assert.ok(/gsd-check-update\.js/.test(handler.command));
+    // Only one GSD hook entry must exist (no duplication).
+    const sessionStart = parsed.hooks?.SessionStart ?? [];
+    const gsdHandlers = sessionStart.flatMap((entry) =>
+      Array.isArray(entry.hooks) ? entry.hooks : []
+    ).filter((h) => typeof h?.command === 'string' && /gsd-check-update\.js/.test(h.command));
+    assert.strictEqual(gsdHandlers.length, 1, 'exactly one managed handler after upgrade');
+  });
+
+  test('reinstall replaces single-block [[hooks.SessionStart]] (no .hooks sub-table) with nested schema', () => {
+    // Upgrade path: user has a config written by the PR #2802 shape —
+    // [[hooks.SessionStart]] without a nested [[hooks.SessionStart.hooks]] sub-table.
+    const prBranchConfig = [
+      '[features]',
+      'codex_hooks = true',
+      '',
+      '# GSD Hooks',
+      '[[hooks.SessionStart]]',
+      'command = "node /old/path/to/gsd-check-update.js"',
+      '',
+    ].join('\n');
+    writeCodexConfig(codexHome, prBranchConfig);
+
+    runCodexInstall(codexHome);
+    const content = readCodexConfig(codexHome);
+    const parsed = parseTomlToObject(content);
+
+    assert.ok(Array.isArray(parsed.hooks && parsed.hooks.SessionStart), '[[hooks.SessionStart]] must be present');
+    const eventEntry = parsed.hooks.SessionStart[0];
+    assert.ok(Array.isArray(eventEntry.hooks), '[[hooks.SessionStart.hooks]] sub-table must be present');
+    const handler = eventEntry.hooks[0];
+    assert.strictEqual(handler.type, 'command');
+    assert.ok(/gsd-check-update\.js/.test(handler.command));
+    const handlers = (parsed.hooks?.SessionStart ?? []).flatMap((entry) =>
+      Array.isArray(entry.hooks) ? entry.hooks : []
     );
-    assert.ok(
-      parsed.hooks.some((h) => h && h.event === 'SessionStart'),
-      'top-level [[hooks]] AoT must contain an entry with event = "SessionStart": '
-        + JSON.stringify(parsed.hooks)
+    assert.strictEqual(
+      handlers.filter((h) => typeof h?.command === 'string' && /gsd-check-update\.js/.test(h.command)).length,
+      1,
+      'exactly one managed handler after upgrade from PR-#2802-shape'
     );
+  });
+
+  test('reinstall is idempotent: correct nested schema is stripped and re-emitted cleanly', () => {
+    writeCodexConfig(codexHome, '');
+    runCodexInstall(codexHome);
+    runCodexInstall(codexHome); // second install
+    const content = readCodexConfig(codexHome);
+
+    const parsed = parseTomlToObject(content);
+    const sessionStart = parsed.hooks?.SessionStart ?? [];
+    assert.strictEqual(sessionStart.length, 1, 'exactly one SessionStart event entry after double install');
+    assert.ok(Array.isArray(sessionStart[0].hooks), 'SessionStart event has nested handlers array');
+    assert.strictEqual(sessionStart[0].hooks.length, 1, 'exactly one handler in SessionStart after double install');
+    assert.ok(/gsd-check-update\.js/.test(sessionStart[0].hooks[0].command), 'managed handler command preserved');
   });
 });
 
@@ -572,15 +671,25 @@ describe('#2760 CR4 finding 2 — Legacy flat [[hooks]] block migrates to namesp
         + (parsed.hooks ? typeof parsed.hooks.SessionStart : 'no hooks table')
     );
 
-    const namespacedCommands = parsed.hooks.SessionStart.map((entry) => entry.command);
+    // Migration now handles stale [[hooks.SessionStart]] entries with handler
+    // fields at event-entry level (pre-#2773 shape), promoting them to the
+    // two-level nested form. Every entry must carry a .hooks sub-array after
+    // migration, so collect from nested handlers only.
     assert.ok(
-      namespacedCommands.includes('echo user hook'),
-      'user [[hooks.SessionStart]] entry preserved: ' + JSON.stringify(namespacedCommands)
+      parsed.hooks.SessionStart.every((entry) => Array.isArray(entry.hooks)),
+      'every hooks.SessionStart entry must use nested [[hooks.SessionStart.hooks]] handlers after migration'
+    );
+    const allSessionStartCommands = parsed.hooks.SessionStart.flatMap((entry) =>
+      entry.hooks.map((h) => h.command).filter(Boolean)
     );
     assert.ok(
-      namespacedCommands.some((cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)),
+      allSessionStartCommands.includes('echo user hook'),
+      'user [[hooks.SessionStart]] entry preserved: ' + JSON.stringify(allSessionStartCommands)
+    );
+    assert.ok(
+      allSessionStartCommands.some((cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)),
       'GSD entry must appear in hooks.SessionStart array (namespaced AoT form): '
-        + JSON.stringify(namespacedCommands)
+        + JSON.stringify(allSessionStartCommands)
     );
 
     // The legacy top-level [[hooks]] AoT must NOT coexist with the namespaced
@@ -592,7 +701,7 @@ describe('#2760 CR4 finding 2 — Legacy flat [[hooks]] block migrates to namesp
     );
 
     // No duplicate gsd-check-update entries — exactly one managed entry.
-    const gsdEntries = namespacedCommands.filter(
+    const gsdEntries = allSessionStartCommands.filter(
       (cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)
     );
     assert.equal(gsdEntries.length, 1,
@@ -936,18 +1045,35 @@ describe('#2760 CR5 finding 3 — migration emits namespaced AoT (no flat/namesp
       parsed.hooks && Array.isArray(parsed.hooks.AfterTool),
       'pre-existing [[hooks.AfterTool]] must remain a namespaced AoT array'
     );
+    // AfterTool was in [[hooks.AfterTool]] with command at event-entry level
+    // (pre-#2773 stale namespaced AoT shape). Migration now promotes these to
+    // the two-level nested form, so every entry must have a .hooks sub-array.
     assert.ok(
-      parsed.hooks.AfterTool.some((entry) => entry.command === 'x'),
-      'user AfterTool entry must be preserved: ' + JSON.stringify(parsed.hooks.AfterTool)
+      parsed.hooks.AfterTool.every((e) => Array.isArray(e.hooks)),
+      'every AfterTool entry must use nested [[hooks.AfterTool.hooks]] handlers after migration'
+    );
+    const afterToolCommands = parsed.hooks.AfterTool.flatMap((e) =>
+      e.hooks.map((h) => h.command).filter(Boolean)
+    );
+    assert.ok(
+      afterToolCommands.includes('x'),
+      'user AfterTool entry must be preserved: ' + JSON.stringify(afterToolCommands)
     );
 
-    // The migrated SessionStart entry is now namespaced AoT, not flat
-    // [[hooks]] with event="SessionStart".
+    // The migrated SessionStart entry is now namespaced AoT with nested .hooks sub-table.
     assert.ok(
       parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
       'migrated SessionStart must be namespaced AoT (not flat [[hooks]])'
     );
-    const ssCommands = parsed.hooks.SessionStart.map((e) => e.command);
+    // After migration, [hooks.SessionStart] map-format is promoted to nested AoT.
+    // Command lives in [[hooks.SessionStart.hooks]][0].command (nested schema).
+    assert.ok(
+      parsed.hooks.SessionStart.every((e) => Array.isArray(e.hooks)),
+      'every SessionStart entry must use nested [[hooks.SessionStart.hooks]] handlers after migration'
+    );
+    const ssCommands = parsed.hooks.SessionStart.flatMap((e) =>
+      e.hooks.map((h) => h.command).filter(Boolean)
+    );
     assert.ok(
       ssCommands.includes('y'),
       'user SessionStart command "y" must be preserved in namespaced array: ' +

--- a/tests/bug-2767-gsd-sdk-commit-files-flag.test.cjs
+++ b/tests/bug-2767-gsd-sdk-commit-files-flag.test.cjs
@@ -1,0 +1,302 @@
+/**
+ * Bug #2767: Workflows pass paths positionally to `gsd-sdk query commit`.
+ *
+ * Runtime behavior under the buggy form (paths positional, no `--files`):
+ *   1. positional path tokens are joined into the commit subject (commit.ts:110); and
+ *   2. `filePaths` is empty, so the handler falls back to staging `.planning/`
+ *      wholesale (commit.ts:136), silently swapping the user's intent.
+ *
+ * Under the well-formed form (`--files <path...>`):
+ *   - subject is the message arg only;
+ *   - exactly the listed files are staged;
+ *   - `commit-to-subrepo` rejects when `--files` is absent (commit.ts:258).
+ *
+ * Note: the supplementary doc-lint's `isWellFormed` accepts any invocation that
+ * has no positional path args after the message — i.e. message-only commits pass
+ * regardless of any trailing comment. There is no required marker (`# message-only`
+ * or otherwise); the absence of positional path tokens is the sole signal.
+ *
+ * Primary test: invoke the actual `gsd-sdk query commit[-to-subrepo]` binary
+ * against a real tmp git project and assert the runtime behavior. Supplementary
+ * test: a doc-lint that scans every shipped .md file to catch regressions of
+ * the 50-file invocation cleanup landed in this PR. The behavioral tests are
+ * the contract; the lint is a defense-in-depth guard.
+ */
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { createTempGitProject, cleanup } = require('./helpers.cjs');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SDK_CLI = path.join(REPO_ROOT, 'sdk', 'dist', 'cli.js');
+
+/**
+ * Run a git command with hardcoded argv (no shell). Returns trimmed stdout.
+ */
+function git(projectDir, args) {
+  return execFileSync('git', args, { cwd: projectDir, encoding: 'utf-8' }).trim();
+}
+
+/**
+ * Invoke `gsd-sdk query <subcommand> <...args>` against a project dir.
+ * Returns { exitCode, stdout, stderr, json } where json is the parsed handler
+ * payload (the SDK prints a single JSON object to stdout for query handlers).
+ */
+function runSdkQuery(subcommand, args, projectDir) {
+  const argv = ['query', subcommand, ...args, '--project-dir', projectDir];
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 0;
+  try {
+    stdout = execFileSync(process.execPath, [SDK_CLI, ...argv], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, GSD_SESSION_KEY: '' },
+    });
+  } catch (err) {
+    exitCode = err.status ?? 1;
+    stdout = err.stdout?.toString() ?? '';
+    stderr = err.stderr?.toString() ?? '';
+  }
+  // Extract the trailing JSON object — the CLI prints status lines before it.
+  let json = null;
+  const lastBrace = stdout.lastIndexOf('{');
+  if (lastBrace >= 0) {
+    try { json = JSON.parse(stdout.slice(lastBrace).trim()); } catch { /* leave null */ }
+    if (!json) {
+      try { json = JSON.parse(stdout.trim()); } catch { /* leave null */ }
+    }
+  }
+  return { exitCode, stdout, stderr, json };
+}
+
+function gitSubject(projectDir) {
+  return git(projectDir, ['log', '-1', '--pretty=%s']);
+}
+
+function gitFilesAt(projectDir) {
+  return git(projectDir, ['show', '--pretty=', '--name-only', 'HEAD'])
+    .split('\n').filter(Boolean).sort();
+}
+
+// ─── Behavioral SDK tests ────────────────────────────────────────────────────
+
+describe('bug #2767 (behavioral): gsd-sdk query commit --files', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject('gsd-2767-');
+    fs.writeFileSync(path.join(tmpDir, 'foo.md'), 'foo body\n');
+    fs.writeFileSync(path.join(tmpDir, 'bar.md'), 'bar body\n');
+    // .planning/ change that MUST NOT leak into the commit when --files is used.
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'state\n');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('well-formed: --files <paths> stages exactly those files with clean subject', () => {
+    const message = 'test(#2767): well-formed commit';
+    const result = runSdkQuery('commit', [message, '--files', 'foo.md', 'bar.md'], tmpDir);
+
+    assert.equal(result.exitCode, 0, `cli failed: ${result.stderr}`);
+    assert.ok(result.json, `expected JSON body in stdout, got:\n${result.stdout}`);
+    assert.equal(result.json.committed, true, `commit failed: ${JSON.stringify(result.json)}`);
+    assert.equal(result.json.message, message, 'subject must be message-only — no path leakage');
+    assert.deepEqual(result.json.files.slice().sort(), ['bar.md', 'foo.md']);
+
+    // Cross-check via git itself.
+    assert.equal(gitSubject(tmpDir), message);
+    assert.deepEqual(gitFilesAt(tmpDir), ['bar.md', 'foo.md']);
+    // The .planning/STATE.md change must remain unstaged/unrelated.
+    const stillDirty = git(tmpDir, ['status', '--porcelain']);
+    assert.ok(stillDirty.includes('.planning/STATE.md'),
+      `.planning/STATE.md should remain unstaged, got status:\n${stillDirty}`);
+  });
+
+  test('buggy form (positional, no --files): paths leak into subject AND .planning/ fallback fires', () => {
+    // Documents the misbehavior #2767 prevents at every workflow call site.
+    // Any future change that makes the buggy form silently "do the right thing"
+    // trips this test and must justify the change.
+    const message = 'test(#2767): positional buggy';
+    const result = runSdkQuery('commit', [message, 'foo.md', 'bar.md'], tmpDir);
+
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.json, `expected JSON body, got:\n${result.stdout}`);
+    assert.equal(result.json.committed, true);
+
+    // Subject got polluted with the path tokens.
+    assert.equal(result.json.message, `${message} foo.md bar.md`,
+      'paths leak into the commit subject under the buggy form (commit.ts:110)');
+    assert.equal(gitSubject(tmpDir), `${message} foo.md bar.md`);
+
+    // Fallback staged .planning/STATE.md, NOT foo.md/bar.md.
+    assert.deepEqual(gitFilesAt(tmpDir), ['.planning/STATE.md'],
+      'positional form triggers the .planning/ wholesale fallback (commit.ts:136)');
+    const dirty = git(tmpDir, ['status', '--porcelain']);
+    assert.ok(dirty.includes('foo.md') && dirty.includes('bar.md'),
+      `foo.md/bar.md should remain unstaged under the buggy form, got:\n${dirty}`);
+  });
+
+  test('positional form with no .planning/ change: returns "nothing staged"', () => {
+    // Reset the .planning/STATE.md change so the fallback has nothing to stage.
+    fs.rmSync(path.join(tmpDir, '.planning', 'STATE.md'), { force: true });
+
+    const result = runSdkQuery('commit', ['msg', 'foo.md'], tmpDir);
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.json, `expected JSON body, got:\n${result.stdout}`);
+    assert.equal(result.json.committed, false);
+    assert.equal(result.json.reason, 'nothing staged',
+      'positional form ignores foo.md and finds nothing under .planning/ to fall back to');
+  });
+});
+
+describe('bug #2767 (behavioral): commit-to-subrepo requires --files', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject('gsd-2767-sub-');
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ sub_repos: ['vendor/lib'] }, null, 2),
+    );
+    fs.mkdirSync(path.join(tmpDir, 'vendor', 'lib'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'vendor', 'lib', 'README.md'), 'sub\n');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('rejects with explicit error when --files is omitted', () => {
+    const result = runSdkQuery('commit-to-subrepo', ['only message, no files'], tmpDir);
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.json, `expected JSON body, got:\n${result.stdout}`);
+    assert.equal(result.json.committed, false);
+    assert.equal(result.json.reason, '--files required for commit-to-subrepo',
+      'commit-to-subrepo enforces --files at runtime (commit.ts:258)');
+  });
+});
+
+// ─── Supplementary doc-lint (defense-in-depth) ───────────────────────────────
+//
+// The behavioral tests above prove the SDK semantics. This lint scans every
+// shipped .md invocation to catch regressions in the 50-file workflow cleanup
+// landed by this PR — without it, a future contributor adding a new workflow
+// could reintroduce the positional form silently. allow-test-rule: doc-text
+// invocations cannot be exercised end-to-end (they are agent-prompt strings
+// rendered into chat, not invoked by gsd-tools.cjs), so a textual guard is
+// the only available enforcement layer.
+
+const SCAN_DIRS = ['agents', 'commands', 'get-shit-done', 'docs', 'scripts'];
+const KNOWN_FLAGS = new Set(['--force', '--amend', '--no-verify', '--files']);
+
+function walk(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+      walk(full, out);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function extractInvocations(filePath) {
+  const text = fs.readFileSync(filePath, 'utf-8');
+  const lines = text.split(/\r?\n/);
+  const invocations = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/(gsd-sdk\s+query\s+commit(?:-to-subrepo)?\b.*)$/);
+    if (!m) continue;
+    const tail = m[1].match(/^gsd-sdk\s+query\s+commit(?:-to-subrepo)?(.?)/);
+    if (tail && tail[1] === '`') continue;
+    let cmd = m[1];
+    let j = i;
+    while (cmd.endsWith('\\') && j + 1 < lines.length) {
+      cmd = cmd.slice(0, -1).trimEnd() + ' ' + lines[j + 1].trim();
+      j++;
+    }
+    invocations.push({ line: i + 1, cmd, file: filePath });
+  }
+  return invocations;
+}
+
+function stripTail(cmd) {
+  let inSingle = false, inDouble = false;
+  for (let i = 0; i < cmd.length; i++) {
+    const c = cmd[i];
+    if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (c === '"' && !inSingle) inDouble = !inDouble;
+    else if (!inSingle && !inDouble) {
+      if (c === '#' && (i === 0 || /\s/.test(cmd[i - 1]))) return cmd.slice(0, i);
+      if (c === '|' || c === ';' || c === '>' || c === '<') return cmd.slice(0, i);
+      if (c === '&' && cmd[i + 1] === '&') return cmd.slice(0, i);
+    }
+  }
+  return cmd;
+}
+
+function tokenize(cmd) {
+  const out = [];
+  let cur = '', inSingle = false, inDouble = false;
+  for (let i = 0; i < cmd.length; i++) {
+    const c = cmd[i];
+    if (c === "'" && !inDouble) { inSingle = !inSingle; cur += c; continue; }
+    if (c === '"' && !inSingle) { inDouble = !inDouble; cur += c; continue; }
+    if (/\s/.test(c) && !inSingle && !inDouble) {
+      if (cur) { out.push(cur); cur = ''; }
+      continue;
+    }
+    cur += c;
+  }
+  if (cur) out.push(cur);
+  return out;
+}
+
+function isWellFormed(cmd) {
+  const truncated = stripTail(cmd);
+  const parts = tokenize(truncated);
+  if (parts.length < 3) return true;
+  const args = parts.slice(3);
+  if (args.length === 0) return true;
+  if (args.includes('--files')) return true;
+  let sawMessage = false;
+  for (const tok of args) {
+    if (KNOWN_FLAGS.has(tok)) continue;
+    if (!sawMessage) { sawMessage = true; continue; }
+    return false;
+  }
+  return true;
+}
+
+describe('bug #2767 (supplementary doc-lint): no positional invocations in shipped .md', () => {
+  const allFiles = SCAN_DIRS.flatMap(d => walk(path.join(REPO_ROOT, d)));
+  const allInvocations = allFiles.flatMap(extractInvocations);
+
+  test('lint scanned at least one invocation (sanity)', () => {
+    assert.ok(allInvocations.length > 0, 'lint scanned 0 invocations — globs are wrong');
+  });
+
+  test('every gsd-sdk query commit invocation either uses --files or has no path args', () => {
+    const broken = allInvocations.filter(({ cmd }) => !isWellFormed(cmd));
+    if (broken.length > 0) {
+      const detail = broken.map(({ file, line, cmd }) => {
+        const rel = path.relative(REPO_ROOT, file);
+        return `  ${rel}:${line}\n    ${cmd}`;
+      }).join('\n');
+      assert.fail(
+        `${broken.length} \`gsd-sdk query commit\` invocation(s) pass paths positionally.\n` +
+        `The behavioral test above proves what goes wrong at runtime; this lint catches\n` +
+        `regressions in shipped workflow markdown.\n${detail}`
+      );
+    }
+  });
+});

--- a/tests/bug-2769-requirements-header-variants.test.cjs
+++ b/tests/bug-2769-requirements-header-variants.test.cjs
@@ -1,0 +1,117 @@
+/**
+ * Regression tests for issue #2769
+ *
+ * The Requirements header in ROADMAP.md phase blocks renders identically in
+ * markdown for three textually distinct forms:
+ *
+ *   **Requirements:**          colon INSIDE bold delimiters
+ *   **Requirements**:          colon OUTSIDE bold delimiters
+ *   **Requirements** :         space-then-colon outside bold
+ *
+ * Two parsers in the codebase used opposing strict regexes — one only
+ * matched the outside-colon form (init.cjs / init.ts), the other only the
+ * inside-colon form (phase.cjs `cmdPhaseComplete` REQUIREMENTS.md
+ * traceability sweep). Both must accept all three variants so phase
+ * metadata propagation is robust to authoring style.
+ *
+ * Tests for the init query side live in `tests/init.test.cjs` (parameterized
+ * over the three variants). This file exercises the inverse bug in
+ * `phase complete`: the REQUIREMENTS.md checkbox must flip when ROADMAP
+ * uses the outside-colon form, which previously was silently skipped.
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+describe('bug #2769: phase complete ticks REQUIREMENTS.md across header variants', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      ['---', 'current_phase: 1', 'status: executing', '---', '# State', ''].join('\n'),
+    );
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  const headerVariants = [
+    { name: 'colon inside bold (**Requirements:**)', header: '**Requirements:** REQ-001' },
+    { name: 'colon outside bold (**Requirements**:)', header: '**Requirements**: REQ-001' },
+    { name: 'space before colon (**Requirements** :)', header: '**Requirements** : REQ-001' },
+  ];
+
+  for (const variant of headerVariants) {
+    test(`flips REQ-001 checkbox in REQUIREMENTS.md when ROADMAP uses ${variant.name}`, () => {
+      const phasesDir = path.join(tmpDir, '.planning', 'phases', '01-foundation');
+      fs.mkdirSync(phasesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(phasesDir, '01-1-PLAN.md'),
+        ['---', 'phase: 1', 'plan: 1', '---', '# Plan 1', ''].join('\n'),
+      );
+      fs.writeFileSync(
+        path.join(phasesDir, '01-1-SUMMARY.md'),
+        ['---', 'status: complete', '---', '# Summary', 'Done.'].join('\n'),
+      );
+
+      const roadmap = [
+        '# Roadmap',
+        '',
+        '### Phase 1: Foundation',
+        '',
+        '**Goal:** Build core',
+        variant.header,
+        '**Plans:** 1 plans',
+        '',
+        'Plans:',
+        '- [x] 01-1-PLAN.md',
+        '',
+        '| Phase | Plans | Status | Completed |',
+        '|-------|-------|--------|-----------|',
+        '| 1. Foundation | 0/1 | Pending | - |',
+      ].join('\n');
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), roadmap);
+
+      const requirements = [
+        '# Requirements',
+        '',
+        '## Functional Requirements',
+        '',
+        '- [ ] **REQ-001**: Core data model',
+        '',
+        '## Traceability',
+        '',
+        '| REQ-ID | Phase | Status |',
+        '|--------|-------|--------|',
+        '| REQ-001 | 1 | Pending |',
+      ].join('\n');
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'REQUIREMENTS.md'), requirements);
+
+      const result = runGsdTools(['phase', 'complete', '1'], tmpDir);
+      assert.ok(result.success, `phase complete failed: ${result.error}`);
+
+      const updated = fs.readFileSync(
+        path.join(tmpDir, '.planning', 'REQUIREMENTS.md'),
+        'utf-8',
+      );
+      assert.match(
+        updated,
+        /-\s*\[x\]\s*\*\*REQ-001\*\*/,
+        `REQ-001 checkbox must be flipped to [x] when ROADMAP header is "${variant.header}". Got:\n${updated}`,
+      );
+      assert.match(
+        updated,
+        /\|\s*REQ-001\s*\|\s*1\s*\|\s*Complete\s*\|/,
+        `Traceability row for REQ-001 must be marked Complete. Got:\n${updated}`,
+      );
+    });
+  }
+});

--- a/tests/bug-2770-annotate-deps-int-coerce.test.cjs
+++ b/tests/bug-2770-annotate-deps-int-coerce.test.cjs
@@ -1,0 +1,200 @@
+'use strict';
+
+/**
+ * Regression — issue #2770
+ *
+ * `roadmap.annotate-dependencies` crashes with
+ * `TypeError: t.trim is not a function` when must_haves.truths contains a
+ * non-string scalar (e.g., a YAML int like `- 3` interpreted by an upstream
+ * parser as a number, or a kv-shaped item whose value is numeric).
+ *
+ * The original guard `if (typeof t !== 'string') continue` skipped silently —
+ * which avoids the crash but **drops the constraint from cross-cutting
+ * analysis**. The required behaviour is to **coerce, not skip**: a numeric
+ * scalar `3` must be surfaced as the string "3", and a kv-shaped truth like
+ * `{ title: "X", count: 3 }` must contribute its title to the analysis.
+ *
+ * The two literal cases called out in the issue title (bare-int `depends_on`
+ * values) are also exercised here as regression guards on the frontmatter
+ * parser to prove the dependency is preserved as a string and never dropped.
+ */
+
+const { test, describe, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+const { extractFrontmatter } = require('../get-shit-done/bin/lib/frontmatter.cjs');
+
+function makePlanProject(files = {}) {
+  const dir = createTempProject();
+  fs.writeFileSync(path.join(dir, '.planning', 'ROADMAP.md'), '');
+  fs.mkdirSync(path.join(dir, '.planning', 'phases', '01-foundation'), { recursive: true });
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf-8');
+  }
+  return dir;
+}
+
+const ROADMAP = [
+  '# Roadmap',
+  '',
+  '### Phase 1: Foundation',
+  '**Goal:** Set up project',
+  '**Plans:** 2 plans',
+  '',
+  'Plans:',
+  '- [ ] 01-01-PLAN.md — Set up DB',
+  '- [ ] 01-02-PLAN.md — Build API',
+  '',
+].join('\n');
+
+// PLAN where must_haves.truths includes a bare numeric scalar AND a kv-shaped
+// item whose value is numeric — both must be surfaced as cross-cutting
+// constraints when shared across plans, not silently dropped.
+const PLAN_NUMERIC_TRUTH = (wave, sharedTitle) => [
+  '---',
+  'phase: "1"',
+  `plan: "01-0${wave}"`,
+  'type: standard',
+  `wave: ${wave}`,
+  'depends_on: []',
+  'files_modified: []',
+  'autonomous: true',
+  'must_haves:',
+  '  truths:',
+  `    - title: ${sharedTitle}`,
+  '      count: 3',
+  '    - 42',
+  '  artifacts: []',
+  '  key_links: []',
+  '---',
+  '',
+  `<objective>Plan ${wave}</objective>`,
+  '',
+].join('\n');
+
+describe('bug #2770 — non-string truths must be coerced, not dropped', () => {
+  let tmpDir;
+  afterEach(() => cleanup(tmpDir));
+
+  test('numeric scalar truth shared across 2+ plans is surfaced as cross-cutting constraint', () => {
+    // Both plans share the numeric truth `42`. Pre-fix: silently dropped by
+    // `typeof t !== 'string' continue`, so cross_cutting_constraints == 0.
+    // Post-fix: coerced to "42" and surfaced as a constraint.
+    const PLAN_BARE_INT_TRUTH = (wave) => [
+      '---',
+      'phase: "1"',
+      `plan: "01-0${wave}"`,
+      'type: standard',
+      `wave: ${wave}`,
+      'depends_on: []',
+      'files_modified: []',
+      'autonomous: true',
+      'must_haves:',
+      '  truths:',
+      '    - 42',
+      '  artifacts: []',
+      '  key_links: []',
+      '---',
+      '',
+      `<objective>Plan ${wave}</objective>`,
+      '',
+    ].join('\n');
+    tmpDir = makePlanProject({
+      '.planning/ROADMAP.md': ROADMAP,
+      '.planning/phases/01-foundation/01-01-PLAN.md': PLAN_BARE_INT_TRUTH(1),
+      '.planning/phases/01-foundation/01-02-PLAN.md': PLAN_BARE_INT_TRUTH(2),
+    });
+
+    const result = runGsdTools('roadmap annotate-dependencies 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const out = JSON.parse(result.output);
+    assert.strictEqual(
+      out.cross_cutting_constraints,
+      1,
+      'numeric truth shared across plans must be surfaced (coerced), not dropped'
+    );
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.ok(roadmap.includes('Cross-cutting constraints:'),
+      'cross-cutting subsection present');
+    assert.ok(/-\s*42\b/.test(roadmap),
+      'numeric truth "42" surfaced as a string in the roadmap');
+  });
+
+  test('kv-shaped truth with numeric value uses title and contributes to cross-cutting analysis', () => {
+    // Both plans share `{ title: 'shared-rule', count: 3 }`. Pre-fix:
+    // typeof === 'object' so silently skipped → constraint dropped.
+    // Post-fix: title extracted, surfaced in cross-cutting subsection.
+    tmpDir = makePlanProject({
+      '.planning/ROADMAP.md': ROADMAP,
+      '.planning/phases/01-foundation/01-01-PLAN.md': PLAN_NUMERIC_TRUTH(1, 'shared-rule'),
+      '.planning/phases/01-foundation/01-02-PLAN.md': PLAN_NUMERIC_TRUTH(2, 'shared-rule'),
+    });
+
+    const result = runGsdTools('roadmap annotate-dependencies 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const out = JSON.parse(result.output);
+    // Both plans share two truths: the kv-shaped { title: 'shared-rule', ... }
+    // and the bare numeric 42. Pre-fix neither would survive the typeof guard;
+    // post-fix both are coerced and surfaced.
+    assert.strictEqual(
+      out.cross_cutting_constraints,
+      2,
+      'kv-shaped truth and numeric truth both surface, not dropped'
+    );
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.ok(roadmap.includes('shared-rule'),
+      'title from kv-shaped truth surfaced in cross-cutting list');
+    assert.ok(/-\s*42\b/.test(roadmap),
+      'numeric truth surfaced as a string');
+  });
+});
+
+describe('bug #2770 — bare-int depends_on values parse as preserved strings', () => {
+  test('scalar bare-int depends_on parses as string "3" (not dropped, not numeric)', () => {
+    // Per issue title: a YAML scalar `depends_on: 3` must be preserved as the
+    // string "3". The frontmatter parser already returns strings here; this
+    // test pins the behaviour so a future "convert YAML scalars to numbers"
+    // optimization cannot silently regress dependency tracking.
+    const fm = extractFrontmatter([
+      '---',
+      'phase: "1"',
+      'plan: "01"',
+      'depends_on: 3',
+      '---',
+      'body',
+      '',
+    ].join('\n'));
+    assert.strictEqual(typeof fm.depends_on, 'string',
+      'scalar depends_on must remain a string after parse');
+    assert.strictEqual(fm.depends_on, '3',
+      'bare int 3 must be preserved as the string "3"');
+  });
+
+  test('inline-array bare-int depends_on parses to ["3","4"] (preserved as strings)', () => {
+    const fm = extractFrontmatter([
+      '---',
+      'phase: "1"',
+      'plan: "01"',
+      'depends_on: [3, 4]',
+      '---',
+      'body',
+      '',
+    ].join('\n'));
+    assert.ok(Array.isArray(fm.depends_on),
+      'inline array depends_on must be an array');
+    assert.deepStrictEqual(fm.depends_on, ['3', '4'],
+      'bare ints in inline array must be preserved as strings — never dropped');
+    // Critical: assert *length* matches input. A naive `if (typeof !== string) continue`
+    // would silently drop entries; we must coerce, not skip.
+    assert.strictEqual(fm.depends_on.length, 2,
+      'no dependency may be silently dropped during coercion');
+  });
+});

--- a/tests/bug-2771-user-profile-manifest.test.cjs
+++ b/tests/bug-2771-user-profile-manifest.test.cjs
@@ -1,0 +1,219 @@
+/**
+ * Regression tests for bug #2771: USER-PROFILE.md tracked in install manifest
+ *
+ * USER-PROFILE.md is a user-owned artifact created/refreshed by /gsd-profile-user.
+ * preserveUserArtifacts() correctly preserves it across reinstalls. But writeManifest()
+ * also records it under "get-shit-done/USER-PROFILE.md" with a SHA-256 of whatever was
+ * on disk at install time. On the next install, saveLocalPatches() compares the on-disk
+ * (refreshed) hash to the manifest hash, finds them different, and emits the spurious
+ * "Found N locally modified GSD file(s) — backed up to gsd-local-patches/" warning.
+ *
+ * Invariant: a file is either distribution (manifest-tracked, diff'd against manifest)
+ * or user artifact (preserved across installs, never diff'd). It cannot be both. The
+ * shared truth source must be a single USER_OWNED_ARTIFACTS list referenced by both
+ * preserveUserArtifacts callers and writeManifest.
+ *
+ * Closes: #2771
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+const INSTALL_SCRIPT = path.join(__dirname, '..', 'bin', 'install.js');
+const BUILD_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
+const MANIFEST_NAME = 'gsd-file-manifest.json';
+const PATCHES_DIR_NAME = 'gsd-local-patches';
+
+before(() => {
+  execFileSync(process.execPath, [BUILD_SCRIPT], { encoding: 'utf-8', stdio: 'pipe' });
+});
+
+function runInstaller(configDir) {
+  const env = { ...process.env, CLAUDE_CONFIG_DIR: configDir };
+  delete env.GSD_TEST_MODE;
+  return execFileSync(
+    process.execPath,
+    [INSTALL_SCRIPT, '--claude', '--global', '--yes', '--no-sdk'],
+    { encoding: 'utf-8', stdio: 'pipe', env }
+  );
+}
+
+// ─── Test 1: writeManifest must NOT record USER-PROFILE.md ────────────────────
+
+describe('#2771: USER-PROFILE.md is excluded from gsd-file-manifest.json', () => {
+  let tmpDir;
+
+  beforeEach(() => { tmpDir = createTempDir('gsd-2771-manifest-'); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  test('writeManifest excludes get-shit-done/USER-PROFILE.md even when present on disk', () => {
+    runInstaller(tmpDir);
+
+    // Simulate /gsd-profile-user creating USER-PROFILE.md
+    const profilePath = path.join(tmpDir, 'get-shit-done', 'USER-PROFILE.md');
+    fs.writeFileSync(profilePath, '# My Profile\n\nFirst version.\n');
+
+    // Re-install: writeManifest runs again with USER-PROFILE.md present on disk
+    runInstaller(tmpDir);
+
+    const manifestPath = path.join(tmpDir, MANIFEST_NAME);
+    assert.ok(fs.existsSync(manifestPath), 'manifest must be written');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(manifest.files, 'get-shit-done/USER-PROFILE.md'),
+      'manifest.files must NOT contain get-shit-done/USER-PROFILE.md — it is a user artifact, not distribution'
+    );
+  });
+});
+
+// ─── Test 2: preserveUserArtifacts still preserves USER-PROFILE.md ────────────
+
+describe('#2771: USER-PROFILE.md is still preserved across reinstall', () => {
+  let tmpDir;
+
+  beforeEach(() => { tmpDir = createTempDir('gsd-2771-preserve-'); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  test('USER-PROFILE.md content survives reinstall (preservation regression guard)', () => {
+    runInstaller(tmpDir);
+
+    const profilePath = path.join(tmpDir, 'get-shit-done', 'USER-PROFILE.md');
+    const content = '# Profile\n\nUser content from /gsd-profile-user.\n';
+    fs.writeFileSync(profilePath, content);
+
+    runInstaller(tmpDir);
+
+    assert.ok(fs.existsSync(profilePath), 'USER-PROFILE.md must survive reinstall');
+    assert.strictEqual(fs.readFileSync(profilePath, 'utf8'), content);
+  });
+});
+
+// ─── Test 3: no spurious "local patches" hit for USER-PROFILE.md refresh ──────
+
+describe('#2771: refreshed USER-PROFILE.md does not trigger local-patches warning', () => {
+  let tmpDir;
+
+  beforeEach(() => { tmpDir = createTempDir('gsd-2771-patches-'); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  test('saveLocalPatches does not classify a refreshed USER-PROFILE.md as a local patch', () => {
+    // Initial install
+    runInstaller(tmpDir);
+
+    // /gsd-profile-user creates USER-PROFILE.md (v1)
+    const profilePath = path.join(tmpDir, 'get-shit-done', 'USER-PROFILE.md');
+    fs.writeFileSync(profilePath, '# Profile v1\n');
+
+    // Reinstall — manifest written with v1 contents (under buggy code) or excluded (under fix)
+    runInstaller(tmpDir);
+
+    // /gsd-profile-user --refresh rewrites USER-PROFILE.md (v2 != v1)
+    fs.writeFileSync(profilePath, '# Profile v2 — refreshed\n');
+
+    // Reinstall — saveLocalPatches scans manifest. Under bug, v2 hash != v1 manifest
+    // hash → patch detected. Under fix, file is not in manifest → no patch.
+    const output = runInstaller(tmpDir);
+
+    const patchesDir = path.join(tmpDir, PATCHES_DIR_NAME);
+    const patchFile = path.join(patchesDir, 'get-shit-done', 'USER-PROFILE.md');
+    assert.ok(
+      !fs.existsSync(patchFile),
+      'USER-PROFILE.md must NOT appear in gsd-local-patches/ — it is a user artifact, not a modified distribution file'
+    );
+
+    const offendingLine = output
+      .split('\n')
+      .find((line) => /locally modified GSD file/.test(line) && /USER-PROFILE/.test(line));
+    assert.strictEqual(
+      offendingLine,
+      undefined,
+      'installer output must not report USER-PROFILE.md as a locally modified GSD file on any single line. Output was:\n' + output
+    );
+  });
+});
+
+// ─── Test 5: legacy manifest with USER-PROFILE.md entry is normalized ─────────
+
+describe('#2771: legacy manifest entries for USER_OWNED_ARTIFACTS are normalized', () => {
+  let tmpDir;
+
+  beforeEach(() => { tmpDir = createTempDir('gsd-2771-legacy-'); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  test('pre-existing manifest entry for USER-PROFILE.md does not trigger patches warning', () => {
+    // Initial install
+    runInstaller(tmpDir);
+
+    const profilePath = path.join(tmpDir, 'get-shit-done', 'USER-PROFILE.md');
+    fs.writeFileSync(profilePath, '# Profile v1\n');
+
+    // Reinstall to populate manifest under the (now-fixed) writer
+    runInstaller(tmpDir);
+
+    // Inject a stale manifest entry simulating a pre-#2771 install: a hash for
+    // USER-PROFILE.md that does NOT match current content.
+    const manifestPath = path.join(tmpDir, MANIFEST_NAME);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.files = manifest.files || {};
+    manifest.files['get-shit-done/USER-PROFILE.md'] = 'deadbeef'.repeat(8); // stale hash
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+    // /gsd-profile-user --refresh rewrites USER-PROFILE.md
+    fs.writeFileSync(profilePath, '# Profile v2 — refreshed\n');
+
+    // Reinstall — saveLocalPatches must strip the legacy entry before scanning
+    const output = runInstaller(tmpDir);
+
+    const patchesDir = path.join(tmpDir, PATCHES_DIR_NAME);
+    const patchFile = path.join(patchesDir, 'get-shit-done', 'USER-PROFILE.md');
+    assert.ok(
+      !fs.existsSync(patchFile),
+      'legacy USER-PROFILE.md manifest entry must be normalized away — not backed up as a patch'
+    );
+
+    const offendingLine = output
+      .split('\n')
+      .find((line) => /locally modified GSD file/.test(line) && /USER-PROFILE/.test(line));
+    assert.strictEqual(
+      offendingLine,
+      undefined,
+      'legacy manifest entry must not surface a USER-PROFILE.md patches warning. Output was:\n' + output
+    );
+  });
+});
+
+// ─── Test 4: shared constant exists and is used by both call sites ────────────
+
+describe('#2771: USER_OWNED_ARTIFACTS is a single source of truth', () => {
+  test('install.js exports USER_OWNED_ARTIFACTS containing USER-PROFILE.md', () => {
+    const origMode = process.env.GSD_TEST_MODE;
+    process.env.GSD_TEST_MODE = '1';
+    let mod;
+    try {
+      delete require.cache[require.resolve(INSTALL_SCRIPT)];
+      mod = require(INSTALL_SCRIPT);
+    } finally {
+      if (origMode === undefined) delete process.env.GSD_TEST_MODE;
+      else process.env.GSD_TEST_MODE = origMode;
+    }
+
+    assert.ok(
+      Array.isArray(mod.USER_OWNED_ARTIFACTS) || mod.USER_OWNED_ARTIFACTS instanceof Set,
+      'install.js must export USER_OWNED_ARTIFACTS as a single source of truth'
+    );
+    const list = Array.isArray(mod.USER_OWNED_ARTIFACTS)
+      ? mod.USER_OWNED_ARTIFACTS
+      : Array.from(mod.USER_OWNED_ARTIFACTS);
+    assert.ok(
+      list.includes('USER-PROFILE.md'),
+      'USER_OWNED_ARTIFACTS must include USER-PROFILE.md'
+    );
+  });
+});

--- a/tests/bug-2772-gitmodules-path-intersection.test.cjs
+++ b/tests/bug-2772-gitmodules-path-intersection.test.cjs
@@ -1,0 +1,563 @@
+/**
+ * Regression test for #2772: worktree isolation is unconditionally disabled
+ * when `.gitmodules` exists in the repo, even when the plan does not touch
+ * any submodule path.
+ *
+ * Behavioral test: the bash decision pipeline from
+ * get-shit-done/workflows/execute-phase.md is extracted verbatim into an
+ * executable snippet here, then run via execFileSync('bash', ...) against
+ * real fixture projects built with `createTempGitProject()`. We assert
+ * the resulting USE_WORKTREES_FOR_PLAN value (printed on the final line
+ * of stdout) and the presence/absence of the [worktree] log line for each
+ * scenario.
+ *
+ * If execute-phase.md's bash gate is ever rewritten so the extracted
+ * snippet stops matching real behavior, this test must be updated to
+ * track the new pipeline — never replaced with a source grep.
+ *
+ * In addition to the per-plan gate behavior, this file also asserts:
+ *   - The workflow markdown actually wires USE_WORKTREES_FOR_PLAN into
+ *     each of the four dispatch sites (worktree-mode gate, sequential-mode
+ *     gate, "worktrees disabled" prose, post-wave cleanup gate). Without
+ *     this, the per-plan computation would be dead code (the original
+ *     #2772 fix shipped in this state — CodeRabbit caught it).
+ *   - The quick.md executor prompt injects SUBMODULE_PATHS and a fail-loud
+ *     pre-commit guard, and the guard actually aborts when staged paths
+ *     fall inside a submodule.
+ */
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { createTempGitProject, cleanup } = require('./helpers.cjs');
+
+// Bash snippet extracted from execute-phase.md (the SUBMODULE_PATHS parse +
+// per-plan intersection logic with normalization + bidirectional matching).
+// Inputs come from env vars: PLAN_FILES (whitespace-separated) and plan_id.
+// Output: log lines on stdout, then a final line
+// `USE_WORKTREES_FOR_PLAN=<true|false>` for the test to parse.
+const GATE_SNIPPET = [
+  'set -e',
+  'USE_WORKTREES="${USE_WORKTREES:-true}"',
+  'if [ -f .gitmodules ]; then',
+  "  SUBMODULE_PATHS=$(git config --file .gitmodules --get-regexp '^submodule\\..*\\.path$' 2>/dev/null | awk '{print $2}')",
+  'else',
+  '  SUBMODULE_PATHS=""',
+  'fi',
+  'USE_WORKTREES_FOR_PLAN="$USE_WORKTREES"',
+  'if [ -n "$SUBMODULE_PATHS" ] && [ "$USE_WORKTREES_FOR_PLAN" != "false" ]; then',
+  '  if [ -z "$PLAN_FILES" ]; then',
+  '    echo "[worktree] Plan ${plan_id}: files_modified missing/unparseable — disabling worktree isolation as a safety fallback (submodule project)"',
+  '    USE_WORKTREES_FOR_PLAN=false',
+  '  else',
+  '    INTERSECT=""',
+  '    set -f',
+  '    for sm_raw in $SUBMODULE_PATHS; do',
+  '      sm="${sm_raw#./}"',
+  '      sm="${sm%/}"',
+  '      [ -z "$sm" ] && continue',
+  '      for pf_raw in $PLAN_FILES; do',
+  '        pf="${pf_raw#./}"',
+  '        pf="${pf%/}"',
+  '        [ -z "$pf" ] && continue',
+  '        matched=0',
+  '        case "$pf" in',
+  '          "$sm"|"$sm"/*) matched=1 ;;',
+  '        esac',
+  '        if [ "$matched" -eq 0 ]; then',
+  '          case "$sm" in',
+  '            "$pf"|"$pf"/*) matched=1 ;;',
+  '          esac',
+  '        fi',
+  '        if [ "$matched" -eq 0 ]; then',
+  '          case "$pf" in',
+  "            *'*'*|*'?'*|*'['*)",
+  '              prefix="${pf%%[*?[]*}"',
+  '              prefix="${prefix%/}"',
+  '              if [ -n "$prefix" ]; then',
+  '                case "$sm" in',
+  '                  "$prefix"|"$prefix"/*) matched=1 ;;',
+  '                esac',
+  '                if [ "$matched" -eq 0 ]; then',
+  '                  case "$prefix" in',
+  '                    "$sm"|"$sm"/*) matched=1 ;;',
+  '                  esac',
+  '                fi',
+  '              fi',
+  '              ;;',
+  '        esac',
+  '        fi',
+  '        if [ "$matched" -eq 1 ]; then',
+  '          INTERSECT="$INTERSECT $pf_raw"',
+  '        fi',
+  '      done',
+  '    done',
+  '    set +f',
+  '    if [ -n "$INTERSECT" ]; then',
+  '      echo "[worktree] Plan ${plan_id}: planned paths intersect submodule paths (${INTERSECT# }) — disabling worktree isolation for this plan"',
+  '      USE_WORKTREES_FOR_PLAN=false',
+  '    fi',
+  '  fi',
+  'fi',
+  'echo "USE_WORKTREES_FOR_PLAN=$USE_WORKTREES_FOR_PLAN"',
+].join('\n');
+
+function runGate(cwd, env) {
+  const out = execFileSync('bash', ['-c', GATE_SNIPPET], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+  });
+  const lines = out.trim().split('\n');
+  const last = lines[lines.length - 1];
+  const m = last.match(/^USE_WORKTREES_FOR_PLAN=(true|false)$/);
+  assert.ok(
+    m,
+    `expected final line to be USE_WORKTREES_FOR_PLAN=<bool>, got: ${last}\nfull stdout:\n${out}`
+  );
+  return { decision: m[1], stdout: out, logLines: lines.slice(0, -1) };
+}
+
+function writeGitmodulesWithSubmodule(repo, submodulePath) {
+  const content = [
+    `[submodule "${submodulePath}"]`,
+    `\tpath = ${submodulePath}`,
+    `\turl = https://example.invalid/${submodulePath}.git`,
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(repo, '.gitmodules'), content);
+}
+
+describe('Submodule worktree-isolation gate intersects planned paths (#2772)', () => {
+  let repo;
+
+  beforeEach(() => {
+    repo = createTempGitProject('gsd-test-2772-');
+  });
+
+  afterEach(() => {
+    cleanup(repo);
+  });
+
+  test('plan touching only src/ in a submodule project keeps worktree isolation ENABLED', () => {
+    writeGitmodulesWithSubmodule(repo, 'vendor/foo');
+
+    const { decision, logLines } = runGate(repo, {
+      PLAN_FILES: 'src/index.ts src/lib/util.ts',
+      plan_id: 'plan-001',
+    });
+
+    assert.equal(decision, 'true');
+    assert.equal(logLines.filter((l) => l.startsWith('[worktree]')).length, 0);
+  });
+
+  test('plan touching vendor/foo/bar.ts in a submodule project DISABLES worktree isolation', () => {
+    writeGitmodulesWithSubmodule(repo, 'vendor/foo');
+
+    const { decision, stdout } = runGate(repo, {
+      PLAN_FILES: 'src/index.ts vendor/foo/bar.ts',
+      plan_id: 'plan-002',
+    });
+
+    assert.equal(decision, 'false');
+    assert.match(stdout, /\[worktree\] Plan plan-002: planned paths intersect submodule paths/);
+    assert.match(stdout, /vendor\/foo\/bar\.ts/);
+  });
+
+  test('plan whose path equals the submodule root (vendor/foo) DISABLES worktree isolation', () => {
+    writeGitmodulesWithSubmodule(repo, 'vendor/foo');
+
+    const { decision, stdout } = runGate(repo, {
+      PLAN_FILES: 'vendor/foo',
+      plan_id: 'plan-003',
+    });
+
+    assert.equal(decision, 'false');
+    assert.match(stdout, /\[worktree\] Plan plan-003: planned paths intersect submodule paths/);
+  });
+
+  test('missing files_modified in a submodule project falls back to DISABLE with a logged reason', () => {
+    writeGitmodulesWithSubmodule(repo, 'vendor/foo');
+
+    const { decision, stdout } = runGate(repo, {
+      PLAN_FILES: '',
+      plan_id: 'plan-004',
+    });
+
+    assert.equal(decision, 'false');
+    assert.match(stdout, /\[worktree\] Plan plan-004: files_modified missing\/unparseable/);
+    assert.match(stdout, /safety fallback/);
+  });
+
+  test('repo with no .gitmodules at all keeps worktree isolation ENABLED regardless of plan paths', () => {
+    const { decision, logLines } = runGate(repo, {
+      PLAN_FILES: 'vendor/foo/bar.ts src/index.ts',
+      plan_id: 'plan-005',
+    });
+
+    assert.equal(decision, 'true');
+    assert.equal(logLines.filter((l) => l.startsWith('[worktree]')).length, 0);
+  });
+
+  test('multiple submodules, plan touches only one of them — DISABLE with that path in the log', () => {
+    const gitmodules = [
+      '[submodule "vendor/foo"]',
+      '\tpath = vendor/foo',
+      '\turl = https://example.invalid/foo.git',
+      '[submodule "third_party/bar"]',
+      '\tpath = third_party/bar',
+      '\turl = https://example.invalid/bar.git',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(repo, '.gitmodules'), gitmodules);
+
+    const { decision, stdout } = runGate(repo, {
+      PLAN_FILES: 'src/a.ts third_party/bar/b.ts',
+      plan_id: 'plan-006',
+    });
+
+    assert.equal(decision, 'false');
+    assert.match(stdout, /third_party\/bar\/b\.ts/);
+  });
+
+  test('planned path that merely shares a prefix with a submodule (vendor/foobar) does NOT count as intersection', () => {
+    writeGitmodulesWithSubmodule(repo, 'vendor/foo');
+
+    const { decision, logLines } = runGate(repo, {
+      PLAN_FILES: 'vendor/foobar/x.ts',
+      plan_id: 'plan-007',
+    });
+
+    assert.equal(decision, 'true');
+    assert.equal(logLines.filter((l) => l.startsWith('[worktree]')).length, 0);
+  });
+
+  // ---- Path-normalization & glob coverage (CodeRabbit MAJOR finding) ----
+
+  test('planned path with leading "./" normalizes and DISABLES isolation when inside a submodule', () => {
+    writeGitmodulesWithSubmodule(repo, 'vendor/foo');
+
+    const { decision, stdout } = runGate(repo, {
+      PLAN_FILES: './vendor/foo/bar.c',
+      plan_id: 'plan-norm-1',
+    });
+
+    assert.equal(decision, 'false', './vendor/foo/bar.c must normalize and intersect vendor/foo');
+    assert.match(stdout, /vendor\/foo\/bar\.c/);
+  });
+
+  test('planned path with trailing slash equal to submodule DISABLES isolation', () => {
+    writeGitmodulesWithSubmodule(repo, 'vendor/foo');
+
+    const { decision } = runGate(repo, {
+      PLAN_FILES: 'vendor/foo/',
+      plan_id: 'plan-norm-2',
+    });
+
+    assert.equal(decision, 'false', 'trailing slash must not defeat the submodule-root match');
+  });
+
+  test('globby planned path "vendor/**/*.c" DISABLES isolation when submodule sits inside vendor/', () => {
+    writeGitmodulesWithSubmodule(repo, 'vendor/foo');
+
+    const { decision, stdout } = runGate(repo, {
+      PLAN_FILES: 'vendor/**/*.c',
+      plan_id: 'plan-norm-3',
+    });
+
+    assert.equal(
+      decision,
+      'false',
+      'glob whose literal prefix "vendor" contains submodule vendor/foo must intersect'
+    );
+    assert.match(stdout, /vendor\/\*\*\/\*\.c/);
+  });
+
+  test('plan declares a parent directory of the submodule (e.g. "vendor") — DISABLES isolation', () => {
+    writeGitmodulesWithSubmodule(repo, 'vendor/foo');
+
+    const { decision } = runGate(repo, {
+      PLAN_FILES: 'vendor',
+      plan_id: 'plan-norm-4',
+    });
+
+    assert.equal(
+      decision,
+      'false',
+      'planned path that contains the submodule must intersect (bidirectional matching)'
+    );
+  });
+
+  test('submodule path declared with leading "./" in .gitmodules still matches a plain planned path', () => {
+    const gitmodules = [
+      '[submodule "vendor/foo"]',
+      '\tpath = ./vendor/foo',
+      '\turl = https://example.invalid/foo.git',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(repo, '.gitmodules'), gitmodules);
+
+    const { decision } = runGate(repo, {
+      PLAN_FILES: 'vendor/foo/bar.ts',
+      plan_id: 'plan-norm-5',
+    });
+
+    assert.equal(
+      decision,
+      'false',
+      'submodule "./vendor/foo" must normalize and match plain planned path vendor/foo/bar.ts'
+    );
+  });
+
+  test('globby planned path that does NOT overlap the submodule keeps isolation ENABLED', () => {
+    writeGitmodulesWithSubmodule(repo, 'vendor/foo');
+
+    const { decision, logLines } = runGate(repo, {
+      PLAN_FILES: 'src/**/*.ts',
+      plan_id: 'plan-norm-6',
+    });
+
+    assert.equal(decision, 'true');
+    assert.equal(logLines.filter((l) => l.startsWith('[worktree]')).length, 0);
+  });
+});
+
+// ---- Workflow-markdown wiring assertions (CodeRabbit CRITICAL finding) ----
+//
+// The original PR computed USE_WORKTREES_FOR_PLAN but never read it at the
+// dispatch sites — the dispatch still branched on the project-level
+// USE_WORKTREES, so the per-plan decision was dead code. Assert the markdown
+// actually wires the variable into the four dispatch sites.
+
+describe('execute-phase.md dispatch wires USE_WORKTREES_FOR_PLAN (#2772)', () => {
+  const workflowPath = path.join(
+    __dirname,
+    '..',
+    'get-shit-done',
+    'workflows',
+    'execute-phase.md'
+  );
+  const gatePath = path.join(
+    __dirname,
+    '..',
+    'get-shit-done',
+    'workflows',
+    'execute-phase',
+    'steps',
+    'per-plan-worktree-gate.md'
+  );
+
+  test('workflow file exists and is readable', () => {
+    assert.ok(fs.existsSync(workflowPath), `expected ${workflowPath} to exist`);
+  });
+
+  test('per-plan worktree gate steps file exists and is readable', () => {
+    assert.ok(fs.existsSync(gatePath), `expected ${gatePath} to exist`);
+  });
+
+  test('Worktree-mode dispatch gate reads USE_WORKTREES_FOR_PLAN, not USE_WORKTREES', () => {
+    const md = fs.readFileSync(workflowPath, 'utf-8');
+    assert.match(
+      md,
+      /\*\*Worktree mode\*\*\s*\(`USE_WORKTREES_FOR_PLAN`/,
+      'Worktree-mode header must gate on USE_WORKTREES_FOR_PLAN per-plan'
+    );
+  });
+
+  test('Sequential-mode dispatch gate reads USE_WORKTREES_FOR_PLAN', () => {
+    const md = fs.readFileSync(workflowPath, 'utf-8');
+    assert.match(
+      md,
+      /\*\*Sequential mode\*\*\s*\(`USE_WORKTREES_FOR_PLAN`/,
+      'Sequential-mode header must gate on USE_WORKTREES_FOR_PLAN per-plan'
+    );
+  });
+
+  test('"Worktrees disabled" sequential rule is documented per-plan, not project-level', () => {
+    const md = fs.readFileSync(workflowPath, 'utf-8');
+    assert.match(
+      md,
+      /worktrees are disabled for a plan/i,
+      'sequential-execution rule must be expressed per-plan'
+    );
+  });
+
+  test('execute-phase.md hooks the per-plan gate steps file at sub-step 2.5', () => {
+    const md = fs.readFileSync(workflowPath, 'utf-8');
+    assert.match(md, /Per-plan worktree decision/, 'sub-step header must exist in execute_waves');
+    assert.match(
+      md,
+      /execute-phase\/steps\/per-plan-worktree-gate\.md/,
+      'execute-phase.md must reference the extracted gate file'
+    );
+  });
+
+  test('per-plan gate file documents PLAN_FILES extraction from plan_json', () => {
+    const md = fs.readFileSync(gatePath, 'utf-8');
+    assert.match(
+      md,
+      /jq -r '\.files_modified \/\/ \[\] \| join\(" "\)' <<<"\$plan_json"/,
+      'PLAN_FILES extraction from plan_json must be documented in the gate file'
+    );
+  });
+
+  test('per-plan gate file uses bidirectional case + glob-prefix handling + set -f discipline', () => {
+    const md = fs.readFileSync(gatePath, 'utf-8');
+    assert.match(md, /set -f/, 'matcher must disable globbing while iterating');
+    assert.match(md, /set \+f/, 'matcher must re-enable globbing after iteration');
+    const pfFirst = md.match(/case "\$pf" in\s+"\$sm"\|"\$sm"\/\*\)/);
+    const smFirst = md.match(/case "\$sm" in\s+"\$pf"\|"\$pf"\/\*\)/);
+    assert.ok(pfFirst, 'matcher must check pf inside sm');
+    assert.ok(smFirst, 'matcher must check sm inside pf (bidirectional)');
+    assert.match(md, /sm="\$\{sm_raw#\.\/\}"/, 'submodule path must strip leading ./');
+    assert.match(md, /pf="\$\{pf_raw#\.\/\}"/, 'planned path must strip leading ./');
+    assert.match(md, /sm="\$\{sm%\/\}"/, 'submodule path must strip trailing /');
+    assert.match(md, /pf="\$\{pf%\/\}"/, 'planned path must strip trailing /');
+  });
+
+  test('Post-wave worktree-cleanup gate is per-plan, not blanket project-level', () => {
+    const md = fs.readFileSync(workflowPath, 'utf-8');
+    assert.match(
+      md,
+      /WAVE_WORKTREE_PLANS/,
+      'post-wave cleanup must track which plans actually used worktrees'
+    );
+  });
+});
+
+// ---- quick.md SUBMODULE_PATHS executor guard (CodeRabbit CRITICAL #3) ----
+//
+// Quick mode does NOT have a pre-declared files_modified list. The fail-loud
+// guard must (a) be present in the markdown of the executor prompt, and
+// (b) actually abort when run against a fixture that stages a submodule path.
+
+describe('quick.md executor pre-commit submodule guard (#2772)', () => {
+  const quickPath = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'quick.md');
+
+  test('quick.md executor prompt injects SUBMODULE_PATHS', () => {
+    const md = fs.readFileSync(quickPath, 'utf-8');
+    assert.match(
+      md,
+      /SUBMODULE_PATHS for this project: \$\{SUBMODULE_PATHS\}/,
+      'executor prompt must inline SUBMODULE_PATHS so the agent can run the guard'
+    );
+  });
+
+  test('quick.md executor prompt contains a fail-loud pre-commit guard with ABORT message', () => {
+    const md = fs.readFileSync(quickPath, 'utf-8');
+    assert.match(md, /<submodule_commit_guard>/, 'guard block must exist');
+    assert.match(
+      md,
+      /git diff --cached --name-only/,
+      'guard must inspect staged paths before commit'
+    );
+    assert.match(
+      md,
+      /ABORT: staged path/,
+      'guard must surface a fail-loud ABORT message on intersection'
+    );
+    assert.match(
+      md,
+      /workflow\.use_worktrees=false/,
+      'guard must tell the user how to recover (re-run without worktrees)'
+    );
+  });
+
+  // Behavioral: extract the guard logic and run it against a fixture repo.
+  // We simulate the executor's commit-time guard and assert it aborts when a
+  // staged path falls inside a SUBMODULE_PATHS entry, and passes otherwise.
+  const QUICK_GUARD_SNIPPET = [
+    'set +e',
+    'STAGED=$(git diff --cached --name-only)',
+    'if [ -n "$SUBMODULE_PATHS" ]; then',
+    '  for sm_raw in $SUBMODULE_PATHS; do',
+    '    sm="${sm_raw#./}"',
+    '    sm="${sm%/}"',
+    '    [ -z "$sm" ] && continue',
+    '    for f_raw in $STAGED; do',
+    '      f="${f_raw#./}"',
+    '      f="${f%/}"',
+    '      case "$f" in',
+    '        "$sm"|"$sm"/*)',
+    '          echo "ABORT: staged path $f_raw falls inside submodule $sm — re-run with workflow.use_worktrees=false" >&2',
+    '          exit 1 ;;',
+    '      esac',
+    '    done',
+    '  done',
+    'fi',
+    'echo "OK"',
+  ].join('\n');
+
+  test('guard ABORTs when a staged path falls inside a submodule', () => {
+    const repo = createTempGitProject('gsd-test-2772-quick-abort-');
+    try {
+      // Create a file inside the submodule path and stage it.
+      fs.mkdirSync(path.join(repo, 'vendor', 'foo'), { recursive: true });
+      fs.writeFileSync(path.join(repo, 'vendor', 'foo', 'bar.ts'), 'export {};\n');
+      execFileSync('git', ['add', 'vendor/foo/bar.ts'], { cwd: repo });
+
+      let err;
+      try {
+        execFileSync('bash', ['-c', QUICK_GUARD_SNIPPET], {
+          cwd: repo,
+          encoding: 'utf-8',
+          env: { ...process.env, SUBMODULE_PATHS: 'vendor/foo' },
+        });
+      } catch (e) {
+        err = e;
+      }
+      assert.ok(err, 'guard must exit non-zero when staged path is inside submodule');
+      assert.equal(err.status, 1, 'guard must exit with status 1');
+      const stderr = err.stderr ? err.stderr.toString() : '';
+      assert.match(stderr, /ABORT: staged path vendor\/foo\/bar\.ts/);
+      assert.match(stderr, /vendor\/foo/);
+    } finally {
+      cleanup(repo);
+    }
+  });
+
+  test('guard passes when no staged path falls inside a submodule', () => {
+    const repo = createTempGitProject('gsd-test-2772-quick-pass-');
+    try {
+      fs.mkdirSync(path.join(repo, 'src'), { recursive: true });
+      fs.writeFileSync(path.join(repo, 'src', 'index.ts'), 'export {};\n');
+      execFileSync('git', ['add', 'src/index.ts'], { cwd: repo });
+
+      const out = execFileSync('bash', ['-c', QUICK_GUARD_SNIPPET], {
+        cwd: repo,
+        encoding: 'utf-8',
+        env: { ...process.env, SUBMODULE_PATHS: 'vendor/foo' },
+      });
+      assert.match(out, /OK/);
+    } finally {
+      cleanup(repo);
+    }
+  });
+
+  test('guard normalizes leading "./" on staged paths and still ABORTs', () => {
+    const repo = createTempGitProject('gsd-test-2772-quick-norm-');
+    try {
+      fs.mkdirSync(path.join(repo, 'vendor', 'foo'), { recursive: true });
+      fs.writeFileSync(path.join(repo, 'vendor', 'foo', 'bar.ts'), 'export {};\n');
+      execFileSync('git', ['add', 'vendor/foo/bar.ts'], { cwd: repo });
+
+      let err;
+      try {
+        // Submodule path declared with ./ prefix — must still match.
+        execFileSync('bash', ['-c', QUICK_GUARD_SNIPPET], {
+          cwd: repo,
+          encoding: 'utf-8',
+          env: { ...process.env, SUBMODULE_PATHS: './vendor/foo' },
+        });
+      } catch (e) {
+        err = e;
+      }
+      assert.ok(err, 'guard must abort even when SUBMODULE_PATHS uses ./ prefix');
+      assert.equal(err.status, 1);
+    } finally {
+      cleanup(repo);
+    }
+  });
+});

--- a/tests/bug-2774-worktree-cleanup-workspace-safety.test.cjs
+++ b/tests/bug-2774-worktree-cleanup-workspace-safety.test.cjs
@@ -1,0 +1,343 @@
+/**
+ * Bug #2774 — Worktree cleanup destroys parent workspace .git
+ *
+ * The cleanup blocks in execute-phase.md and quick.md previously used an
+ * EXCLUSION-based filter:
+ *
+ *   git worktree list --porcelain | grep "^worktree " | grep -v "$(pwd)$" | sed ...
+ *
+ * That filter only excludes the literal `$(pwd)`. When a GSD project is itself
+ * a git worktree of an upstream main repo (the multi-workspace case, including
+ * the cross-drive Windows case where `git worktree list` reports the registry
+ * path as e.g. `E:/...` while `$(pwd)` resolves to `C:/...`), every other
+ * worktree — including the workspace itself — is wiped, taking the
+ * workspace's `.git` pointer file with it.
+ *
+ * The fix is INCLUSION-based: only target paths matching the agent worktree
+ * convention (`.claude/worktrees/agent-`), the namespace under which Claude
+ * Code's `isolation="worktree"` always creates executor worktrees.
+ *
+ * These tests assert the cleanup block in BOTH workflow files:
+ *   1. Includes only paths matching `.claude/worktrees/agent-` (positive filter)
+ *   2. Does NOT rely on `grep -v "$(pwd)$"` as the sole guard (negative filter)
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { cleanup } = require('./helpers.cjs');
+
+// The exact discovery pipeline from get-shit-done/workflows/quick.md and
+// get-shit-done/workflows/execute-phase.md (line: `WORKTREES=$(git worktree
+// list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" |
+// sed 's/^worktree //')`). We invoke it as a standalone shell pipeline
+// against either real `git worktree list --porcelain` output (in the
+// end-to-end case) or piped-in fixture text (in the unit case).
+// Note: execSync runs with `shell: '/bin/sh'` by default, which interprets the
+// command string directly — no extra `bash -c '...'` wrapper needed. The
+// pipeline string below is the verbatim shell from quick.md / execute-phase.md
+// (the RHS of the `WORKTREES=$(...)` substitution).
+const DISCOVERY_PIPELINE =
+  'grep "^worktree " | grep "\\.claude/worktrees/agent-" | sed \'s/^worktree //\'';
+
+function runDiscoveryAgainstFixture(porcelain) {
+  const out = execSync(DISCOVERY_PIPELINE, {
+    input: porcelain,
+    encoding: 'utf-8',
+  });
+  return out.split('\n').filter((l) => l.length > 0);
+}
+
+function runDiscoveryAgainstRepo(repoCwd) {
+  const out = execSync(
+    `git worktree list --porcelain | ${DISCOVERY_PIPELINE}`,
+    { cwd: repoCwd, encoding: 'utf-8' }
+  );
+  return out.split('\n').filter((l) => l.length > 0);
+}
+
+function makeTempUpstreamRepo(prefix) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  execSync('git init -b main', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git config commit.gpgsign false', { cwd: tmpDir, stdio: 'pipe' });
+  fs.writeFileSync(path.join(tmpDir, 'README.md'), '# upstream\n');
+  execSync('git add -A', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git commit -m "initial"', { cwd: tmpDir, stdio: 'pipe' });
+  return tmpDir;
+}
+
+describe('bug #2774 — worktree cleanup pipeline must not target the parent workspace', () => {
+  describe('discovery pipeline (unit)', () => {
+    test('selects only the agent worktree when workspace itself is a worktree', () => {
+      // Fixture mirrors the multi-workspace setup: upstream main + sibling
+      // workspace worktree + agent worktree under workspace's
+      // `.claude/worktrees/agent-` namespace.
+      const porcelain = [
+        'worktree /Users/dev/upstream/get-shit-done',
+        'HEAD abc123',
+        'branch refs/heads/main',
+        '',
+        'worktree /Users/dev/workspaces/feature-x',
+        'HEAD def456',
+        'branch refs/heads/workspace/feature-x',
+        '',
+        'worktree /Users/dev/workspaces/feature-x/.claude/worktrees/agent-deadbeef',
+        'HEAD 789abc',
+        'branch refs/heads/worktree-agent-deadbeef',
+        '',
+      ].join('\n');
+
+      const discovered = runDiscoveryAgainstFixture(porcelain);
+
+      assert.deepEqual(
+        discovered,
+        ['/Users/dev/workspaces/feature-x/.claude/worktrees/agent-deadbeef'],
+        'pipeline must select only the agent-spawned worktree, never the ' +
+          'workspace or upstream main repo'
+      );
+    });
+
+    test('selects nothing when no agent worktrees exist', () => {
+      const porcelain = [
+        'worktree /Users/dev/upstream/get-shit-done',
+        'HEAD abc123',
+        'branch refs/heads/main',
+        '',
+        'worktree /Users/dev/workspaces/feature-x',
+        'HEAD def456',
+        'branch refs/heads/workspace/feature-x',
+        '',
+      ].join('\n');
+
+      const discovered = runDiscoveryAgainstFixture(porcelain);
+
+      assert.deepEqual(discovered, []);
+    });
+
+    test('selects multiple agent worktrees and excludes non-agent paths', () => {
+      const porcelain = [
+        'worktree /repo/main',
+        'HEAD a',
+        'branch refs/heads/main',
+        '',
+        'worktree /repo/main/.claude/worktrees/agent-aaa',
+        'HEAD b',
+        'branch refs/heads/agent-aaa',
+        '',
+        'worktree /repo/main/.claude/worktrees/agent-bbb',
+        'HEAD c',
+        'branch refs/heads/agent-bbb',
+        '',
+        'worktree /repo/main/some-other-dir',
+        'HEAD d',
+        'branch refs/heads/feature',
+        '',
+      ].join('\n');
+
+      const discovered = runDiscoveryAgainstFixture(porcelain);
+
+      assert.deepEqual(discovered.sort(), [
+        '/repo/main/.claude/worktrees/agent-aaa',
+        '/repo/main/.claude/worktrees/agent-bbb',
+      ]);
+    });
+
+    test('selects agent worktree even when path contains whitespace', () => {
+      // Regression for CodeRabbit feedback on PR #2778: `for WT in $WORKTREES`
+      // splits on whitespace and would emit broken half-paths like
+      // "/Users/dev/My" and "Workspace/.claude/worktrees/agent-xyz". The
+      // pipeline output itself is line-delimited and preserves the full path —
+      // the workflow's loop must consume it line-by-line via `while IFS= read`.
+      const porcelain = [
+        'worktree /Users/dev/My Workspace',
+        'HEAD def456',
+        'branch refs/heads/workspace/feature-x',
+        '',
+        'worktree /Users/dev/My Workspace/.claude/worktrees/agent-deadbeef',
+        'HEAD 789abc',
+        'branch refs/heads/worktree-agent-deadbeef',
+        '',
+      ].join('\n');
+
+      const discovered = runDiscoveryAgainstFixture(porcelain);
+
+      assert.deepEqual(
+        discovered,
+        ['/Users/dev/My Workspace/.claude/worktrees/agent-deadbeef'],
+        'pipeline output must preserve whitespace-bearing agent worktree path on a single line'
+      );
+    });
+
+    test('while/read loop iterates each whitespace-bearing path exactly once', () => {
+      // Verify the actual consumer pattern from quick.md / execute-phase.md:
+      //   while IFS= read -r WT; do ...; done < <(<pipeline>)
+      // Counts the lines yielded to the loop body. With the previous
+      // `for WT in $WORKTREES` form, a path containing one space would yield
+      // 2 iterations (broken halves). The `while/read` form yields exactly 1.
+      const porcelain = [
+        'worktree /tmp/has space/.claude/worktrees/agent-aaa',
+        'HEAD a',
+        'branch refs/heads/agent-aaa',
+        '',
+        'worktree /tmp/two  spaces/.claude/worktrees/agent-bbb',
+        'HEAD b',
+        'branch refs/heads/agent-bbb',
+        '',
+      ].join('\n');
+
+      // Mirror the workflow's loop verbatim. Print one line per iteration with
+      // a sentinel so we can count and inspect what the loop actually saw.
+      const script = `
+while IFS= read -r WT; do
+  [ -z "$WT" ] && continue
+  printf 'ITER:%s\\n' "$WT"
+done < <(${DISCOVERY_PIPELINE})
+`;
+      // bash needed for process substitution `< <(...)`.
+      const out = execSync(`bash -c '${script.replace(/'/g, `'\\''`)}'`, {
+        input: porcelain,
+        encoding: 'utf-8',
+      });
+      const iterations = out
+        .split('\n')
+        .filter((l) => l.startsWith('ITER:'))
+        .map((l) => l.slice('ITER:'.length));
+
+      assert.deepEqual(
+        iterations,
+        [
+          '/tmp/has space/.claude/worktrees/agent-aaa',
+          '/tmp/two  spaces/.claude/worktrees/agent-bbb',
+        ],
+        'while/read loop must yield exactly one iteration per worktree, with whitespace preserved'
+      );
+    });
+  });
+
+  describe('end-to-end against real git worktrees', () => {
+    let upstream;
+    let workspace;
+    let agentWorktree;
+    let workspacesParent;
+
+    beforeEach(() => {
+      // Build the multi-worktree scenario from #2774:
+      //   upstream/         <- main repo
+      //   workspace/        <- worktree of upstream (the "workspace")
+      //   workspace/.claude/worktrees/agent-XXXX/  <- agent worktree
+      upstream = makeTempUpstreamRepo('gsd-2774-upstream-');
+
+      workspacesParent = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'gsd-2774-workspaces-')
+      );
+      workspace = path.join(workspacesParent, 'feature-x');
+      execSync(`git worktree add -b workspace/feature-x "${workspace}"`, {
+        cwd: upstream,
+        stdio: 'pipe',
+      });
+
+      const agentDir = path.join(workspace, '.claude', 'worktrees');
+      fs.mkdirSync(agentDir, { recursive: true });
+      agentWorktree = path.join(agentDir, 'agent-deadbeef');
+      execSync(
+        `git worktree add -b worktree-agent-deadbeef "${agentWorktree}"`,
+        { cwd: upstream, stdio: 'pipe' }
+      );
+    });
+
+    afterEach(() => {
+      try {
+        execSync('git worktree prune', { cwd: upstream, stdio: 'pipe' });
+      } catch (_) {
+        /* ignore */
+      }
+      cleanup(upstream);
+      cleanup(workspacesParent);
+    });
+
+    test('discovery from inside workspace returns only the agent worktree', () => {
+      const discovered = runDiscoveryAgainstRepo(workspace);
+
+      // Resolve symlinks (macOS /var → /private/var) for stable comparison.
+      const expected = fs.realpathSync(agentWorktree);
+      const actual = discovered.map((p) => fs.realpathSync(p));
+
+      assert.deepEqual(
+        actual,
+        [expected],
+        'pipeline must list only the agent worktree, not the workspace or upstream'
+      );
+    });
+
+    test('running cleanup loop on discovered paths preserves workspace .git', () => {
+      const workspaceGitBefore = fs.readFileSync(
+        path.join(workspace, '.git'),
+        'utf-8'
+      );
+      assert.ok(
+        fs.existsSync(path.join(upstream, '.git')),
+        'precondition: upstream .git must exist'
+      );
+
+      const discovered = runDiscoveryAgainstRepo(workspace);
+      assert.equal(
+        discovered.length,
+        1,
+        'precondition: exactly one agent worktree should be discovered'
+      );
+
+      // Execute the cleanup behavior end-to-end: `git worktree remove --force`
+      // each discovered path. This mirrors the workflow's cleanup loop.
+      for (const wt of discovered) {
+        execSync(`git worktree remove --force "${wt}"`, {
+          cwd: workspace,
+          stdio: 'pipe',
+        });
+      }
+
+      // Agent worktree dir must be gone.
+      assert.equal(
+        fs.existsSync(agentWorktree),
+        false,
+        'agent worktree dir should be removed by cleanup'
+      );
+
+      // Workspace `.git` pointer file must still exist and be unchanged —
+      // the regression we are guarding against.
+      assert.ok(
+        fs.existsSync(path.join(workspace, '.git')),
+        'workspace .git pointer must survive cleanup (regression #2774)'
+      );
+      assert.equal(
+        fs.readFileSync(path.join(workspace, '.git'), 'utf-8'),
+        workspaceGitBefore,
+        'workspace .git pointer contents must be unchanged'
+      );
+
+      // Upstream repo's .git directory must also be intact.
+      assert.ok(
+        fs.existsSync(path.join(upstream, '.git')),
+        'upstream .git must survive cleanup'
+      );
+
+      // Workspace must still be a functional git worktree.
+      const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+        cwd: workspace,
+        encoding: 'utf-8',
+      }).trim();
+      assert.equal(
+        branch,
+        'workspace/feature-x',
+        'workspace must still be a functional worktree on its branch'
+      );
+    });
+  });
+});

--- a/tests/bug-2775-sdk-shim-path-verify.test.cjs
+++ b/tests/bug-2775-sdk-shim-path-verify.test.cjs
@@ -1,0 +1,233 @@
+/**
+ * Regression test for bug #2775
+ *
+ * `npx get-shit-done-cc@latest --global` runs the installer, which prints
+ * `✓ GSD SDK ready` even though the secondary `gsd-sdk` bin is not on the
+ * user's PATH. Root cause: `npx` only links the package's primary bin into
+ * the ephemeral cache; secondary bins are not symlinked. The installer's
+ * `installSdkIfNeeded` only verified that `sdk/dist/cli.js` exists on disk
+ * — a strictly weaker invariant than `command -v gsd-sdk` resolving.
+ *
+ * The fix tightens the success gate: after confirming the dist is present,
+ * the installer must verify `gsd-sdk` resolves on PATH. If it does not, the
+ * installer attempts to materialize the shim into a user-writable PATH
+ * location (`~/.local/bin/gsd-sdk`) and re-checks. Only when the PATH probe
+ * succeeds does it print `✓ GSD SDK ready`. Otherwise it emits a clear
+ * warning + remediation and does NOT lie about readiness.
+ *
+ * This test exercises `installSdkIfNeeded` against a synthetic npx-cache
+ * shape: sdk/dist/cli.js present, but PATH does not contain any directory
+ * with a `gsd-sdk` shim. The legacy code printed the success line in this
+ * shape; the fixed code must not.
+ */
+
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const installModule = require('../bin/install.js');
+const { installSdkIfNeeded } = installModule;
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+function captureConsole(fn) {
+  const stdout = [];
+  const stderr = [];
+  const origLog = console.log;
+  const origWarn = console.warn;
+  const origError = console.error;
+  console.log = (...a) => stdout.push(a.join(' '));
+  console.warn = (...a) => stderr.push(a.join(' '));
+  console.error = (...a) => stderr.push(a.join(' '));
+  let threw = null;
+  try {
+    fn();
+  } catch (e) {
+    threw = e;
+  } finally {
+    console.log = origLog;
+    console.warn = origWarn;
+    console.error = origError;
+  }
+  // Re-throw any captured exception AFTER restoring console so callers don't
+  // have to destructure-and-assert on `threw` (and a future regression that
+  // crashes before printing won't falsely pass `!hasReady`). (#2775
+  // CodeRabbit follow-up)
+  if (threw) throw threw;
+  // strip ANSI for matching
+  const strip = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
+  return {
+    stdout: stdout.map(strip).join('\n'),
+    stderr: stderr.map(strip).join('\n'),
+  };
+}
+
+describe('bug #2775: installSdkIfNeeded must verify gsd-sdk on PATH before reporting ready', () => {
+  let tmpRoot;
+  let sdkDir;
+  let pathDir;
+  let homeDir;
+  let savedEnv;
+
+  beforeEach(() => {
+    tmpRoot = createTempDir('gsd-2775-');
+    sdkDir = path.join(tmpRoot, 'sdk');
+    fs.mkdirSync(path.join(sdkDir, 'dist'), { recursive: true });
+    fs.writeFileSync(
+      path.join(sdkDir, 'dist', 'cli.js'),
+      '#!/usr/bin/env node\nconsole.log("0.0.0-test");\n',
+      { mode: 0o755 },
+    );
+    pathDir = path.join(tmpRoot, 'somebin');
+    fs.mkdirSync(pathDir, { recursive: true });
+    homeDir = path.join(tmpRoot, 'home');
+    fs.mkdirSync(homeDir, { recursive: true });
+    savedEnv = { PATH: process.env.PATH, HOME: process.env.HOME };
+    // PATH does NOT contain anything with a gsd-sdk shim — simulates npx-cache.
+    process.env.PATH = pathDir;
+    process.env.HOME = homeDir;
+  });
+
+  afterEach(() => {
+    if (savedEnv.PATH == null) delete process.env.PATH;
+    else process.env.PATH = savedEnv.PATH;
+    if (savedEnv.HOME == null) delete process.env.HOME;
+    else process.env.HOME = savedEnv.HOME;
+    cleanup(tmpRoot);
+  });
+
+  test('does NOT print "GSD SDK ready" when gsd-sdk is not callable on PATH and cannot be linked', () => {
+    // Make ~/.local/bin not on PATH and not creatable-friendly: PATH stays
+    // as a single dir with no gsd-sdk. The installer may attempt to create
+    // ~/.local/bin/gsd-sdk, but that location isn't on PATH either, so the
+    // post-link probe should still fail and the success line must be withheld.
+    const { stdout, stderr } = captureConsole(() => {
+      installSdkIfNeeded({ sdkDir });
+    });
+    const combined = `${stdout}\n${stderr}`;
+    const hasReady = /GSD SDK ready/.test(combined);
+    const mentionsPath = /not on (your )?PATH|gsd-sdk.*PATH|PATH.*gsd-sdk/i.test(combined);
+    assert.ok(
+      !hasReady,
+      `installer must not print "GSD SDK ready" when gsd-sdk is not on PATH. Output:\n${combined}`,
+    );
+    assert.ok(
+      mentionsPath,
+      `installer must surface a PATH-related warning when gsd-sdk is not callable. Output:\n${combined}`,
+    );
+  });
+
+  test('DOES print "GSD SDK ready" after self-linking into a directory that IS on PATH', () => {
+    // Put ~/.local/bin on PATH; the installer should create the shim there
+    // and the post-link callability probe should succeed.
+    const localBin = path.join(homeDir, '.local', 'bin');
+    fs.mkdirSync(localBin, { recursive: true });
+    process.env.PATH = `${localBin}${path.delimiter}${pathDir}`;
+
+    const { stdout, stderr } = captureConsole(() => {
+      installSdkIfNeeded({ sdkDir });
+    });
+    const combined = `${stdout}\n${stderr}`;
+    assert.ok(
+      /GSD SDK ready/.test(combined),
+      `installer must print "GSD SDK ready" after self-linking to a dir on PATH. Output:\n${combined}`,
+    );
+    // And the link must actually exist + resolve back to the shim.
+    const linkPath = path.join(localBin, 'gsd-sdk');
+    assert.ok(fs.existsSync(linkPath), `installer must materialize ${linkPath}`);
+  });
+
+  test('symlink-fallback writes a wrapper that require()s the real shim by absolute path (preserves __dirname)', () => {
+    // Simulate a symlink-hostile filesystem by forcing fs.symlinkSync to throw.
+    // The fallback must NOT copy bin/gsd-sdk.js into ~/.local/bin (which would
+    // break the shim's `path.resolve(__dirname, '..', 'sdk', 'dist', 'cli.js')`
+    // resolution). Instead it must write a tiny wrapper script that
+    // require()s the real shim by absolute path so __dirname stays correct.
+    const localBin = path.join(homeDir, '.local', 'bin');
+    fs.mkdirSync(localBin, { recursive: true });
+    process.env.PATH = `${localBin}${path.delimiter}${pathDir}`;
+
+    const realShimSrc = path.resolve(__dirname, '..', 'bin', 'gsd-sdk.js');
+    const origSymlink = fs.symlinkSync;
+    fs.symlinkSync = () => {
+      const err = new Error('EPERM: simulated symlink-hostile filesystem');
+      err.code = 'EPERM';
+      throw err;
+    };
+    try {
+      captureConsole(() => {
+        installSdkIfNeeded({ sdkDir });
+      });
+    } finally {
+      fs.symlinkSync = origSymlink;
+    }
+
+    const target = path.join(localBin, 'gsd-sdk');
+    assert.ok(fs.existsSync(target), `fallback must materialize ${target}`);
+    // Critical: it must NOT be a verbatim copy of bin/gsd-sdk.js.
+    const targetContent = fs.readFileSync(target, 'utf8');
+    const realShimContent = fs.readFileSync(realShimSrc, 'utf8');
+    assert.notStrictEqual(
+      targetContent,
+      realShimContent,
+      'fallback must not copyFileSync bin/gsd-sdk.js — that breaks __dirname-based CLI resolution',
+    );
+    // It must be a wrapper that require()s the real shim by absolute path.
+    assert.ok(
+      targetContent.includes('require(') && targetContent.includes(realShimSrc),
+      `fallback wrapper must require() the real shim by absolute path. Got:\n${targetContent}`,
+    );
+    // And it must be executable.
+    const st = fs.statSync(target);
+    assert.ok(
+      (st.mode & 0o111) !== 0,
+      `fallback wrapper must have execute bit set (mode=${st.mode.toString(8)})`,
+    );
+    // (Earlier assertions on targetContent already verify the wrapper points
+    // at the real shim by absolute path, which is what guarantees __dirname
+    // resolves correctly. A separate "does <pkg>/sdk/dist exist?" check would
+    // be tautological — that path is true regardless of what the wrapper
+    // wrote.) (#2775 CodeRabbit follow-up)
+  });
+
+  test('self-link prefers a PATH-backed HOME dir over ~/.local/bin when ~/.local/bin is off-PATH', () => {
+    // Regression for #2775 CodeRabbit follow-up: the candidate ordering must
+    // try PATH-backed HOME dirs FIRST, falling back to ~/.local/bin only when
+    // it's not on PATH. Otherwise we self-link to ~/.local/bin (off-PATH) and
+    // warn — when we could have linked to ~/bin (on-PATH) and printed success.
+    const homeBin = path.join(homeDir, 'bin');
+    fs.mkdirSync(homeBin, { recursive: true });
+    // PATH contains ~/bin (a HOME dir) but NOT ~/.local/bin.
+    process.env.PATH = `${homeBin}${path.delimiter}${pathDir}`;
+
+    const { stdout, stderr } = captureConsole(() => {
+      installSdkIfNeeded({ sdkDir });
+    });
+    const combined = `${stdout}\n${stderr}`;
+    assert.ok(
+      /GSD SDK ready/.test(combined),
+      `installer must self-link into the on-PATH HOME dir and print success. Output:\n${combined}`,
+    );
+    assert.ok(
+      fs.existsSync(path.join(homeBin, 'gsd-sdk')),
+      `installer must materialize the link in the on-PATH HOME dir (~/bin), not ~/.local/bin`,
+    );
+  });
+
+  test('DOES print "GSD SDK ready" when gsd-sdk is already resolvable on PATH', () => {
+    // Pre-populate PATH with a `gsd-sdk` shim so the probe finds one.
+    const preexisting = path.join(pathDir, 'gsd-sdk');
+    fs.writeFileSync(preexisting, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const { stdout } = captureConsole(() => {
+      installSdkIfNeeded({ sdkDir });
+    });
+    assert.ok(
+      /GSD SDK ready/.test(stdout),
+      `installer must print "GSD SDK ready" when gsd-sdk is already on PATH. Output:\n${stdout}`,
+    );
+  });
+});

--- a/tests/bug-2784-update-cache-clear-path.test.cjs
+++ b/tests/bug-2784-update-cache-clear-path.test.cjs
@@ -1,0 +1,86 @@
+/**
+ * Regression test for bug #2784
+ *
+ * /gsd-update cache-clear step only cleared per-runtime cache paths
+ * (e.g. ~/.claude/cache/gsd-update-check.json) but the SessionStart hook
+ * (hooks/gsd-check-update.js) writes to the shared tool-agnostic path
+ * ~/.cache/gsd/gsd-update-check.json. After a successful update, the statusline
+ * kept showing the stale "⬆ /gsd-update" indicator because the actual cache
+ * file was never deleted.
+ *
+ * Fix: add `rm -f "$HOME/.cache/gsd/gsd-update-check.json"` to the
+ * run_update step's cache-clear block in get-shit-done/workflows/update.md.
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const UPDATE_WORKFLOW = path.join(
+  REPO_ROOT,
+  'get-shit-done',
+  'workflows',
+  'update.md'
+);
+const CHECK_UPDATE_HOOK = path.join(REPO_ROOT, 'hooks', 'gsd-check-update.js');
+
+describe('bug-2784: update.md cache-clear covers shared cache path', () => {
+  test('gsd-check-update.js hook constructs cache dir from .cache and gsd path segments', () => {
+    const hookContent = fs.readFileSync(CHECK_UPDATE_HOOK, 'utf-8');
+    // Parse the path.join() call structurally rather than text-grepping.
+    const m = hookContent.match(/const cacheDir\s*=\s*path\.join\(([^)]+)\)/);
+    assert.ok(
+      m !== null,
+      'hook must assign cacheDir via path.join() with explicit path segments'
+    );
+    const segments = m[1].split(',').map((a) => a.trim().replace(/^['"]|['"]$/g, ''));
+    assert.ok(
+      segments.includes('.cache'),
+      `hook cacheDir path.join() must include '.cache' segment; got: ${JSON.stringify(segments)}`
+    );
+    assert.ok(
+      segments.includes('gsd'),
+      `hook cacheDir path.join() must include 'gsd' segment; got: ${JSON.stringify(segments)}`
+    );
+  });
+
+  test('update.md run_update bash commands include rm for shared gsd cache file', () => {
+    const workflowContent = fs.readFileSync(UPDATE_WORKFLOW, 'utf-8');
+    // Parse the step block structurally, then extract only bash fenced code lines.
+    const stepMatch = workflowContent.match(/<step name="run_update">[\s\S]*?<\/step>/);
+    assert.ok(stepMatch, 'update.md must have a <step name="run_update"> block');
+    const stepContent = stepMatch[0];
+
+    const bashLines = [];
+    const fenceRe = /```(?:bash|sh)\n([\s\S]*?)```/g;
+    let m;
+    while ((m = fenceRe.exec(stepContent)) !== null) {
+      for (const line of m[1].split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed) bashLines.push(trimmed);
+      }
+    }
+
+    const sharedCacheClearCmds = bashLines.filter(
+      (line) => /^rm\b/.test(line) && line.includes('.cache/gsd/gsd-update-check.json')
+    );
+    assert.ok(
+      sharedCacheClearCmds.length > 0,
+      [
+        'run_update step bash blocks must include an `rm` command targeting .cache/gsd/gsd-update-check.json.',
+        `Bash lines found: ${JSON.stringify(bashLines)}`,
+      ].join('\n')
+    );
+    const hasHomeExpansion = sharedCacheClearCmds.some(
+      (line) => line.includes('$HOME') || line.includes('~/')
+    );
+    assert.ok(
+      hasHomeExpansion,
+      `shared cache rm command must use $HOME or ~/ expansion; found: ${JSON.stringify(sharedCacheClearCmds)}`
+    );
+  });
+});

--- a/tests/bug-2787-milestone-fenced-block-truncation.test.cjs
+++ b/tests/bug-2787-milestone-fenced-block-truncation.test.cjs
@@ -1,0 +1,203 @@
+'use strict';
+
+/**
+ * Regression test for #2787:
+ * extractCurrentMilestone truncates ROADMAP.md at heading-like lines inside
+ * fenced code blocks. The nextMilestonePattern regex runs against the raw
+ * string with the `m` flag, which matches `^` at every newline — including
+ * newlines inside ``` blocks. A line like `# Ops runbook (v1.0 compat)` inside
+ * a fence matches the pattern and prematurely sets sectionEnd, hiding all
+ * phases defined after the fenced block.
+ */
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
+
+describe('extractCurrentMilestone — fenced code block boundary (#2787)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('roadmap analyze returns all phases when a fenced block contains a heading-like line matching the milestone-end pattern', () => {
+    // ROADMAP.md: milestone v1.1 with 4 phases. Between Phase 2 and Phase 3,
+    // a fenced code block contains `# Ops runbook — v1.0 compat`, which
+    // matches ^#{1,2}\s+.*v\d+\.\d+ (the nextMilestonePattern) and would
+    // prematurely terminate the milestone slice before the fix.
+    const roadmap = [
+      '# Project Roadmap',
+      '',
+      '## ✅ v1.0: Foundation',
+      '',
+      '<details>',
+      '<summary>✅ v1.0 Foundation — SHIPPED</summary>',
+      '',
+      '### Phase 1: Bootstrap',
+      '**Goal:** Bootstrap the project',
+      '',
+      '</details>',
+      '',
+      '## Roadmap v1.1: New Work',
+      '',
+      '### Phase 1: Setup',
+      '**Goal:** Set up the environment',
+      '',
+      '### Phase 2: Core Logic',
+      '**Goal:** Implement core logic',
+      '',
+      'Deployment notes:',
+      '',
+      '```bash',
+      '# Ops runbook — v1.0 compat',
+      'echo "deploy complete"',
+      '```',
+      '',
+      '### Phase 3: Testing',
+      '**Goal:** Write regression tests',
+      '',
+      '### Phase 4: Deploy',
+      '**Goal:** Ship to production',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), roadmap);
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      '---\nmilestone: v1.1\n---\n\n# GSD State\n'
+    );
+
+    const result = runGsdTools('roadmap analyze', tmpDir);
+    assert.ok(result.success, `roadmap analyze should succeed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(
+      output.phase_count,
+      4,
+      [
+        'All 4 phases in the v1.1 milestone section should be found.',
+        `Got ${output.phase_count} phase(s): ${JSON.stringify(output.phases?.map(p => p.number))}`,
+        'Phases 3 and 4 are likely being cut off by the fenced code block heading match.',
+      ].join(' ')
+    );
+  });
+
+  test('roadmap analyze returns all phases when a fenced block contains a backtick-tilde fence with milestone-like heading', () => {
+    // Verify tilde fences (~~~) are also tracked correctly.
+    const roadmap = [
+      '## Roadmap v2.0: Feature Work',
+      '',
+      '### Phase 1: Alpha',
+      '**Goal:** Alpha release',
+      '',
+      '~~~markdown',
+      '## Prior art (v1.9 snapshot)',
+      '~~~',
+      '',
+      '### Phase 2: Beta',
+      '**Goal:** Beta release',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), roadmap);
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      '---\nmilestone: v2.0\n---\n\n# GSD State\n'
+    );
+
+    const result = runGsdTools('roadmap analyze', tmpDir);
+    assert.ok(result.success, `roadmap analyze should succeed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(
+      output.phase_count,
+      2,
+      [
+        'Both phases in the v2.0 milestone section should be found.',
+        `Got ${output.phase_count} phase(s).`,
+        'Phase 2 is likely being cut off by the tilde-fenced heading match.',
+      ].join(' ')
+    );
+  });
+
+  test('fenced block with info string (e.g. ```js) is not closed by a nested info-string line', () => {
+    // A closing fence MUST have only optional trailing spaces — an info string
+    // like ```js inside an open fence must NOT close it. Before the fix the
+    // regex matched any line starting with ``` regardless of what followed, so
+    // a line like "```js" inside the fenced block would toggle fenceChar off
+    // and expose the heading-like line that follows to the milestone-end check.
+    const roadmap = [
+      '## Roadmap v3.0: Info-String Edge Case',
+      '',
+      '### Phase 1: Setup',
+      '**Goal:** First phase',
+      '',
+      '```text',
+      '```js',
+      '# This heading-like line (v3.0 compat) must NOT end the milestone',
+      '```',
+      '',
+      '### Phase 2: Core',
+      '**Goal:** Second phase',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), roadmap);
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      '---\nmilestone: v3.0\n---\n\n# GSD State\n'
+    );
+
+    const result = runGsdTools('roadmap analyze', tmpDir);
+    assert.ok(result.success, `roadmap analyze should succeed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(
+      output.phase_count,
+      2,
+      [
+        'Both phases should be found; the ```js line inside the fence must not close it.',
+        `Got ${output.phase_count} phase(s).`,
+      ].join(' ')
+    );
+  });
+
+  test('roadmap get-phase finds a phase defined after a fenced code block', () => {
+    const roadmap = [
+      '## Roadmap v1.1: New Work',
+      '',
+      '### Phase 1: Setup',
+      '**Goal:** Bootstrap',
+      '',
+      '```bash',
+      '# Runbook for v1.0 deploy',
+      '```',
+      '',
+      '### Phase 2: Core',
+      '**Goal:** Core implementation',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), roadmap);
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      '---\nmilestone: v1.1\n---\n\n# GSD State\n'
+    );
+
+    const result = runGsdTools('roadmap get-phase 2', tmpDir);
+    assert.ok(result.success, `roadmap get-phase should succeed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(
+      output.found,
+      [
+        'Phase 2 should be found even though it comes after a fenced code block.',
+        `Got: found=${output.found}`,
+      ].join(' ')
+    );
+    assert.strictEqual(output.phase_number, '2', 'should return phase number 2');
+  });
+});

--- a/tests/bug-2788-audit-uat-frontmatter.test.cjs
+++ b/tests/bug-2788-audit-uat-frontmatter.test.cjs
@@ -1,0 +1,175 @@
+/**
+ * Regression test for bug #2788
+ *
+ * `gsd-sdk query audit-uat` returned total_items: 0 for VERIFICATION.md
+ * files where human-needed items were encoded in the frontmatter
+ * `human_verification:` YAML array (the format written by gsd-verifier),
+ * or where the body section heading used `## human_verification` (underscore)
+ * instead of `## Human Verification` (space).
+ *
+ * Root cause:
+ * 1. parseVerificationItems only searched the body for "## Human Verification"
+ *    (space, case-insensitive) — never read frontmatter.
+ * 2. The body-section regex did not accept underscore in the heading name.
+ *
+ * Fix: parseVerificationItems now reads the frontmatter human_verification:
+ * array first (via extractFrontmatter). Falls back to body-section scan
+ * with a relaxed regex that accepts underscore and parenthetical suffixes.
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { createTempProject, cleanup } = require('./helpers.cjs');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SDK_CLI = path.join(REPO_ROOT, 'sdk', 'dist', 'cli.js');
+
+function runAuditUat(projectDir) {
+  const argv = ['query', 'audit-uat', '--project-dir', projectDir];
+  let stdout = '';
+  let exitCode = 0;
+  try {
+    stdout = execFileSync(process.execPath, [SDK_CLI, ...argv], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, GSD_SESSION_KEY: '' },
+    });
+  } catch (err) {
+    exitCode = err.status ?? 1;
+    stdout = err.stdout?.toString() ?? '';
+  }
+  let json = null;
+  try { json = JSON.parse(stdout.trim()); } catch { /* ok */ }
+  return { exitCode, json };
+}
+
+/** Set up a project with a ROADMAP.md milestone and a phase VERIFICATION.md */
+function setupProject(tmpDir, verificationContent) {
+  const planningDir = path.join(tmpDir, '.planning');
+  const phaseDir = path.join(planningDir, 'phases', '03-invoicing');
+  fs.mkdirSync(phaseDir, { recursive: true });
+
+  // Write a minimal ROADMAP.md so getMilestonePhaseFilter works
+  fs.writeFileSync(
+    path.join(planningDir, 'ROADMAP.md'),
+    [
+      '# Roadmap',
+      '',
+      '## v1.0 — MVP',
+      '',
+      '### Phase 3: Invoicing',
+    ].join('\n')
+  );
+
+  // Write STATE.md with current milestone
+  fs.writeFileSync(
+    path.join(planningDir, 'STATE.md'),
+    [
+      '---',
+      'version: "v1.0"',
+      '---',
+      '# State',
+    ].join('\n')
+  );
+
+  fs.writeFileSync(
+    path.join(phaseDir, '03-invoicing-VERIFICATION.md'),
+    verificationContent
+  );
+}
+
+describe('bug-2788: audit-uat reads frontmatter human_verification array', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-test-2788-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('frontmatter human_verification: array items are reported', () => {
+    // This is the format gsd-verifier writes; before fix total_items was 0
+    const content = [
+      '---',
+      'phase: 03-invoicing',
+      'status: human_needed',
+      'human_verification:',
+      '  - test: "Manual frontend smoke — /invoices, /invoices/new"',
+      '    expected: "All four routes render correctly"',
+      '    why_human: "Visual rendering cannot be verified by static code inspection"',
+      '  - test: "Run integration test suite against a real Postgres"',
+      '    expected: "105 currently-skipped tests pass green"',
+      '    why_human: "Docker not installed locally"',
+      '---',
+      '',
+      '# Phase 3 Verification Report',
+      '',
+      'No body Human Verification section here.',
+    ].join('\n');
+
+    setupProject(tmpDir, content);
+    const result = runAuditUat(tmpDir);
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0');
+    assert.ok(result.json !== null, 'should emit JSON');
+    assert.ok(
+      result.json.summary.total_items >= 2,
+      `total_items should be >= 2, got ${result.json.summary.total_items}`
+    );
+  });
+
+  test('body ## human_verification (underscore) heading is parsed', () => {
+    const content = [
+      '---',
+      'phase: 03-invoicing',
+      'status: human_needed',
+      '---',
+      '',
+      '# Phase 3 Verification Report',
+      '',
+      '## human_verification (action required by Sammy)',
+      '',
+      '- Manual frontend smoke — /invoices, /invoices/new: verify all four routes render',
+      '- Run integration test suite against a real Postgres database',
+    ].join('\n');
+
+    setupProject(tmpDir, content);
+    const result = runAuditUat(tmpDir);
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0');
+    assert.ok(result.json !== null, 'should emit JSON');
+    assert.ok(
+      result.json.summary.total_items >= 2,
+      `total_items should be >= 2, got ${result.json.summary.total_items}`
+    );
+  });
+
+  test('body ## Human Verification (space) heading still works', () => {
+    const content = [
+      '---',
+      'phase: 03-invoicing',
+      'status: human_needed',
+      '---',
+      '',
+      '# Phase 3 Verification Report',
+      '',
+      '## Human Verification',
+      '',
+      '- Manual frontend smoke test — verify all four routes render correctly or describe what breaks',
+      '- Run integration test suite: 105 tests must pass green',
+    ].join('\n');
+
+    setupProject(tmpDir, content);
+    const result = runAuditUat(tmpDir);
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0');
+    assert.ok(result.json?.summary.total_items >= 2, `total_items should be >= 2`);
+  });
+});

--- a/tests/bug-2791-sdk-workstream-env.test.cjs
+++ b/tests/bug-2791-sdk-workstream-env.test.cjs
@@ -1,0 +1,170 @@
+/**
+ * Regression test for bug #2791 (Issue 2 — query registry not workstream-aware)
+ *
+ * When GSD_WORKSTREAM is set in the environment, `gsd-sdk query` commands must
+ * route .planning/ reads to `.planning/workstreams/<name>/` — matching the
+ * behaviour of `gsd-tools.cjs` which reads the same env var via planningDir().
+ *
+ * Before the fix: the SDK CLI only respected `--ws <name>` flag; GSD_WORKSTREAM
+ * was ignored, so `gsd-sdk query roadmap.analyze` always read the root
+ * `.planning/ROADMAP.md` even when a workstream was active.
+ *
+ * After the fix: the SDK CLI falls back to GSD_WORKSTREAM when --ws is absent.
+ *
+ * This test also verifies:
+ * - The `gsd-tools` bin alias maps to the same SDK shim as `gsd-sdk` (#2791 Issue 1)
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const childProc = require('node:child_process');
+const { cleanup } = require('./helpers.cjs');
+const os = require('node:os');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SDK_CLI = path.join(REPO_ROOT, 'sdk', 'dist', 'cli.js');
+const PKG_JSON = path.join(REPO_ROOT, 'package.json');
+
+function runSdkQuery(args, projectDir, extraEnv = {}) {
+  let stdout = '';
+  let exitCode = 0;
+  try {
+    stdout = childProc.execFileSync(
+      process.execPath,
+      [SDK_CLI, 'query', ...args, '--project-dir', projectDir],
+      {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, GSD_SESSION_KEY: '', ...extraEnv },
+      }
+    );
+  } catch (err) {
+    exitCode = err.status ?? 1;
+    stdout = (err.stdout?.toString() ?? '') + (err.stderr?.toString() ?? '');
+  }
+  let json = null;
+  try { json = JSON.parse(stdout.trim()); } catch { /* ok */ }
+  return { exitCode, stdout, json };
+}
+
+describe('bug-2791: GSD_WORKSTREAM env var respected by gsd-sdk query', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-test-2791-'));
+    // Create root .planning/ with a minimal config
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({ mode: 'balanced' }));
+    // Create workstream .planning/workstreams/my-ws/ with its own ROADMAP
+    const wsDir = path.join(tmpDir, '.planning', 'workstreams', 'my-ws');
+    fs.mkdirSync(path.join(wsDir, 'phases'), { recursive: true });
+    fs.writeFileSync(
+      path.join(wsDir, 'config.json'),
+      JSON.stringify({ mode: 'balanced' })
+    );
+    fs.writeFileSync(
+      path.join(wsDir, 'STATE.md'),
+      '---\nmilestone: v1.0\n---\n\n# GSD State\n\n**Current Phase:** 1\n'
+    );
+    fs.writeFileSync(
+      path.join(wsDir, 'ROADMAP.md'),
+      [
+        '## Roadmap v1.0: Workstream Work',
+        '',
+        '### Phase 1: Workstream Phase',
+        '**Goal:** Test workstream routing',
+        '- [ ] Task A',
+      ].join('\n')
+    );
+    // Also create a root ROADMAP that is intentionally empty of phases
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '## Roadmap v1.0: Root\n\n(no phases in root)\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      '---\nmilestone: v1.0\n---\n\n# GSD State\n'
+    );
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('without GSD_WORKSTREAM: roadmap.analyze reads root .planning/ROADMAP.md', () => {
+    const result = runSdkQuery(['roadmap.analyze'], tmpDir);
+    assert.strictEqual(result.exitCode, 0, `expected exit 0: ${result.stdout}`);
+    assert.ok(result.json !== null, 'expected JSON output');
+    // Root ROADMAP has no phases
+    assert.strictEqual(
+      result.json.phase_count,
+      0,
+      `expected 0 phases from root ROADMAP, got ${result.json.phase_count}`
+    );
+  });
+
+  test('with GSD_WORKSTREAM set: roadmap.analyze reads workstream ROADMAP.md', () => {
+    const result = runSdkQuery(['roadmap.analyze'], tmpDir, { GSD_WORKSTREAM: 'my-ws' });
+    assert.strictEqual(result.exitCode, 0, `expected exit 0: ${result.stdout}`);
+    assert.ok(result.json !== null, 'expected JSON output');
+    // Workstream ROADMAP has 1 phase
+    assert.strictEqual(
+      result.json.phase_count,
+      1,
+      `expected 1 phase from workstream ROADMAP, got ${result.json.phase_count}`
+    );
+  });
+
+  test('--ws flag takes precedence over GSD_WORKSTREAM env var', () => {
+    // Set GSD_WORKSTREAM to a non-existent workstream; --ws should override it.
+    // This verifies flag-wins-over-env precedence, not just that --ws works.
+    const result = runSdkQuery(['roadmap.analyze', '--ws', 'my-ws'], tmpDir, {
+      GSD_WORKSTREAM: 'nonexistent-ws',
+    });
+    assert.strictEqual(result.exitCode, 0, `expected exit 0: ${result.stdout}`);
+    assert.ok(result.json !== null, 'expected JSON output');
+    // --ws my-ws should route to the workstream ROADMAP which has 1 phase,
+    // proving the flag overrides the env var (nonexistent-ws has no phases).
+    assert.strictEqual(
+      result.json.phase_count,
+      1,
+      `expected 1 phase via --ws flag (overriding GSD_WORKSTREAM), got ${result.json.phase_count}`
+    );
+  });
+
+  test('invalid GSD_WORKSTREAM value is silently ignored and falls back to root', () => {
+    const result = runSdkQuery(['roadmap.analyze'], tmpDir, { GSD_WORKSTREAM: '../evil' });
+    // Should not crash; invalid name is silently ignored and falls back to root ROADMAP.
+    assert.strictEqual(result.exitCode, 0, `expected exit 0 (invalid GSD_WORKSTREAM ignored): ${result.stdout}`);
+    assert.ok(result.json !== null, 'expected JSON output after invalid GSD_WORKSTREAM fallback');
+    // Root ROADMAP has no phases — confirming root fallback, not an error path.
+    assert.strictEqual(
+      result.json.phase_count,
+      0,
+      `expected 0 phases from root ROADMAP fallback (invalid GSD_WORKSTREAM), got ${result.json.phase_count}`
+    );
+  });
+});
+
+describe('bug-2791: package.json declares gsd-tools bin alias (#2791 Issue 1)', () => {
+  test('package.json bin has gsd-tools entry', () => {
+    const pkg = JSON.parse(fs.readFileSync(PKG_JSON, 'utf-8'));
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(pkg.bin ?? {}, 'gsd-tools'),
+      'package.json bin must include "gsd-tools" to provide collision-free alternative to gsd-sdk'
+    );
+  });
+
+  test('gsd-tools bin entry points to same file as gsd-sdk', () => {
+    const pkg = JSON.parse(fs.readFileSync(PKG_JSON, 'utf-8'));
+    assert.strictEqual(
+      pkg.bin['gsd-tools'],
+      pkg.bin['gsd-sdk'],
+      'gsd-tools and gsd-sdk must point to the same bin shim'
+    );
+  });
+});

--- a/tests/bug-2794-opencode-model-profile-overrides.test.cjs
+++ b/tests/bug-2794-opencode-model-profile-overrides.test.cjs
@@ -1,0 +1,243 @@
+/**
+ * Regression test for bug #2794
+ *
+ * OpenCode generated agents ignored `model_profile_overrides.opencode.*`.
+ * The agent install path called `readGsdEffectiveModelOverrides` (explicit
+ * per-agent overrides) but never called `readGsdRuntimeProfileResolver`
+ * (tier-based profile overrides). When a user configured:
+ *
+ *   { runtime: "opencode", model_profile_overrides: { opencode: { sonnet: "..." } } }
+ *
+ * generated `.opencode/agents/gsd-*.md` files contained no `model:` frontmatter.
+ *
+ * The fix adds a tier-resolver fallback in the OpenCode agent conversion block:
+ * explicit `model_overrides[agent]` > `model_profile_overrides.opencode.<tier>` > omit.
+ *
+ * This test exercises:
+ * 1. `readGsdRuntimeProfileResolver` correctly resolves OpenCode tier overrides.
+ * 2. The agent install code path embeds the resolved model into OpenCode frontmatter.
+ * 3. Explicit `model_overrides` still wins over tier-based resolution.
+ * 4. Missing overrides produce no `model:` field (no regression on omit behavior).
+ */
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const {
+  readGsdRuntimeProfileResolver,
+  readGsdEffectiveModelOverrides,
+  convertClaudeToOpencodeFrontmatter,
+  install,
+} = require('../bin/install.js');
+
+function makeTmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `gsd-2794-${prefix}-`));
+}
+
+function writeJson(p, obj) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(obj, null, 2), 'utf-8');
+}
+
+function rmr(p) {
+  try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+describe('bug-2794: readGsdRuntimeProfileResolver resolves opencode tier overrides', () => {
+  let projectDir;
+  let homeDir;
+  let origHome;
+
+  beforeEach(() => {
+    projectDir = makeTmp('proj');
+    homeDir = makeTmp('home');
+    origHome = process.env.HOME;
+    process.env.HOME = homeDir;
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origHome;
+    rmr(projectDir);
+    rmr(homeDir);
+  });
+
+  test('resolves opencode sonnet tier to user-supplied model ID', () => {
+    writeJson(path.join(projectDir, '.planning', 'config.json'), {
+      runtime: 'opencode',
+      model_profile: 'balanced',
+      model_profile_overrides: {
+        opencode: {
+          sonnet: 'anthropic/claude-sonnet-4-7',
+        },
+      },
+    });
+
+    const resolver = readGsdRuntimeProfileResolver(projectDir);
+    assert.ok(resolver !== null, 'expected a resolver for opencode runtime');
+
+    // gsd-roadmapper balanced tier = sonnet — should resolve to override
+    const entry = resolver.resolve('gsd-roadmapper');
+    assert.ok(entry !== null, 'expected entry for gsd-roadmapper');
+    assert.strictEqual(entry.model, 'anthropic/claude-sonnet-4-7', 'sonnet override applied');
+  });
+
+  test('returns null resolver when runtime is not set', () => {
+    writeJson(path.join(projectDir, '.planning', 'config.json'), {
+      model_profile: 'balanced',
+      model_profile_overrides: { opencode: { sonnet: 'x' } },
+    });
+    const resolver = readGsdRuntimeProfileResolver(projectDir);
+    assert.strictEqual(resolver, null, 'no resolver without runtime field');
+  });
+
+  test('resolver returns null for agent not in MODEL_PROFILES', () => {
+    writeJson(path.join(projectDir, '.planning', 'config.json'), {
+      runtime: 'opencode',
+      model_profile: 'balanced',
+      model_profile_overrides: { opencode: { sonnet: 'x' } },
+    });
+    const resolver = readGsdRuntimeProfileResolver(projectDir);
+    assert.ok(resolver !== null);
+    const entry = resolver.resolve('gsd-nonexistent-agent');
+    assert.strictEqual(entry, null, 'unknown agent name yields null');
+  });
+});
+
+describe('bug-2794: OpenCode agent install embeds model_profile_overrides model', () => {
+  let projectDir;
+  let homeDir;
+  let origHome;
+  let origCwd;
+
+  beforeEach(() => {
+    projectDir = makeTmp('proj');
+    homeDir = makeTmp('home');
+    origHome = process.env.HOME;
+    origCwd = process.cwd();
+    process.env.HOME = homeDir;
+    process.chdir(projectDir);
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origHome;
+    process.chdir(origCwd);
+    rmr(projectDir);
+    rmr(homeDir);
+  });
+
+  test('generated OpenCode agent frontmatter includes model from model_profile_overrides', () => {
+    writeJson(path.join(projectDir, '.planning', 'config.json'), {
+      runtime: 'opencode',
+      model_profile: 'balanced',
+      model_profile_overrides: {
+        opencode: {
+          sonnet: 'anthropic/claude-sonnet-4-7',
+          opus: 'anthropic/claude-opus-4-7',
+          haiku: 'anthropic/claude-haiku-4-5',
+        },
+      },
+    });
+
+    const oldLog = console.log;
+    console.log = () => {};
+    try {
+      install(false, 'opencode');
+    } finally {
+      console.log = oldLog;
+    }
+
+    const agentsDir = path.join(projectDir, '.opencode', 'agents');
+    assert.ok(fs.existsSync(agentsDir), 'agents directory should be created');
+
+    // gsd-roadmapper is balanced -> sonnet tier
+    const roadmapperPath = path.join(agentsDir, 'gsd-roadmapper.md');
+    assert.ok(fs.existsSync(roadmapperPath), 'gsd-roadmapper.md should exist');
+    const roadmapperContent = fs.readFileSync(roadmapperPath, 'utf-8');
+    assert.match(
+      roadmapperContent,
+      /^model: anthropic\/claude-sonnet-4-7$/m,
+      'gsd-roadmapper should have sonnet model from model_profile_overrides'
+    );
+
+    // gsd-planner is balanced -> opus tier
+    const plannerPath = path.join(agentsDir, 'gsd-planner.md');
+    assert.ok(fs.existsSync(plannerPath), 'gsd-planner.md should exist');
+    const plannerContent = fs.readFileSync(plannerPath, 'utf-8');
+    assert.match(
+      plannerContent,
+      /^model: anthropic\/claude-opus-4-7$/m,
+      'gsd-planner should have opus model from model_profile_overrides'
+    );
+  });
+
+  test('explicit model_overrides[agent] wins over model_profile_overrides tier', () => {
+    writeJson(path.join(projectDir, '.planning', 'config.json'), {
+      runtime: 'opencode',
+      model_profile: 'balanced',
+      model_overrides: {
+        'gsd-roadmapper': 'explicit-winner-model',
+      },
+      model_profile_overrides: {
+        opencode: {
+          sonnet: 'tier-model-that-should-lose',
+        },
+      },
+    });
+
+    const oldLog = console.log;
+    console.log = () => {};
+    try {
+      install(false, 'opencode');
+    } finally {
+      console.log = oldLog;
+    }
+
+    const roadmapperPath = path.join(projectDir, '.opencode', 'agents', 'gsd-roadmapper.md');
+    assert.ok(fs.existsSync(roadmapperPath));
+    const content = fs.readFileSync(roadmapperPath, 'utf-8');
+    assert.match(
+      content,
+      /^model: explicit-winner-model$/m,
+      'explicit model_overrides must win over model_profile_overrides tier'
+    );
+    assert.doesNotMatch(
+      content,
+      /tier-model-that-should-lose/,
+      'tier model must not appear when explicit override is present'
+    );
+  });
+
+  test('no model field when neither model_overrides nor model_profile_overrides is set', () => {
+    writeJson(path.join(projectDir, '.planning', 'config.json'), {
+      runtime: 'opencode',
+      model_profile: 'balanced',
+    });
+
+    const oldLog = console.log;
+    console.log = () => {};
+    try {
+      install(false, 'opencode');
+    } finally {
+      console.log = oldLog;
+    }
+
+    const roadmapperPath = path.join(projectDir, '.opencode', 'agents', 'gsd-roadmapper.md');
+    if (fs.existsSync(roadmapperPath)) {
+      const content = fs.readFileSync(roadmapperPath, 'utf-8');
+      // When no overrides, model field should either be absent or use built-in default
+      // The key invariant: no model field if there are no user-supplied overrides
+      // AND no built-in opencode defaults for this tier
+      // (gsd-roadmapper balanced = sonnet; opencode has built-in sonnet defaults)
+      // So we only assert no crash and no tier-model-not-provided entries
+      assert.ok(typeof content === 'string', 'agent file should be a string');
+    }
+    // Key: no exception thrown (test passes = no crash on missing overrides)
+  });
+});

--- a/tests/bug-2796-arg-parsing-regression.test.cjs
+++ b/tests/bug-2796-arg-parsing-regression.test.cjs
@@ -1,0 +1,153 @@
+/**
+ * Regression test for bug #2796
+ *
+ * roadmap.update-plan-progress used positional-only arg destructuring:
+ * `const phaseNum = args[0]`. When called with the flag form documented in
+ * execute-phase.md:228 (`--phase "TEST" --plan "01" --status "complete"`),
+ * args[0] was the literal string "--phase", which was passed to findPhase().
+ * findPhase found no phase named "--phase" and returned `updated: false` with
+ * `reason: "no matching checkbox found"`, silently no-oping. ROADMAP.md plan
+ * checkboxes never advanced.
+ *
+ * The stateBeginPhase handler already uses parseNamedArgs and is NOT affected.
+ *
+ * Fix: roadmap-update-plan-progress.ts now checks for --phase <value> before
+ * falling back to positional arg[0] (filtering out flag tokens).
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { createTempGitProject, cleanup } = require('./helpers.cjs');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SDK_CLI = path.join(REPO_ROOT, 'sdk', 'dist', 'cli.js');
+
+function runSdkQuery(subcommand, args, projectDir) {
+  const argv = ['query', subcommand, ...args, '--project-dir', projectDir];
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 0;
+  try {
+    stdout = execFileSync(process.execPath, [SDK_CLI, ...argv], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, GSD_SESSION_KEY: '' },
+    });
+  } catch (err) {
+    exitCode = err.status ?? 1;
+    stdout = err.stdout?.toString() ?? '';
+    stderr = err.stderr?.toString() ?? '';
+  }
+  let json = null;
+  try { json = JSON.parse(stdout.trim()); } catch { /* ok */ }
+  return { exitCode, stdout: stdout.trim(), stderr: stderr.trim(), json };
+}
+
+/** Create a minimal ROADMAP.md with a phase checkbox */
+function createRoadmap(projectDir, phaseNum, planLabel) {
+  const planningDir = path.join(projectDir, '.planning');
+  fs.mkdirSync(path.join(planningDir, 'phases'), { recursive: true });
+
+  const roadmap = [
+    '# My Project Roadmap',
+    '',
+    '## v1.0 — MVP',
+    '',
+    `### Phase ${phaseNum}: Test Phase`,
+    '',
+    `**Plans:** 1/1 plans complete`,
+    '',
+    `| # | Phase | Plans | Status | Date |`,
+    `|---|-------|-------|--------|------|`,
+    `| ${phaseNum} | Test Phase | 0/1 | Planned | |`,
+    '',
+    `- [ ] ${planLabel}: Do the thing`,
+    '',
+  ].join('\n');
+
+  fs.writeFileSync(path.join(planningDir, 'ROADMAP.md'), roadmap);
+
+  // Create the phase directory so findPhase finds it
+  const phaseDir = path.join(
+    planningDir, 'phases',
+    `${String(phaseNum).padStart(2, '0')}-test-phase`
+  );
+  fs.mkdirSync(phaseDir, { recursive: true });
+
+  // Create a plan file and a summary so progress = 1/1
+  fs.writeFileSync(path.join(phaseDir, `${planLabel}-PLAN.md`), '# Plan\n');
+  fs.writeFileSync(path.join(phaseDir, `${planLabel}-SUMMARY.md`), '# Summary\n');
+
+  return phaseDir;
+}
+
+describe('bug-2796: roadmap update-plan-progress accepts --phase flag', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject('gsd-test-2796-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('flag form --phase <N> resolves the correct phase (not literal "--phase")', () => {
+    createRoadmap(tmpDir, '9', '01');
+
+    // Flag form: this is the form execute-phase.md:228 uses
+    const result = runSdkQuery(
+      'roadmap.update-plan-progress',
+      ['--phase', '9'],
+      tmpDir
+    );
+
+    // Before fix: exitCode=1 with "phase --phase not found" or updated:false
+    // After fix: should succeed with phase="9" and updated:true
+    assert.strictEqual(result.exitCode, 0, `should exit 0; stderr: ${result.stderr}`);
+    assert.ok(result.json !== null, 'should emit JSON');
+    assert.ok(result.json.updated === true, 'updated should be true');
+    assert.strictEqual(String(result.json.phase), '9', 'phase should be "9", not "--phase"');
+  });
+
+  test('positional form still works (backward compat)', () => {
+    createRoadmap(tmpDir, '9', '01');
+
+    const result = runSdkQuery(
+      'roadmap.update-plan-progress',
+      ['9'],
+      tmpDir
+    );
+
+    assert.strictEqual(result.exitCode, 0, `should exit 0; stderr: ${result.stderr}`);
+    assert.ok(result.json?.updated === true, 'updated should be true');
+    assert.strictEqual(String(result.json.phase), '9', 'phase should be "9"');
+  });
+
+  test('flag form does not pass "--phase" as the phase value to findPhase', () => {
+    // Before fix: findPhase("--phase") returned found:false, causing updated:false
+    // This test confirms the phase value is not the flag name itself.
+    createRoadmap(tmpDir, '5', '01');
+
+    const result = runSdkQuery(
+      'roadmap.update-plan-progress',
+      ['--phase', '5'],
+      tmpDir
+    );
+
+    // If the phase was "--phase", we'd get an error like "Phase --phase not found"
+    assert.ok(
+      !result.stderr.includes('--phase not found'),
+      'stderr must not say "--phase not found"'
+    );
+    assert.ok(
+      !result.stderr.includes('"--phase"'),
+      'stderr must not treat "--phase" as the phase value'
+    );
+  });
+});

--- a/tests/bug-2798-context-window-config-key.test.cjs
+++ b/tests/bug-2798-context-window-config-key.test.cjs
@@ -1,0 +1,89 @@
+/**
+ * Regression test for bug #2798
+ *
+ * `gsd-sdk query config-set context_window <n>` was rejected with
+ * "Unknown config key: context_window" because context_window was missing
+ * from VALID_CONFIG_KEYS in sdk/src/query/config-schema.ts.
+ *
+ * The fix added 'context_window' to the allowlist.
+ * This test prevents future drift where the key gets accidentally removed.
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { createTempProject, cleanup } = require('./helpers.cjs');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SDK_CLI = path.join(REPO_ROOT, 'sdk', 'dist', 'cli.js');
+
+function runConfigSet(key, value, projectDir) {
+  const argv = ['query', 'config-set', key, String(value), '--project-dir', projectDir];
+  let stdout = '';
+  let exitCode = 0;
+  try {
+    stdout = execFileSync(process.execPath, [SDK_CLI, ...argv], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, GSD_SESSION_KEY: '' },
+    });
+  } catch (err) {
+    exitCode = err.status ?? 1;
+    stdout = err.stdout?.toString() ?? '';
+  }
+  let json = null;
+  try { json = JSON.parse(stdout.trim()); } catch { /* ok */ }
+  return { exitCode, json };
+}
+
+describe('bug-2798: context_window is a valid config key', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-test-2798-');
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ mode: 'balanced' })
+    );
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('config-set context_window succeeds (not rejected as unknown key)', () => {
+    const result = runConfigSet('context_window', 1000000, tmpDir);
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 (key is valid)');
+    assert.ok(result.json !== null, 'should emit JSON');
+    assert.strictEqual(result.json?.updated, true, 'updated should be true');
+    assert.strictEqual(result.json?.key, 'context_window');
+  });
+
+  test('context_window value is written to config.json', () => {
+    runConfigSet('context_window', 500000, tmpDir);
+
+    const config = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, '.planning', 'config.json'), 'utf-8')
+    );
+    assert.strictEqual(config.context_window, 500000, 'context_window should be persisted');
+  });
+
+  test('config-schema CJS and SDK allowlists both include context_window', () => {
+    const cjsSchema = require(path.join(REPO_ROOT, 'get-shit-done', 'bin', 'lib', 'config-schema.cjs'));
+    const sdkSchema = require(path.join(REPO_ROOT, 'sdk', 'dist', 'query', 'config-schema.js'));
+
+    assert.ok(
+      cjsSchema.VALID_CONFIG_KEYS.has('context_window'),
+      'CJS VALID_CONFIG_KEYS must include context_window'
+    );
+    assert.ok(
+      sdkSchema.VALID_CONFIG_KEYS.has('context_window'),
+      'SDK VALID_CONFIG_KEYS must include context_window'
+    );
+  });
+});

--- a/tests/bug-2801-ingest-docs-handler.test.cjs
+++ b/tests/bug-2801-ingest-docs-handler.test.cjs
@@ -1,0 +1,140 @@
+/**
+ * Regression test for bug #2801
+ *
+ * `/gsd-ingest-docs` was broken because:
+ * 1. `workflows/ingest-docs.md` called `gsd-sdk query init.ingest-docs` but the
+ *    installed binary is `gsd-tools` (not `gsd-sdk`).
+ * 2. `gsd-tools init` had no `ingest-docs` case in its dispatch switch.
+ *
+ * The fix:
+ * - Added `case 'ingest-docs'` to the `init` switch in `gsd-tools.cjs`.
+ * - Exported `cmdInitIngestDocs` from `init.cjs`.
+ * - Updated `workflows/ingest-docs.md` to call `gsd-tools init ingest-docs`.
+ *
+ * This test prevents regression of the dispatch omission.
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const childProc = require('node:child_process');
+const { createTempProject, cleanup, TOOLS_PATH } = require('./helpers.cjs');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const WORKFLOW_FILE = path.join(REPO_ROOT, 'get-shit-done', 'workflows', 'ingest-docs.md');
+
+function spawnGsdTools(args, projectDir) {
+  let stdout = '';
+  let exitCode = 0;
+  try {
+    stdout = childProc.execFileSync(
+      process.execPath,
+      [TOOLS_PATH, ...args, '--cwd', projectDir],
+      {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, GSD_SESSION_KEY: '' },
+      }
+    );
+  } catch (err) {
+    exitCode = err.status ?? 1;
+    stdout = (err.stdout?.toString() ?? '') + (err.stderr?.toString() ?? '');
+  }
+  return { exitCode, stdout };
+}
+
+describe('bug-2801: gsd-tools init ingest-docs handler exists', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-test-2801-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('init ingest-docs exits 0 (not "Unknown init workflow")', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0, `expected exit 0, got: ${stdout}`);
+  });
+
+  test('init ingest-docs returns JSON with project_exists field', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0);
+    let json;
+    try { json = JSON.parse(stdout.trim()); } catch { assert.fail(`non-JSON output: ${stdout}`); }
+    assert.ok(Object.prototype.hasOwnProperty.call(json, 'project_exists'), 'project_exists present');
+  });
+
+  test('init ingest-docs returns JSON with planning_exists field', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0);
+    const json = JSON.parse(stdout.trim());
+    assert.ok(Object.prototype.hasOwnProperty.call(json, 'planning_exists'), 'planning_exists present');
+  });
+
+  test('init ingest-docs returns JSON with has_git field', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0);
+    const json = JSON.parse(stdout.trim());
+    assert.ok(Object.prototype.hasOwnProperty.call(json, 'has_git'), 'has_git present');
+  });
+
+  test('init ingest-docs returns JSON with project_path field', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0);
+    const json = JSON.parse(stdout.trim());
+    assert.ok(Object.prototype.hasOwnProperty.call(json, 'project_path'), 'project_path present');
+    assert.ok(Object.prototype.hasOwnProperty.call(json, 'commit_docs'), 'commit_docs present');
+  });
+
+  test('planning_exists is true when .planning/ directory exists', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0);
+    const json = JSON.parse(stdout.trim());
+    assert.strictEqual(json.planning_exists, true, 'planning_exists should be true (.planning/ created by createTempProject)');
+  });
+});
+
+describe('bug-2801: ingest-docs.md workflow calls gsd-tools not gsd-sdk', () => {
+  test('no bash code block in ingest-docs.md calls gsd-sdk', () => {
+    const content = fs.readFileSync(WORKFLOW_FILE, 'utf-8');
+    // Extract bash fenced code blocks structurally.
+    const bashBlocks = [];
+    const codeBlockRe = /```bash\n([\s\S]*?)```/g;
+    let m;
+    while ((m = codeBlockRe.exec(content)) !== null) {
+      bashBlocks.push(m[1]);
+    }
+    assert.ok(bashBlocks.length > 0, 'expected bash code blocks in workflow');
+
+    // Check every line in every bash block — not just lines that start with the token,
+    // since gsd-sdk can appear in subshell expansions like $(gsd-sdk query ...).
+    const sdkCalls = bashBlocks
+      .join('\n')
+      .split('\n')
+      .filter((line) => /\bgsd-sdk\b/.test(line));
+
+    assert.deepStrictEqual(
+      sdkCalls,
+      [],
+      `workflow bash blocks still reference gsd-sdk (should use gsd-tools): ${sdkCalls.join(', ')}`
+    );
+  });
+
+  test('ingest-docs.md init step uses gsd-tools init ingest-docs', () => {
+    const content = fs.readFileSync(WORKFLOW_FILE, 'utf-8');
+    const lines = content.split('\n');
+    const initLine = lines.find(l => /gsd-tools\s+init\s+ingest-docs/.test(l));
+    assert.ok(initLine, 'workflow must contain "gsd-tools init ingest-docs"');
+  });
+
+  test('cmdInitIngestDocs is exported from init.cjs', () => {
+    const init = require(path.join(REPO_ROOT, 'get-shit-done', 'bin', 'lib', 'init.cjs'));
+    assert.strictEqual(typeof init.cmdInitIngestDocs, 'function', 'cmdInitIngestDocs must be exported');
+  });
+});

--- a/tests/bug-2803-config-get-default-flag.test.cjs
+++ b/tests/bug-2803-config-get-default-flag.test.cjs
@@ -1,0 +1,132 @@
+/**
+ * Regression test for bug #2803
+ *
+ * `gsd-sdk query config-get <key> --default <value>` silently ignored the
+ * --default flag. When the key was missing, the SDK threw "Error: Key not found"
+ * and exited 1, identical to calling it without --default.
+ *
+ * The CJS path (gsd-tools.cjs config-get <key> --default <value>) honored
+ * --default correctly since #1893. The SDK handler was never ported.
+ *
+ * Fix: configGet in sdk/src/query/config-query.ts now strips --default <value>
+ * from args before key lookup and returns { data: defaultValue } instead of
+ * throwing when the key is absent (config missing, key missing, or nested
+ * object missing).
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { createTempProject, cleanup } = require('./helpers.cjs');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SDK_CLI = path.join(REPO_ROOT, 'sdk', 'dist', 'cli.js');
+
+/**
+ * Invoke `gsd-sdk query config-get <...args>` against a project dir.
+ * Returns { exitCode, stdout, stderr }.
+ */
+function runConfigGet(args, projectDir) {
+  const argv = ['query', 'config-get', ...args, '--project-dir', projectDir];
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 0;
+  try {
+    stdout = execFileSync(process.execPath, [SDK_CLI, ...argv], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, GSD_SESSION_KEY: '' },
+    });
+  } catch (err) {
+    exitCode = err.status ?? 1;
+    stdout = err.stdout?.toString() ?? '';
+    stderr = err.stderr?.toString() ?? '';
+  }
+  let json = null;
+  try { json = JSON.parse(stdout.trim()); } catch { /* ok */ }
+  return { exitCode, stdout: stdout.trim(), stderr: stderr.trim(), json };
+}
+
+describe('bug-2803: config-get --default flag honored in SDK', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-test-2803-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('--default returns fallback value when key absent, exit 0', () => {
+    // Write a config without the key
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ mode: 'balanced' })
+    );
+
+    const result = runConfigGet(
+      ['workflow.test_command', '--default', 'FALLBACK'],
+      tmpDir
+    );
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 when --default provided');
+    assert.ok(result.json !== null, 'should emit JSON');
+    assert.strictEqual(result.json, 'FALLBACK', 'data should be the default value');
+  });
+
+  test('--default not consumed as key path', () => {
+    // The key path should still be the first positional, not --default
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ mode: 'quality' })
+    );
+
+    const result = runConfigGet(['mode', '--default', 'balanced'], tmpDir);
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 for found key');
+    assert.strictEqual(result.json, 'quality', 'should return actual value when key exists');
+  });
+
+  test('--default with empty string value works', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({})
+    );
+
+    const result = runConfigGet(['missing.key', '--default', ''], tmpDir);
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 with empty default');
+    assert.strictEqual(result.json, '', 'data should be empty string');
+  });
+
+  test('without --default: missing key still exits 1', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ mode: 'balanced' })
+    );
+
+    const result = runConfigGet(['workflow.missing_key'], tmpDir);
+
+    assert.strictEqual(result.exitCode, 1, 'should exit 1 when key absent and no --default');
+  });
+
+  test('--default with nested missing path', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ workflow: {} })
+    );
+
+    const result = runConfigGet(
+      ['workflow.test_command', '--default', 'npm test'],
+      tmpDir
+    );
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 with default for nested missing key');
+    assert.strictEqual(result.json, 'npm test', 'data should be the default value');
+  });
+});

--- a/tests/bug-2805-archived-phase-fallback.test.cjs
+++ b/tests/bug-2805-archived-phase-fallback.test.cjs
@@ -1,0 +1,145 @@
+/**
+ * Regression test for bug #2805
+ *
+ * `gsd-sdk query init.plan-phase <N>` returned the archived prior-milestone
+ * directory when the current milestone had a phase with the same number but
+ * no directory yet. getPhaseInfoWithFallback did not treat an archived hit as
+ * "not yet created" when the current ROADMAP listed the phase.
+ *
+ * Root cause: findPhase searches archived milestones as a fallback. When the
+ * archive matched (found:true, archived:"vX"), getPhaseInfoWithFallback
+ * treated it as a valid disk match and never consulted the current ROADMAP.
+ *
+ * Fix: in getPhaseInfoWithFallback, when phaseInfo.archived is set AND
+ * roadmapPhase.found is true, discard the archived hit and fall through to
+ * the ROADMAP-based fallback (directory:null, current phase metadata).
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { createTempGitProject, cleanup } = require('./helpers.cjs');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SDK_CLI = path.join(REPO_ROOT, 'sdk', 'dist', 'cli.js');
+
+function runSdkQuery(subcommand, args, projectDir) {
+  const argv = ['query', subcommand, ...args, '--project-dir', projectDir];
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 0;
+  try {
+    stdout = execFileSync(process.execPath, [SDK_CLI, ...argv], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, GSD_SESSION_KEY: '' },
+    });
+  } catch (err) {
+    exitCode = err.status ?? 1;
+    stdout = err.stdout?.toString() ?? '';
+    stderr = err.stderr?.toString() ?? '';
+  }
+  let json = null;
+  try { json = JSON.parse(stdout.trim()); } catch { /* ok */ }
+  return { exitCode, json, stderr: stderr.trim() };
+}
+
+/**
+ * Create a project with:
+ * - An archived prior milestone vX with a phase 02
+ * - A current milestone vX+1 with phase 02 in ROADMAP.md but NO directory yet
+ */
+function setupArchivedAndCurrent(tmpDir) {
+  const planningDir = path.join(tmpDir, '.planning');
+
+  // Archived prior milestone phase 02
+  const archivePhaseDir = path.join(
+    planningDir, 'milestones', 'v1.0-phases', '02-auth'
+  );
+  fs.mkdirSync(archivePhaseDir, { recursive: true });
+  fs.writeFileSync(path.join(archivePhaseDir, '01-PLAN.md'), '# Plan\n');
+
+  // Current milestone ROADMAP.md with phase 02 (no directory yet)
+  const roadmap = [
+    '# My Project Roadmap',
+    '',
+    '## v2.0 — Phase 2',
+    '',
+    '### Phase 2: New Auth Refactor',
+    '',
+    '**Requirements:** REQ-010, REQ-011',
+    '',
+    '| # | Phase | Plans | Status | Date |',
+    '|---|-------|-------|--------|------|',
+    '| 2 | New Auth Refactor | 0/3 | Planned | |',
+    '',
+  ].join('\n');
+  fs.mkdirSync(path.join(planningDir, 'phases'), { recursive: true });
+  fs.writeFileSync(path.join(planningDir, 'ROADMAP.md'), roadmap);
+
+  // STATE.md pointing at v2.0
+  fs.writeFileSync(
+    path.join(planningDir, 'STATE.md'),
+    [
+      '---',
+      'version: "v2.0"',
+      '---',
+      '# State',
+    ].join('\n')
+  );
+}
+
+describe('bug-2805: init.plan-phase prefers current ROADMAP over archived dir', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject('gsd-test-2805-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('phase_dir is null (not archived dir) when current milestone has the phase', () => {
+    setupArchivedAndCurrent(tmpDir);
+
+    const result = runSdkQuery('init.plan-phase', ['2'], tmpDir);
+
+    assert.strictEqual(result.exitCode, 0, `should exit 0; stderr: ${result.stderr}`);
+    assert.ok(result.json !== null, 'should emit JSON');
+
+    // Before fix: phase_dir was ".planning/milestones/v1.0-phases/02-auth"
+    // After fix: phase_dir must be null (no directory yet for current milestone)
+    assert.strictEqual(
+      result.json.phase_dir,
+      null,
+      `phase_dir should be null (current milestone has no dir yet), got: ${result.json.phase_dir}`
+    );
+  });
+
+  test('phase_found is true (phase exists in ROADMAP) even without a disk directory', () => {
+    setupArchivedAndCurrent(tmpDir);
+
+    const result = runSdkQuery('init.plan-phase', ['2'], tmpDir);
+
+    assert.ok(result.json?.phase_found === true, 'phase_found should be true (ROADMAP has it)');
+  });
+
+  test('phase_name comes from current ROADMAP, not archived dir name', () => {
+    setupArchivedAndCurrent(tmpDir);
+
+    const result = runSdkQuery('init.plan-phase', ['2'], tmpDir);
+
+    // Archived dir is named "02-auth"; current ROADMAP says "New Auth Refactor"
+    // Assert the exact value from the ROADMAP fixture to fully protect the regression.
+    assert.strictEqual(
+      result.json?.phase_name,
+      'New Auth Refactor',
+      `phase_name should come from ROADMAP ("New Auth Refactor"), not the archived dir slug "02-auth", got: "${result.json?.phase_name}"`
+    );
+  });
+});

--- a/tests/bug-2808-skill-hyphen-name.test.cjs
+++ b/tests/bug-2808-skill-hyphen-name.test.cjs
@@ -1,0 +1,116 @@
+/**
+ * Regression test for bug #2808
+ *
+ * All 85 GSD SKILL.md files declared `name: gsd:<cmd>` (colon), the deprecated
+ * form. Claude Code surfaces the `name:` frontmatter field in autocomplete, so
+ * users saw `/gsd:add-phase` suggestions instead of the canonical `/gsd-add-phase`.
+ *
+ * Root cause: skillFrontmatterName() in bin/install.js converted hyphenated
+ * skill dir names to colon form (gsd-add-phase → gsd:add-phase) because
+ * workflows called Skill(skill="gsd:<cmd>"). That was the original fix for
+ * #2643. Since then, workflows have been updated to use hyphen form (#2808).
+ *
+ * Fix: skillFrontmatterName() now returns the hyphen form unchanged.
+ * Four workflow Skill() colon calls updated to hyphen.
+ *
+ * This test verifies:
+ * 1. skillFrontmatterName returns hyphen form (not colon).
+ * 2. Installed SKILL.md would emit name: gsd-<cmd> (not gsd:<cmd>).
+ * 3. No workflow contains a Skill(skill="gsd:<cmd>") colon call.
+ */
+
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const { convertClaudeCommandToClaudeSkill, skillFrontmatterName } =
+  require(path.join(ROOT, 'bin', 'install.js'));
+
+const WORKFLOWS_DIR = path.join(ROOT, 'get-shit-done', 'workflows');
+const COMMANDS_DIR = path.join(ROOT, 'commands', 'gsd');
+
+function walkMd(dir) {
+  const files = [];
+  try {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) files.push(...walkMd(full));
+      else if (e.name.endsWith('.md')) files.push(full);
+    }
+  } catch (err) {
+    assert.fail(`failed to read markdown files from ${dir}: ${err.message}`);
+  }
+  return files;
+}
+
+describe('bug-2808: SKILL.md name: uses hyphen form', () => {
+  test('skillFrontmatterName returns hyphen form (not colon)', () => {
+    assert.strictEqual(skillFrontmatterName('gsd-add-phase'), 'gsd-add-phase');
+    assert.strictEqual(skillFrontmatterName('gsd-plan-phase'), 'gsd-plan-phase');
+    assert.strictEqual(skillFrontmatterName('gsd-autonomous'), 'gsd-autonomous');
+  });
+
+  test('generated SKILL.md contains name: gsd-<cmd> (not gsd:<cmd>)', () => {
+    const cmdFiles = fs.readdirSync(COMMANDS_DIR).filter(f => f.endsWith('.md'));
+    assert.ok(cmdFiles.length > 0, 'expected GSD command files');
+
+    for (const cmd of cmdFiles) {
+      const base = cmd.replace(/\.md$/, '');
+      const skillDirName = 'gsd-' + base;
+      const src = fs.readFileSync(path.join(COMMANDS_DIR, cmd), 'utf-8');
+      const skillContent = convertClaudeCommandToClaudeSkill(src, skillDirName);
+
+      // Parse frontmatter structurally: extract name: line from the --- block.
+      const fmMatch = skillContent.match(/^---\n([\s\S]*?)\n---/);
+      assert.ok(fmMatch, `${cmd}: generated skill content must have a frontmatter block`);
+      const fmLines = fmMatch[1].split('\n');
+      const nameEntry = fmLines.find((l) => l.startsWith('name:'));
+      assert.ok(nameEntry, `${cmd}: generated SKILL.md is missing required name: field`);
+
+      const name = nameEntry.replace(/^name:\s*/, '').trim();
+      assert.ok(
+        !name.includes(':'),
+        `${cmd}: SKILL.md name should be hyphen form, got "${name}"`
+      );
+      assert.ok(
+        name.startsWith('gsd-'),
+        `${cmd}: SKILL.md name should start with gsd-, got "${name}"`
+      );
+    }
+  });
+
+  test('no workflow contains Skill(skill="gsd:<cmd>") colon form', () => {
+    const workflowFiles = walkMd(WORKFLOWS_DIR);
+    assert.ok(
+      workflowFiles.length > 0,
+      `expected workflow markdown files under ${WORKFLOWS_DIR}`
+    );
+    const colonCalls = [];
+    for (const f of workflowFiles) {
+      const src = fs.readFileSync(f, 'utf-8');
+      // Strip HTML comments to avoid matching commented-out examples.
+      const stripped = src.replace(/<!--[\s\S]*?-->/g, '');
+      // Scan each line for Skill() calls using the colon form.
+      // Parsing line-by-line is more precise than a multi-line regex
+      // and avoids false positives from incidental matches in prose.
+      for (const line of stripped.split('\n')) {
+        const colonCallRe = /Skill\(skill=['"]gsd:([a-z0-9-]+)['"]/gi;
+        let m;
+        while ((m = colonCallRe.exec(line)) !== null) {
+          colonCalls.push(`${path.basename(f)}: Skill(skill="gsd:${m[1]}")`);
+        }
+      }
+    }
+    assert.deepStrictEqual(
+      colonCalls,
+      [],
+      'deprecated colon-form Skill() calls found — update to gsd-<cmd>: ' + colonCalls.join(', ')
+    );
+  });
+});

--- a/tests/claude-skills-migration.test.cjs
+++ b/tests/claude-skills-migration.test.cjs
@@ -69,7 +69,7 @@ describe('convertClaudeCommandToClaudeSkill', () => {
     );
   });
 
-  test('emits colon-form name (gsd:<cmd>) from hyphen-form dir (#2643)', () => {
+  test('emits hyphen-form name (gsd-<cmd>) from hyphen-form dir (#2808)', () => {
     const input = [
       '---',
       'name: gsd:next',
@@ -80,9 +80,9 @@ describe('convertClaudeCommandToClaudeSkill', () => {
     ].join('\n');
 
     // Directory name is gsd-next (hyphen, Windows-safe), frontmatter name is
-    // gsd:next (colon) so Claude Code resolves `/gsd:next` against the skill.
+    // gsd-next (hyphen, #2808) so Claude Code autocomplete shows canonical form.
     const result = convertClaudeCommandToClaudeSkill(input, 'gsd-next');
-    assert.ok(result.includes('name: gsd:next'), 'frontmatter name uses colon form');
+    assert.ok(result.includes('name: gsd-next'), 'frontmatter name uses hyphen form (#2808)');
   });
 
   test('preserves body content unchanged', () => {

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -8,11 +8,30 @@
 // Enable test exports from install.js (skips main CLI logic)
 process.env.GSD_TEST_MODE = '1';
 
-const { test, describe, beforeEach, afterEach } = require('node:test');
+const { test, describe, before, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { execFileSync } = require('child_process');
+
+// #2153 follow-up: ensure hooks/dist/ exists before any install integration
+// test runs. The Codex install path copies hook files from hooks/dist/, which
+// is gitignored and only populated by `npm run build:hooks`. When this file is
+// run in isolation (`node --test tests/codex-config.test.cjs`) the build step
+// from the npm-test pretest chain does not run, and the "Codex install copies
+// hook file" regression silently fails because hooks/dist/ is empty.
+// Build on demand so the test passes regardless of runner ordering.
+const HOOKS_DIST = path.join(__dirname, '..', 'hooks', 'dist');
+const BUILD_HOOKS_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
+before(() => {
+  if (!fs.existsSync(HOOKS_DIST) || fs.readdirSync(HOOKS_DIST).length === 0) {
+    execFileSync(process.execPath, [BUILD_HOOKS_SCRIPT], {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+  }
+});
 
 const {
   getCodexSkillAdapterHeader,
@@ -26,6 +45,7 @@ const {
   install,
   GSD_CODEX_MARKER,
   CODEX_AGENT_SANDBOX,
+  parseTomlToObject,
 } = require('../bin/install.js');
 
 function runCodexInstall(codexHome, cwd = path.join(__dirname, '..')) {
@@ -575,7 +595,7 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.strictEqual(migrateCodexHooksMapFormat(''), '');
   });
 
-  test('converts [hooks.shell] with command key to [[hooks]] with type = "shell"', () => {
+  test('converts [hooks.shell] to namespaced AoT [[hooks.shell]] (#2760 CR5 finding 3)', () => {
     const content = [
       '[features]',
       'codex_hooks = true',
@@ -587,34 +607,38 @@ describe('migrateCodexHooksMapFormat', () => {
       '',
     ].join('\n');
     const result = migrateCodexHooksMapFormat(content);
-    // Old format removed
-    assert.ok(!result.includes('[hooks.shell]'), 'removes [hooks.shell] map header');
-    assert.ok(!result.match(/^\[hooks\]$/m), 'removes bare [hooks] container');
-    // New format present
-    assert.ok(result.includes('[[hooks]]'), 'adds [[hooks]] array header');
-    assert.ok(result.includes('type = "shell"'), 'adds type = "shell" key');
-    assert.ok(result.includes('command = "node /home/.codex/hooks/gsd-check-update.js"'), 'preserves command value');
-    // User content preserved
-    assert.ok(result.includes('[features]'), 'preserves [features] section');
-    assert.ok(result.includes('codex_hooks = true'), 'preserves codex_hooks key');
+    // Parse structurally — no source-grep on raw bytes.
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.shell),
+      'hooks.shell must be an array of tables, got: ' + (parsed.hooks ? typeof parsed.hooks.shell : 'no hooks table'));
+    assert.strictEqual(parsed.hooks.shell.length, 1);
+    assert.strictEqual(parsed.hooks.shell[0].command, 'node /home/.codex/hooks/gsd-check-update.js');
+    // No flat top-level [[hooks]] AoT and no synthetic event field.
+    assert.ok(!Array.isArray(parsed.hooks),
+      'no top-level [[hooks]] AoT — namespace IS the event in CR5 form');
+    assert.equal(parsed.hooks.shell[0].event, undefined,
+      'no synthetic event field — namespace [[hooks.shell]] encodes the event');
+    // User content preserved.
+    assert.equal(parsed.features && parsed.features.codex_hooks, true);
   });
 
-  test('converts [hooks.exec] to [[hooks]] with type = "exec"', () => {
+  test('converts [hooks.exec] to namespaced AoT [[hooks.exec]] (#2760 CR5 finding 3)', () => {
     const content = [
       '[hooks.exec]',
       'command = "echo hello"',
-      'event = "SessionStart"',
+      'extra_key = "preserved"',
       '',
     ].join('\n');
     const result = migrateCodexHooksMapFormat(content);
-    assert.ok(!result.includes('[hooks.exec]'), 'removes [hooks.exec] map header');
-    assert.ok(result.includes('[[hooks]]'), 'adds [[hooks]] array header');
-    assert.ok(result.includes('type = "exec"'), 'adds type = "exec" key');
-    assert.ok(result.includes('command = "echo hello"'), 'preserves command');
-    assert.ok(result.includes('event = "SessionStart"'), 'preserves event');
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.exec));
+    assert.strictEqual(parsed.hooks.exec.length, 1);
+    assert.strictEqual(parsed.hooks.exec[0].command, 'echo hello');
+    assert.strictEqual(parsed.hooks.exec[0].extra_key, 'preserved');
+    assert.equal(parsed.hooks.exec[0].event, undefined);
   });
 
-  test('converts multiple [hooks.TYPE] sections to separate [[hooks]] blocks', () => {
+  test('converts multiple [hooks.TYPE] sections to separate namespaced AoT blocks (#2760 CR5 finding 3)', () => {
     const content = [
       '[hooks.shell]',
       'command = "node /home/.codex/hooks/gsd-check-update.js"',
@@ -624,12 +648,13 @@ describe('migrateCodexHooksMapFormat', () => {
       '',
     ].join('\n');
     const result = migrateCodexHooksMapFormat(content);
-    assert.ok(!result.includes('[hooks.shell]'), 'removes [hooks.shell]');
-    assert.ok(!result.includes('[hooks.exec]'), 'removes [hooks.exec]');
-    const hookHeaders = (result.match(/\[\[hooks\]\]/g) || []).length;
-    assert.strictEqual(hookHeaders, 2, 'produces two [[hooks]] array entries');
-    assert.ok(result.includes('type = "shell"'), 'first entry has type = "shell"');
-    assert.ok(result.includes('type = "exec"'), 'second entry has type = "exec"');
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.shell));
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.exec));
+    assert.strictEqual(parsed.hooks.shell.length, 1);
+    assert.strictEqual(parsed.hooks.exec.length, 1);
+    assert.strictEqual(parsed.hooks.shell[0].command, 'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.exec[0].command, 'echo done');
   });
 
   test('leaves user-authored [[hooks]] array entries untouched when no legacy [hooks] map present', () => {
@@ -642,7 +667,7 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.strictEqual(migrateCodexHooksMapFormat(content), content);
   });
 
-  test('end-to-end: install on config with old [hooks] map format produces [[hooks]] array format (#2637)', () => {
+  test('end-to-end: install on config with old [hooks] map format produces namespaced AoT (#2637, #2760 CR5)', () => {
     // Simulates the exact old GSD config.toml format that broke on Codex 0.124.0
     const oldContent = [
       '[features]',
@@ -655,18 +680,15 @@ describe('migrateCodexHooksMapFormat', () => {
       '',
     ].join('\n');
     const result = migrateCodexHooksMapFormat(oldContent);
-    // Must not contain any [hooks] or [hooks.*] map-style headers
-    assert.ok(!result.match(/^\s*\[hooks\]\s*$/m), 'no bare [hooks] map header');
-    assert.ok(!result.match(/^\s*\[hooks\./m), 'no [hooks.TYPE] map headers');
-    // Must contain [[hooks]] array format
-    assert.ok(result.includes('[[hooks]]'), 'has [[hooks]] array-of-tables header');
-    // type key must be present
-    assert.ok(result.includes('type = "shell"'), 'has type = "shell" in [[hooks]] entry');
-    // command is preserved
-    assert.ok(result.includes('command = "node /home/.codex/hooks/gsd-check-update.js"'), 'command preserved');
-    // [features] user content preserved
-    assert.ok(result.includes('[features]'), 'preserves [features]');
-    assert.ok(result.includes('codex_hooks = true'), 'preserves codex_hooks');
+    const parsed = parseTomlToObject(result);
+    // Codex 0.124.0+: must produce array-of-tables form. CR5 finding 3:
+    // namespaced AoT [[hooks.shell]] (no flat [[hooks]] with synthetic event).
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.shell),
+      'hooks.shell must be array-of-tables in namespaced form');
+    assert.strictEqual(parsed.hooks.shell.length, 1);
+    assert.strictEqual(parsed.hooks.shell[0].command,
+      'node /home/.codex/hooks/gsd-check-update.js');
+    assert.equal(parsed.features && parsed.features.codex_hooks, true);
   });
 
   test('bare [hooks] section without sub-tables is dropped (no [[hooks]] block added)', () => {
@@ -688,7 +710,7 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(result.includes('[model]'), 'preserves [model]');
   });
 
-  test('CRLF line endings are preserved through migration', () => {
+  test('CRLF line endings are preserved through migration (#2760 CR5: namespaced AoT)', () => {
     const content = [
       '[features]',
       'codex_hooks = true',
@@ -698,9 +720,58 @@ describe('migrateCodexHooksMapFormat', () => {
       '',
     ].join('\r\n');
     const result = migrateCodexHooksMapFormat(content);
-    assert.ok(result.includes('[[hooks]]\r\n'), 'uses CRLF in [[hooks]] header');
-    assert.ok(result.includes('type = "shell"\r\n'), 'uses CRLF in type line');
-    assert.ok(!result.includes('[hooks.shell]'), 'removes legacy [hooks.shell]');
+    assert.ok(result.includes('[[hooks.shell]]\r\n'),
+      'uses CRLF in namespaced [[hooks.shell]] header');
+    // Round-trip parse confirms the structural shape independent of EOL.
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.shell));
+    assert.strictEqual(parsed.hooks.shell[0].command,
+      'node /home/.codex/hooks/gsd-check-update.js');
+  });
+});
+
+// ─── shape parity between migration and managed emit (#2760 CR5 finding 3) ──
+
+describe('Codex hooks emit: migration produces namespaced AoT so managed-emit converges', () => {
+  // After #2760 CR5 finding 3, the legacy migration path
+  // (migrateCodexHooksMapFormat) emits `[[hooks.<TYPE>]]` directly — the
+  // namespace IS the event, no synthetic `event = ...` field. The managed
+  // install path (writes "# GSD Hooks") detects existing namespaced AoT via
+  // hasUserNamespacedAotHooks and emits its block in the same shape. The two
+  // paths must therefore both produce a namespaced layout when a legacy
+  // [hooks.SessionStart] is migrated, eliminating the mixed flat+namespaced
+  // bug class entirely.
+
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-codex-fieldparity-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('migration of legacy [hooks.SessionStart] produces namespaced AoT', () => {
+    const legacyContent = [
+      '[features]',
+      'codex_hooks = true',
+      '',
+      '[hooks.SessionStart]',
+      'command = "node /home/.codex/hooks/gsd-check-update.js"',
+      '',
+    ].join('\n');
+    const migrated = migrateCodexHooksMapFormat(legacyContent);
+    const parsed = parseTomlToObject(migrated);
+    assert.ok(
+      parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
+      'migration must emit [[hooks.SessionStart]] namespaced AoT'
+    );
+    assert.equal(parsed.hooks.SessionStart[0].event, undefined,
+      'migration must NOT emit a synthetic event field — namespace IS the event');
+    assert.equal(
+      Array.isArray(parsed.hooks),
+      false,
+      'migration must NOT emit a flat top-level [[hooks]] AoT'
+    );
   });
 });
 
@@ -929,7 +1000,7 @@ describe('mergeCodexConfig', () => {
     assertUsesOnlyEol(content, '\r\n');
   });
 
-  test('case 2 preserves user-authored [agents] tables while stripping leaked GSD sections in CRLF files', () => {
+  test('case 2 strips bare [agents] tables (invalid in current Codex schema, #2760) and removes leaked GSD sections in CRLF files', () => {
     const configPath = path.join(tmpDir, 'config.toml');
     const brokenContent = [
       '[features]',
@@ -958,8 +1029,24 @@ describe('mergeCodexConfig', () => {
     const markerIndex = content.indexOf(GSD_CODEX_MARKER);
     const beforeMarker = content.slice(0, markerIndex);
 
-    assert.ok(beforeMarker.includes('[agents]\r\ndefault = "custom-agent"\r\n'), 'preserves user-authored [agents] table');
-    assert.strictEqual(countMatches(beforeMarker, /^\[agents\.gsd-executor\]\s*$/gm), 0, 'removes leaked GSD agent section above marker');
+    // Bare [agents] is invalid under Codex's current schema (rejected with
+    // "expected struct AgentsToml") so install-time stripping always purges
+    // it (#2760). User feature keys above the marker are preserved.
+    // Structural assertion: TOML-parse the pre-marker region and verify the
+    // bare [agents] block is fully gone — header AND body keys (e.g.,
+    // `default = "custom-agent"`). A header-only check would miss a
+    // partial-strip regression that leaves orphan body keys reparented to a
+    // sibling section.
+    const parsedBefore = parseTomlToObject(beforeMarker);
+    assert.equal(
+      parsedBefore.agents,
+      undefined,
+      'bare [agents] block fully purged including body keys (#2760)',
+    );
+    assert.ok(
+      parsedBefore.features && parsedBefore.features.child_agents_md === false,
+      'preserves user feature keys above marker',
+    );
     // New struct format: exactly one [agents.gsd-executor] in the GSD block (after marker)
     assert.strictEqual(countMatches(content, /^\[agents\.gsd-executor\]\s*$/gm), 1, 'exactly one struct agent header in GSD block');
     assert.strictEqual(countMatches(content, /name = "gsd-executor"/g), 0, 'no name = field in struct format');

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -578,7 +578,9 @@ describe('stripGsdFromCodexConfig', () => {
 // ─── migrateCodexHooksMapFormat ─────────────────────────────────────────────────
 
 describe('migrateCodexHooksMapFormat', () => {
-  test('returns content unchanged when no legacy [hooks] map sections present', () => {
+  test('migrates flat [[hooks]] with event key to namespaced [[hooks.<EVENT>]] form', () => {
+    // Flat [[hooks]] + event = "..." is TOML-incompatible with [[hooks.SessionStart]],
+    // so migrateCodexHooksMapFormat now converts it to the nested namespaced form.
     const content = [
       '[features]',
       'codex_hooks = true',
@@ -588,7 +590,21 @@ describe('migrateCodexHooksMapFormat', () => {
       'command = "node /home/.codex/hooks/gsd-check-update.js"',
       '',
     ].join('\n');
-    assert.strictEqual(migrateCodexHooksMapFormat(content), content);
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
+      'flat [[hooks]] event=SessionStart must be promoted to [[hooks.SessionStart]] AoT');
+    assert.strictEqual(parsed.hooks.SessionStart.length, 1);
+    assert.ok(Array.isArray(parsed.hooks.SessionStart[0].hooks),
+      'must emit [[hooks.SessionStart.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].command,
+      'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].type, 'command',
+      'migrated handler must carry type = "command" per Codex 0.124.0+ schema');
+    assert.equal(parsed.hooks.SessionStart[0].event, undefined,
+      'event key consumed as namespace — must not appear in emitted block');
+    assert.ok(!Array.isArray(parsed.hooks), 'hooks must be a table, not a flat array');
+    assert.equal(parsed.features && parsed.features.codex_hooks, true);
   });
 
   test('returns content unchanged for empty string', () => {
@@ -612,7 +628,10 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(parsed.hooks && Array.isArray(parsed.hooks.shell),
       'hooks.shell must be an array of tables, got: ' + (parsed.hooks ? typeof parsed.hooks.shell : 'no hooks table'));
     assert.strictEqual(parsed.hooks.shell.length, 1);
-    assert.strictEqual(parsed.hooks.shell[0].command, 'node /home/.codex/hooks/gsd-check-update.js');
+    // #2773: command now lives in [[hooks.shell.hooks]] sub-table, not at event-entry level
+    assert.ok(Array.isArray(parsed.hooks.shell[0].hooks), 'must emit [[hooks.shell.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].command, 'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].type, 'command');
     // No flat top-level [[hooks]] AoT and no synthetic event field.
     assert.ok(!Array.isArray(parsed.hooks),
       'no top-level [[hooks]] AoT — namespace IS the event in CR5 form');
@@ -633,8 +652,12 @@ describe('migrateCodexHooksMapFormat', () => {
     const parsed = parseTomlToObject(result);
     assert.ok(parsed.hooks && Array.isArray(parsed.hooks.exec));
     assert.strictEqual(parsed.hooks.exec.length, 1);
-    assert.strictEqual(parsed.hooks.exec[0].command, 'echo hello');
-    assert.strictEqual(parsed.hooks.exec[0].extra_key, 'preserved');
+    // #2773: command and extra keys now live in [[hooks.exec.hooks]] sub-table
+    assert.ok(Array.isArray(parsed.hooks.exec[0].hooks), 'must emit [[hooks.exec.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.exec[0].hooks[0].command, 'echo hello');
+    assert.strictEqual(parsed.hooks.exec[0].hooks[0].type, 'command',
+      'migrated handler must carry type = "command" per Codex 0.124.0+ schema');
+    assert.strictEqual(parsed.hooks.exec[0].hooks[0].extra_key, 'preserved');
     assert.equal(parsed.hooks.exec[0].event, undefined);
   });
 
@@ -653,18 +676,37 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(parsed.hooks && Array.isArray(parsed.hooks.exec));
     assert.strictEqual(parsed.hooks.shell.length, 1);
     assert.strictEqual(parsed.hooks.exec.length, 1);
-    assert.strictEqual(parsed.hooks.shell[0].command, 'node /home/.codex/hooks/gsd-check-update.js');
-    assert.strictEqual(parsed.hooks.exec[0].command, 'echo done');
+    // #2773: commands now live in the [[hooks.<TYPE>.hooks]] sub-table
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].command, 'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].type, 'command',
+      'migrated shell handler must carry type = "command"');
+    assert.strictEqual(parsed.hooks.exec[0].hooks[0].command, 'echo done');
+    assert.strictEqual(parsed.hooks.exec[0].hooks[0].type, 'command',
+      'migrated exec handler must carry type = "command"');
   });
 
-  test('leaves user-authored [[hooks]] array entries untouched when no legacy [hooks] map present', () => {
+  test('migrates flat [[hooks]] with event=AfterCommand to [[hooks.AfterCommand]] namespaced form', () => {
+    // Flat [[hooks]] + event = "..." is incompatible with [[hooks.<EVENT>]] AoT in the same
+    // file — TOML cannot have hooks be both an array and a table. Migration promotes it.
     const content = [
       '[[hooks]]',
       'event = "AfterCommand"',
       'command = "echo custom"',
       '',
     ].join('\n');
-    assert.strictEqual(migrateCodexHooksMapFormat(content), content);
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.AfterCommand),
+      'flat [[hooks]] event=AfterCommand must become [[hooks.AfterCommand]] AoT');
+    assert.strictEqual(parsed.hooks.AfterCommand.length, 1);
+    assert.ok(Array.isArray(parsed.hooks.AfterCommand[0].hooks),
+      'must emit [[hooks.AfterCommand.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.AfterCommand[0].hooks[0].command, 'echo custom');
+    assert.strictEqual(parsed.hooks.AfterCommand[0].hooks[0].type, 'command',
+      'migrated AfterCommand handler must carry type = "command" per Codex 0.124.0+ schema');
+    assert.equal(parsed.hooks.AfterCommand[0].event, undefined,
+      'event key consumed as namespace — must not appear in emitted block');
+    assert.ok(!Array.isArray(parsed.hooks), 'hooks must be a table, not a flat array');
   });
 
   test('end-to-end: install on config with old [hooks] map format produces namespaced AoT (#2637, #2760 CR5)', () => {
@@ -686,8 +728,12 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(parsed.hooks && Array.isArray(parsed.hooks.shell),
       'hooks.shell must be array-of-tables in namespaced form');
     assert.strictEqual(parsed.hooks.shell.length, 1);
-    assert.strictEqual(parsed.hooks.shell[0].command,
+    // #2773: command lives in [[hooks.shell.hooks]] sub-table
+    assert.ok(Array.isArray(parsed.hooks.shell[0].hooks), 'must emit [[hooks.shell.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].command,
       'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].type, 'command',
+      'migrated shell handler must carry type = "command" per Codex 0.124.0+ schema');
     assert.equal(parsed.features && parsed.features.codex_hooks, true);
   });
 
@@ -710,6 +756,132 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(result.includes('[model]'), 'preserves [model]');
   });
 
+  test('upgrades stale [[hooks.SessionStart]] with event-level command to nested schema (#2773 CR6)', () => {
+    // Pre-#2773 single-block format: handler fields live directly under
+    // [[hooks.SessionStart]] rather than under [[hooks.SessionStart.hooks]].
+    // Codex 0.124.0+ rejects this shape. Migration must promote it.
+    const content = [
+      '[features]',
+      'codex_hooks = true',
+      '',
+      '[[hooks.SessionStart]]',
+      'command = "echo stale-user-hook"',
+      '',
+    ].join('\n');
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
+      'stale [[hooks.SessionStart]] must remain a namespaced AoT');
+    assert.strictEqual(parsed.hooks.SessionStart.length, 1);
+    assert.ok(Array.isArray(parsed.hooks.SessionStart[0].hooks),
+      'must emit [[hooks.SessionStart.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].command, 'echo stale-user-hook');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].type, 'command',
+      'must inject type = "command" when source body has no explicit type');
+    assert.equal(parsed.hooks.SessionStart[0].command, undefined,
+      'command must not remain at event-entry level after promotion');
+    assert.equal(parsed.features && parsed.features.codex_hooks, true);
+  });
+
+  test('leaves [[hooks.SessionStart]] + [[hooks.SessionStart.hooks]] untouched (already nested)', () => {
+    // Properly-nested schema: handler lives under [[hooks.SessionStart.hooks]].
+    // Migration must NOT create a double-wrapped [[hooks.SessionStart.hooks.hooks]] shape.
+    const content = [
+      '[[hooks.SessionStart]]',
+      '',
+      '[[hooks.SessionStart.hooks]]',
+      'type = "command"',
+      'command = "echo already-nested"',
+      '',
+    ].join('\n');
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(Array.isArray(parsed.hooks?.SessionStart),
+      'SessionStart must remain a namespaced AoT after no-op migration');
+    assert.strictEqual(parsed.hooks.SessionStart.length, 1,
+      'must not duplicate the event entry');
+    assert.ok(Array.isArray(parsed.hooks.SessionStart[0].hooks),
+      'nested [[hooks.SessionStart.hooks]] sub-table must still be present');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks.length, 1,
+      'must not create a double-wrapped [[hooks.SessionStart.hooks.hooks]]');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].type, 'command');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].command, 'echo already-nested');
+    assert.equal(parsed.hooks.SessionStart[0].command, undefined,
+      'command must not appear at event-entry level');
+  });
+
+  test('promotes multiple stale [[hooks.TYPE]] entries from different event types', () => {
+    const content = [
+      '[[hooks.SessionStart]]',
+      'command = "echo session"',
+      '',
+      '[[hooks.AfterCommand]]',
+      'command = "echo after-cmd"',
+      '',
+    ].join('\n');
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.SessionStart));
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.AfterCommand));
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].command, 'echo session');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].type, 'command');
+    assert.strictEqual(parsed.hooks.AfterCommand[0].hooks[0].command, 'echo after-cmd');
+    assert.strictEqual(parsed.hooks.AfterCommand[0].hooks[0].type, 'command');
+    assert.equal(parsed.hooks.SessionStart[0].command, undefined);
+    assert.equal(parsed.hooks.AfterCommand[0].command, undefined);
+  });
+
+  test('matcher-only [[hooks.SessionStart]] (no handler fields) is left untouched', () => {
+    // A [[hooks.SessionStart]] entry with only a `matcher` key is a valid
+    // event filter — no handler fields → not a stale single-block entry.
+    const content = [
+      '[[hooks.SessionStart]]',
+      'matcher = "some-tool"',
+      '',
+    ].join('\n');
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(Array.isArray(parsed.hooks?.SessionStart),
+      'matcher-only SessionStart must remain a namespaced AoT');
+    assert.strictEqual(parsed.hooks.SessionStart.length, 1);
+    assert.strictEqual(parsed.hooks.SessionStart[0].matcher, 'some-tool',
+      'matcher key must be preserved');
+    assert.equal(parsed.hooks.SessionStart[0].hooks, undefined,
+      'matcher-only entry must not gain a .hooks sub-array');
+    assert.equal(parsed.hooks.SessionStart[0].command, undefined,
+      'no spurious command key must appear');
+  });
+
+  test('quoted event name with dot ([[hooks."before.tool"]]) is treated as single 2-segment namespace', () => {
+    // Regression for the split('.') bug: "before.tool" contains a dot, but the
+    // key is quoted so it is ONE segment — [[hooks."before.tool"]] has exactly
+    // two path segments and must be classified the same as [[hooks.SessionStart]].
+    // It should NOT be treated as a 3-level path (hooks / before / tool).
+    const content = [
+      '[[hooks."before.tool"]]',
+      'command = "echo hi"',
+      '',
+    ].join('\n');
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    // The key in the parsed object is the unquoted event name "before.tool".
+    assert.ok(
+      parsed.hooks && Array.isArray(parsed.hooks['before.tool']),
+      '[[hooks."before.tool"]] must be a namespaced AoT — not split on the inner dot'
+    );
+    assert.ok(
+      Array.isArray(parsed.hooks['before.tool'][0].hooks),
+      'must emit [[hooks."before.tool".hooks]] sub-table'
+    );
+    assert.strictEqual(
+      parsed.hooks['before.tool'][0].hooks[0].command,
+      'echo hi',
+      'command must be preserved in the nested handler sub-table'
+    );
+    // Ensure no spurious "before" or "tool" top-level hook keys appeared.
+    assert.equal(parsed.hooks?.before, undefined, 'must not split quoted key on dot');
+  });
+
   test('CRLF line endings are preserved through migration (#2760 CR5: namespaced AoT)', () => {
     const content = [
       '[features]',
@@ -725,8 +897,12 @@ describe('migrateCodexHooksMapFormat', () => {
     // Round-trip parse confirms the structural shape independent of EOL.
     const parsed = parseTomlToObject(result);
     assert.ok(parsed.hooks && Array.isArray(parsed.hooks.shell));
-    assert.strictEqual(parsed.hooks.shell[0].command,
+    // #2773: command lives in [[hooks.shell.hooks]] sub-table
+    assert.ok(Array.isArray(parsed.hooks.shell[0].hooks), 'must emit [[hooks.shell.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].command,
       'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].type, 'command',
+      'migrated shell handler must carry type = "command" per Codex 0.124.0+ schema');
   });
 });
 
@@ -750,7 +926,7 @@ describe('Codex hooks emit: migration produces namespaced AoT so managed-emit co
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('migration of legacy [hooks.SessionStart] produces namespaced AoT', () => {
+  test('migration of legacy [hooks.SessionStart] produces two-level nested AoT (#2773)', () => {
     const legacyContent = [
       '[features]',
       'codex_hooks = true',
@@ -761,16 +937,27 @@ describe('Codex hooks emit: migration produces namespaced AoT so managed-emit co
     ].join('\n');
     const migrated = migrateCodexHooksMapFormat(legacyContent);
     const parsed = parseTomlToObject(migrated);
+    // Outer event entry
     assert.ok(
       parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
       'migration must emit [[hooks.SessionStart]] namespaced AoT'
     );
     assert.equal(parsed.hooks.SessionStart[0].event, undefined,
       'migration must NOT emit a synthetic event field — namespace IS the event');
-    assert.equal(
-      Array.isArray(parsed.hooks),
-      false,
-      'migration must NOT emit a flat top-level [[hooks]] AoT'
+    assert.equal(Array.isArray(parsed.hooks), false,
+      'migration must NOT emit a flat top-level [[hooks]] AoT');
+    // Inner handler sub-table
+    assert.ok(
+      Array.isArray(parsed.hooks.SessionStart[0].hooks),
+      'migration must emit [[hooks.SessionStart.hooks]] sub-table'
+    );
+    const handler = parsed.hooks.SessionStart[0].hooks[0];
+    assert.strictEqual(handler.type, 'command',
+      'migration must inject type = "command" in handler sub-table');
+    assert.strictEqual(
+      handler.command,
+      'node /home/.codex/hooks/gsd-check-update.js',
+      'migration must preserve original command value in handler sub-table'
     );
   });
 });
@@ -1237,7 +1424,17 @@ describe('Codex install hook configuration (e2e)', () => {
 
     const content = readCodexConfig(codexHome);
     assert.ok(content.includes('[features]\ncodex_hooks = true\n'), 'writes codex_hooks feature');
-    assert.ok(content.includes('# GSD Hooks\n[[hooks]]\nevent = "SessionStart"\n'), 'writes GSD SessionStart hook block');
+    // Codex 0.124.0+ nested schema: [[hooks.SessionStart]] + [[hooks.SessionStart.hooks]]
+    const parsed = parseTomlToObject(content);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.SessionStart), 'writes [[hooks.SessionStart]] AoT');
+    assert.ok(Array.isArray(parsed.hooks.SessionStart[0].hooks), 'writes [[hooks.SessionStart.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].type, 'command', 'handler type is "command"');
+    assert.strictEqual(
+      parsed.hooks.SessionStart[0].hooks[0].command,
+      'node ' + path.join(codexHome, 'hooks', 'gsd-check-update.js').replace(/\\/g, '/'),
+      'handler command must be the exact absolute path to gsd-check-update.js'
+    );
+    assert.ok(!Array.isArray(parsed.hooks), 'no flat [[hooks]] AoT emitted');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'writes one codex_hooks key');
     assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'writes one GSD update hook');
     assertNoDraftRootKeys(content);
@@ -1667,7 +1864,14 @@ describe('Codex install hook configuration (e2e)', () => {
     assert.ok(content.includes('notes = \'\'\'\n[model]\ncodex_hooks = false\n\'\'\''), 'preserves multiline string content');
     assert.strictEqual(countMatches(content, /^codex_hooks = false$/gm), 1, 'does not rewrite codex_hooks text inside multiline string');
     assert.ok(content.indexOf('codex_hooks = true') > content.indexOf('other_feature = true'), 'does not stop the features section at multiline string content');
-    assert.ok(content.indexOf('codex_hooks = true') < content.indexOf('[[hooks]]'), 'inserts the real codex_hooks key before the next table');
+    // Parse structurally — verify codex_hooks and migrated AfterCommand hook via parsed object
+    const parsed = parseTomlToObject(content);
+    assert.equal(parsed.features?.codex_hooks, true, 'writes a real codex_hooks boolean key');
+    assert.ok(Array.isArray(parsed.hooks?.AfterCommand), 'AfterCommand flat [[hooks]] migrated to namespaced AoT');
+    const afterCmds = parsed.hooks.AfterCommand.flatMap((entry) =>
+      Array.isArray(entry.hooks) ? entry.hooks.map((h) => h.command).filter(Boolean) : []
+    );
+    assert.ok(afterCmds.includes('echo custom-after-command'), 'preserves AfterCommand user hook command');
     assertNoDraftRootKeys(content);
   });
 
@@ -1846,7 +2050,10 @@ describe('Codex install hook configuration (e2e)', () => {
     // [features] is inserted after top-level lines, before [model] — not prepended
     assert.ok(content.includes('# first line wins\n\n[features]\ncodex_hooks = true\n'), 'inserts features after top-level lines using first newline style');
     assert.ok(content.includes(`# GSD Agent Configuration — managed by get-shit-done installer\n`), 'writes the managed agent block using the first newline style');
-    assert.ok(content.includes('# GSD Hooks\n[[hooks]]\nevent = "SessionStart"\n'), 'writes the GSD hook block using the first newline style');
+    // Structural check: nested schema must be present regardless of mixed EOL
+    const parsedMixed = parseTomlToObject(content);
+    assert.ok(parsedMixed.hooks && Array.isArray(parsedMixed.hooks.SessionStart), 'writes [[hooks.SessionStart]] AoT with first-newline style');
+    assert.ok(Array.isArray(parsedMixed.hooks.SessionStart[0].hooks), 'writes [[hooks.SessionStart.hooks]] sub-table');
     assert.ok(content.includes('[model]\r\nname = "o3"'), 'preserves the existing CRLF model lines');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'remains idempotent on repeated installs');
     assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'does not duplicate the GSD hook block');

--- a/tests/dispatcher.test.cjs
+++ b/tests/dispatcher.test.cjs
@@ -71,6 +71,14 @@ describe('dispatcher error paths', () => {
     const result = runGsdTools('state bogus', tmpDir);
     assert.strictEqual(result.success, false, 'Should exit non-zero');
     assert.ok(result.error.includes('Unknown state subcommand'), `Expected "Unknown state subcommand" in stderr, got: ${result.error}`);
+    // Pin the enumerated subcommand list. If a future refactor reformats the
+    // error string and silently drops 'complete-phase' from the available list,
+    // this test fails loudly rather than passing on the substring above.
+    // CodeRabbit nitpick on PR #2761.
+    assert.ok(
+      result.error.includes('complete-phase'),
+      `Expected enumerated subcommands to include "complete-phase", got: ${result.error}`,
+    );
   });
 
   // Unknown subcommand: template

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -252,6 +252,64 @@ describe('init commands', () => {
     assert.strictEqual(output.phase_req_ids, null, 'TBD placeholder should return null');
   });
 
+  // ── #2769: Requirements header bold/colon variants ───────────────────────
+  // The visible label "**Requirements:**" (colon INSIDE bold) and
+  // "**Requirements**:" (colon OUTSIDE bold) render identically. The parser
+  // must accept both, plus the spaced "**Requirements** :" variant and the
+  // plain "## Requirements" header form (used in REQUIREMENTS.md), so phase
+  // metadata is robust to authoring style.
+  const headerVariants = [
+    { name: 'colon inside bold (**Requirements:**)', header: '**Requirements:** RV-01, RV-02' },
+    { name: 'colon outside bold (**Requirements**:)', header: '**Requirements**: RV-01, RV-02' },
+    { name: 'space before colon (**Requirements** :)', header: '**Requirements** : RV-01, RV-02' },
+  ];
+
+  for (const variant of headerVariants) {
+    test(`init plan-phase parses Requirements with ${variant.name}`, () => {
+      fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '03-api'), { recursive: true });
+      const roadmap = [
+        '# Roadmap',
+        '',
+        '### Phase 3: API',
+        '**Goal:** Build API',
+        variant.header,
+        '**Plans:** 0 plans',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), roadmap);
+
+      const result = runGsdTools('init plan-phase 3', tmpDir);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      assert.strictEqual(output.phase_req_ids, 'RV-01, RV-02',
+        `phase_req_ids must be parsed when header uses "${variant.header}"`);
+    });
+
+    test(`init execute-phase parses Requirements with ${variant.name}`, () => {
+      const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+      fs.mkdirSync(phaseDir, { recursive: true });
+      fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.md'), '# Plan');
+      const roadmap = [
+        '# Roadmap',
+        '',
+        '### Phase 3: API',
+        '**Goal:** Build API',
+        variant.header,
+        '**Plans:** 1 plans',
+        '',
+      ].join('\n');
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), roadmap);
+
+      const result = runGsdTools('init execute-phase 3', tmpDir);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      assert.strictEqual(output.phase_req_ids, 'RV-01, RV-02',
+        `phase_req_ids must be parsed when header uses "${variant.header}"`);
+    });
+  }
+
   test('init execute-phase returns null phase_req_ids when Requirements line is absent', () => {
     const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
     fs.mkdirSync(phaseDir, { recursive: true });

--- a/tests/qwen-skills-migration.test.cjs
+++ b/tests/qwen-skills-migration.test.cjs
@@ -66,7 +66,7 @@ describe('Qwen Code: convertClaudeCommandToClaudeSkill', () => {
     );
   });
 
-  test('emits colon-form name (gsd:<cmd>) from hyphen-form dir (#2643)', () => {
+  test('emits hyphen-form name (gsd-<cmd>) from hyphen-form dir (#2808)', () => {
     const input = [
       '---',
       'name: gsd:next',
@@ -77,9 +77,9 @@ describe('Qwen Code: convertClaudeCommandToClaudeSkill', () => {
     ].join('\n');
 
     // Directory name is gsd-next (hyphen, Windows-safe), frontmatter name is
-    // gsd:next (colon) so Claude Code resolves `/gsd:next` against the skill.
+    // gsd-next (hyphen, #2808 — canonical invocation form for Claude Code autocomplete).
     const result = convertClaudeCommandToClaudeSkill(input, 'gsd-next');
-    assert.ok(result.includes('name: gsd:next'), 'frontmatter name uses colon form');
+    assert.ok(result.includes('name: gsd-next'), 'frontmatter name uses hyphen form (#2808)');
   });
 
   test('preserves body content unchanged', () => {
@@ -154,7 +154,7 @@ describe('Qwen Code: copyCommandsAsClaudeSkills', () => {
 
     // Verify content
     const content = fs.readFileSync(skillPath, 'utf8');
-    assert.ok(content.includes('name: gsd:quick'), 'frontmatter name uses colon form (#2643)');
+    assert.ok(content.includes('name: gsd-quick'), 'frontmatter name uses hyphen form (#2808)');
     assert.ok(content.includes('description:'), 'description present');
     assert.ok(content.includes('allowed-tools:'), 'allowed-tools preserved');
     assert.ok(content.includes('<objective>'), 'body content preserved');
@@ -274,7 +274,7 @@ describe('Qwen Code: SKILL.md format validation', () => {
     assert.ok(fmMatch, 'has frontmatter block');
 
     const fmLines = fmMatch[1].split('\n');
-    const hasName = fmLines.some(l => l.startsWith('name: gsd:review'));
+    const hasName = fmLines.some(l => l.startsWith('name: gsd-review'));
     const hasDesc = fmLines.some(l => l.startsWith('description:'));
     const hasAgent = fmLines.some(l => l.startsWith('agent:'));
     const hasTools = fmLines.some(l => l.startsWith('allowed-tools:'));

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2371,5 +2371,104 @@ describe('stale phase dirs do not corrupt phase counts (bug #2445)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// state complete-phase: Phase-fallback decoration handling (PR #2761 nitpick)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// When STATE.md is missing the canonical `**Current Phase:**` field but
+// includes a decorated `## Current Position` body line, the fallback path used
+// to leak the decoration into downstream Status/Phase strings — producing
+// `**Status:** Phase 01 (Foo) — EXECUTING complete` instead of the expected
+// `**Status:** Phase 01 complete`. CodeRabbit flagged this on PR #2761 and the
+// Phase fallback now strips everything past the leading numeric/decimal token.
+describe('state complete-phase: decorated Phase fallback (#2761 nitpick)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('writes clean Phase identifier when only Current Position decoration is present', () => {
+    // STATE.md without the canonical `**Current Phase:**` field — the only
+    // phase signal lives inside the `## Current Position` block as a decorated
+    // line. This is the regression fixture.
+    const stateMd = [
+      '---',
+      'milestone: v1.0',
+      '---',
+      '',
+      '# State',
+      '',
+      '**Status:** Executing',
+      '**Last Activity:** 2024-01-15',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 01 (Foo) — EXECUTING',
+      'Plan: bootstrap',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools('state complete-phase', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const updated = fs.readFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      'utf-8',
+    );
+
+    // Status should reference the bare phase identifier (`01`), not the
+    // decorated string. The negative assertion catches the regression
+    // shape directly.
+    assert.ok(
+      updated.includes('**Status:** Phase 01 complete'),
+      `Status should be "Phase 01 complete", got STATE.md:\n${updated}`,
+    );
+    assert.ok(
+      !updated.includes('Phase 01 (Foo) — EXECUTING complete'),
+      `Status must not embed Current Position decoration: ${updated}`,
+    );
+  });
+
+  test('canonical Current Phase field is preferred over Current Position decoration', () => {
+    // When both are present, Current Phase wins — same outcome as before, but
+    // pinned here so a future refactor that flips precedence is caught.
+    const stateMd = [
+      '---',
+      'milestone: v1.0',
+      '---',
+      '',
+      '# State',
+      '',
+      '**Status:** Executing',
+      '**Current Phase:** 03',
+      '**Last Activity:** 2024-01-15',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 01 (Foo) — EXECUTING',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools('state complete-phase', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const updated = fs.readFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      'utf-8',
+    );
+    assert.ok(
+      updated.includes('**Status:** Phase 03 complete'),
+      `Status should reference canonical Current Phase (03), got: ${updated}`,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // summary-extract command
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Sync downstream `gsd-hermes` with upstream `gsd-build/get-shit-done` at `eeaf9c55` / `get-shit-done-cc@1.39.0-rc.5`.
- Preserve downstream `gsd-hermes` package identity, Hermes install semantics, dash-form command discovery, and strict runtime/model binding receipt contracts.
- Prepare downstream release metadata for `gsd-hermes@1.7.0`.

Closes #40

## Verification
- [x] `npm run test:hermes`
- [x] `npm test` (`5921/5921`)
- [x] `npm run lint:tests`
- [x] `npm pack --dry-run --json` (`gsd-hermes-1.7.0.tgz`, 942 files)
