### PR TITLE
Prepare gsd-hermes v1.9.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Hermes-first Get Shit Done distribution with strict provider-routed agent execution.",
   "bin": {
     "gsd-hermes": "bin/install.js",


### PR DESCRIPTION
## Summary

Prepare the formal npm release for `gsd-hermes@1.9.0` after the upstream sync PR merged.

Changes:

- bump root `package.json` version to `1.9.0`
- update root `package-lock.json` package metadata to `1.9.0`
- keep package identity as `gsd-hermes`

## Local verification

- [x] `npm run test:hermes`
- [x] `npm test`
- [x] `npm run lint:tests`
- [x] `npm pack --dry-run --json`
- [x] `git diff --check`

## Release follow-up

After merge:

1. create GitHub Release `v1.9.0`
2. run Trusted Publishing dry-run/publish if required by workflow
3. verify `npm view gsd-hermes version` and `npm dist-tag ls gsd-hermes`

Closes #47
