### PR TITLE
chore: prepare v1.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,14 @@ syncs from.
 
 ## [Unreleased]
 
+## 1.8.0 — 2026-04-29
+
+GSD Hermes package version: `1.8.0`
+Upstream GSD base: `upstream/main@eeaf9c55` / `get-shit-done-cc@1.39.0-rc.5`
+Previous downstream package version: `1.7.0`
+
 ### Added
-- **Provider-routed agent execution (v1.8 draft)** — `workflow.agent_execution_router: "provider-cli"` turns explicit `model_overrides` into strict per-agent CLI bindings: OpenAI/GPT-family models route to `codex exec --model ...`, and Anthropic/Claude-family models route to `claude -p --model ...`.
+- **Provider-routed agent execution** — `workflow.agent_execution_router: "provider-cli"` turns explicit `model_overrides` into strict per-agent CLI bindings: OpenAI/GPT-family models route to `codex exec --model ...`, and Anthropic/Claude-family models route to `claude -p --model ...`.
 - **Execution binding receipts** — execute-phase init payloads now include `agent_execution_bindings` alongside existing `model_binding_receipts`, making provider family, execution driver, normalized CLI model, and fail-fast diagnostics visible before dispatch.
 - **Strict regression coverage** — Hermes validation now covers provider-routing fixtures, negative fallback guards, command-rendering proof, and workflow static checks so `openai/gpt-5.5` cannot silently regress to `claude -p`.
 
@@ -19,7 +25,10 @@ syncs from.
 - `workflow.cross_ai_execution` is documented as a lower-priority legacy whole-plan fallback; valid provider-cli bindings take priority unless the operator explicitly bypasses provider routing.
 
 ### Documentation
-- Added draft release notes: [`docs/releases/v1.8.0-provider-routed-agent-execution.md`](docs/releases/v1.8.0-provider-routed-agent-execution.md).
+- Added release notes: [`docs/releases/v1.8.0-provider-routed-agent-execution.md`](docs/releases/v1.8.0-provider-routed-agent-execution.md).
+
+### Verification
+- Local validation passed: `npm run test:hermes`, `npm test` (`5942/5942`), `npm run lint:tests`, and `npm pack --dry-run --json`.
 
 ## 1.7.0 — 2026-04-29
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "A get-shit-done fork that adds Hermes Agent runtime support while preserving upstream GSD workflows.",
   "bin": {
     "gsd-hermes": "bin/install.js",


### PR DESCRIPTION
## Summary
- Bump `gsd-hermes` package metadata to `1.8.0`.
- Promote the provider-routed agent execution changelog entry from `Unreleased` to `1.8.0`.
- Keep this PR limited to release metadata; implementation already landed in #42.

## Verification
- [x] `npm run test:hermes`
- [x] `npm test` (`5942/5942`)
- [x] `npm run lint:tests`
- [x] `npm pack --dry-run --json` (`gsd-hermes-1.8.0.tgz`)

## Release plan after merge
- Create GitHub Release `v1.8.0` using `docs/releases/v1.8.0-provider-routed-agent-execution.md`.
- Trigger `.github/workflows/publish-npm.yml` with `auth_mode=trusted-publishing`, `tag=latest`, `dry_run=false`.
- Verify npm registry reports `gsd-hermes@1.8.0` as `latest`.

Closes #43
