### PR TITLE
Prepare gsd-hermes v1.9.1 release

### DIFF
--- a/.changeset/quiet-hermes-sync.md
+++ b/.changeset/quiet-hermes-sync.md
@@ -1,0 +1,4 @@
+---
+type: Changed
+---
+Publish `gsd-hermes@1.9.1` for the upstream `f2decefe` maintenance sync, including SDK diagnostics and `/gsd-update --reapply` recovery messaging while preserving Hermes provider-routing guarantees.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ syncs from.
 
 ## [Unreleased]
 
+## 1.9.1 — 2026-05-02
+
+GSD Hermes package version: `1.9.1`
+Upstream GSD base: `upstream/main@f2decefe` / upstream `get-shit-done-cc@1.40.0-rc.1` development line
+Previous downstream package version: `1.9.0`
+Previous upstream base: `upstream/main@de25400b`
+
+### Synced
+- **Upstream sync to `upstream/main@f2decefe`** — imports upstream maintenance fixes for SDK diagnostics, typed-IR test coverage, and `/gsd-update --reapply` recovery messaging while preserving downstream `gsd-hermes` package identity.
+
+### Fixed
+- Kept SDK fail-fast repair hints pointed at `gsd-hermes`, not upstream package names.
+- Preserved strict Hermes/provider-routing invariants and dash-form command discovery while accepting upstream-owned `/gsd:` regression tests.
+
+### Documentation
+- Added release notes: [`docs/releases/v1.9.1-upstream-f2decefe-sync.md`](docs/releases/v1.9.1-upstream-f2decefe-sync.md).
+
+### Verification
+- Local and PR validation passed: `npm run test:hermes`, `npm test`, `npm run lint:tests`, and `npm pack --dry-run --json`.
+
 ## 1.9.0 — 2026-05-02
 
 GSD Hermes package version: `1.9.0`

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ See [docs/COMMANDS.md](docs/COMMANDS.md) for the full command reference.
 - [docs/hermes-compatibility.md](docs/hermes-compatibility.md) — Hermes compatibility contract and regression gate.
 - [docs/releases/v1.8.0-provider-routed-agent-execution.md](docs/releases/v1.8.0-provider-routed-agent-execution.md) — provider-routing release notes.
 - [docs/releases/v1.9.0-hermes-first-upstream-sync.md](docs/releases/v1.9.0-hermes-first-upstream-sync.md) — v1.9 sync/repositioning notes.
+- [docs/releases/v1.9.1-upstream-f2decefe-sync.md](docs/releases/v1.9.1-upstream-f2decefe-sync.md) — v1.9.1 upstream maintenance sync notes.
 - [CHANGELOG.md](CHANGELOG.md) — downstream release history.
 
 ---
@@ -201,7 +202,7 @@ npm pack --dry-run --json
 
 ## Upstream base
 
-`gsd-hermes@1.9.0` syncs to upstream `gsd-build/get-shit-done@de25400b` while preserving downstream package identity and Hermes/provider-routing invariants.
+`gsd-hermes@1.9.1` syncs to upstream `gsd-build/get-shit-done@f2decefe` while preserving downstream package identity and Hermes/provider-routing invariants.
 
 Public package identity remains:
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -4,9 +4,9 @@
 
 ---
 
-## GSD Hermes v1.9 Release Note
+## GSD Hermes v1.9.1 Release Note
 
-`gsd-hermes@1.9.0` syncs the command surface with `upstream/main@de25400b` while keeping the downstream Hermes-first guarantees: project-linked Hermes installs, `gsd-<command>` skill discovery, strict runtime model receipts, and provider-routed execution. Upstream basic Hermes support is preserved where useful, but `gsd-hermes` keeps the stricter rule that configured `model_overrides` either route through the matching provider driver or fail fast.
+`gsd-hermes@1.9.1` syncs the command surface with `upstream/main@f2decefe` while keeping the downstream Hermes-first guarantees: project-linked Hermes installs, `gsd-<command>` skill discovery, strict runtime model receipts, and provider-routed execution. This patch release also carries upstream `/gsd-update --reapply` recovery guidance so local-patch users no longer see stale reapply command names.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,9 +4,9 @@
 
 ---
 
-## GSD Hermes v1.9 Release Note
+## GSD Hermes v1.9.1 Release Note
 
-`gsd-hermes@1.9.0` carries upstream config and SDK query changes through `upstream/main@de25400b` while preserving the downstream strict-provider contract. For Hermes projects, `model_overrides` are the source of model intent; `workflow.agent_execution_router: "provider-cli"` binds OpenAI/GPT overrides to Codex CLI, Anthropic/Claude overrides to Claude CLI, and rejects unsupported routes instead of silently falling back to another provider.
+`gsd-hermes@1.9.1` carries upstream config, SDK query, and SDK diagnostic changes through `upstream/main@f2decefe` while preserving the downstream strict-provider contract. For Hermes projects, `model_overrides` are the source of model intent; `workflow.agent_execution_router: "provider-cli"` binds OpenAI/GPT overrides to Codex CLI, Anthropic/Claude overrides to Claude CLI, and rejects unsupported routes instead of silently falling back to another provider.
 
 ---
 

--- a/docs/releases/v1.9.1-upstream-f2decefe-sync.md
+++ b/docs/releases/v1.9.1-upstream-f2decefe-sync.md
@@ -1,0 +1,42 @@
+# gsd-hermes v1.9.1 — upstream f2decefe sync
+
+Target package: `gsd-hermes@1.9.1`
+
+Upstream base: `gsd-build/get-shit-done@f2decefede39`
+
+Previous downstream package: `gsd-hermes@1.9.0`
+Previous upstream base: `gsd-build/get-shit-done@de25400b708a351e24df6fcb7f28fe99ee0a6191`
+
+## Summary
+
+v1.9.1 publishes the post-v1.9 upstream maintenance sync through `f2decefe` while preserving the downstream Hermes-first contract:
+
+- package identity remains `gsd-hermes` / `npx gsd-hermes`;
+- Hermes project-linked installs still use the downstream flat skill layout;
+- strict provider-routed execution remains unchanged;
+- unsupported provider/model bindings continue to fail fast instead of silently falling back.
+
+## Upstream fixes included
+
+- `f55069ec` — migrates SDK/path diagnostic tests to typed-IR assertions.
+- `a4e5cc7c` — improves SDK-not-on-PATH diagnostics with shim location and shell-specific PATH repair commands.
+- `f2decefe` — replaces stale local-patch recovery references with `/gsd-update --reapply` guidance.
+
+## Downstream conflict resolution
+
+- Kept `gsd-hermes` install hints in SDK fail-fast diagnostics instead of reverting to upstream `get-shit-done-cc` package names.
+- Preserved `installSdkIfNeeded()` arity/source-contract compatibility while using upstream typed-IR diagnostic helpers.
+- Allowed the new upstream `/gsd:` regression test as an upstream-owned test path without weakening Hermes dash-form skill discovery checks.
+
+## Validation
+
+Release-prep validation should pass:
+
+```bash
+npm run test:hermes
+npm test
+npm run lint:tests
+npm pack --dry-run --json
+```
+
+The upstream-sync PR also passed GitHub checks across Ubuntu/macOS Node 22/24 smoke and test jobs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Hermes-first Get Shit Done distribution with strict provider-routed agent execution.",
   "bin": {
     "gsd-hermes": "bin/install.js",


### PR DESCRIPTION
## Summary
- Bumps `gsd-hermes` from `1.9.0` to `1.9.1` after the upstream `f2decefe` sync merged in #50.
- Adds v1.9.1 release notes for the SDK diagnostic and `/gsd-update --reapply` upstream maintenance sync.
- Aligns README, COMMANDS, CONFIGURATION, and CHANGELOG with the new upstream base.

## Validation
- `npm run test:hermes`
- `npm test`
- `npm run lint:tests`
- `npm pack --dry-run --json`

## Publish plan after merge
- Create GitHub Release `v1.9.1` targeting the merged release-prep commit.
- Run `publish-npm.yml` dry-run via Trusted Publishing.
- Run `publish-npm.yml` real publish via Trusted Publishing.
- Verify npm `latest` / package metadata.

Closes #51
