### PR TITLE
feat: add Hermes model-prefix routing

### DIFF
--- a/.changeset/hermes-model-prefix-routing.md
+++ b/.changeset/hermes-model-prefix-routing.md
@@ -1,0 +1,5 @@
+---
+"gsd-hermes": minor
+---
+
+Add `hermes/<model>` model-prefix routing so Hermes-native execution works from `model_overrides` without requiring `workflow.agent_execution_router` or `workflow.agent_execution_driver`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ syncs from.
 
 ## [Unreleased]
 
+## 1.11.0 — 2026-05-03
+
+GSD Hermes package version: `1.11.0`
+Upstream GSD base: `upstream/main@f2decefe` / upstream `get-shit-done-cc@1.40.0-rc.1` development line
+
+### Added
+- **Hermes model-prefix routing** — `model_overrides` values such as `hermes/gpt-5-5` and `hermes/claude-opus-4-7` now auto-select Hermes-native `hermes chat` execution without requiring `workflow.agent_execution_router` or `workflow.agent_execution_driver` in normal project config.
+- **Per-agent mixed routing safety** — `hermes/*` routes through Hermes while plain `openai/*` and `anthropic/*` overrides in the same phase continue to use Codex CLI and Claude Code CLI respectively.
+
+### Changed
+- Simplified README, configuration, command, and execute-phase workflow docs so the primary UX is model-string-first instead of `agent_execution_*`-first.
+- Hermes command rendering now omits `--provider ...`; Hermes receives a fully qualified model token such as `openai/gpt-5.5` or `anthropic/claude-opus-4-7` and resolves provider handling through its own config/runtime behavior.
+
+### Documentation
+- Added release notes: [`docs/releases/v1.11.0-hermes-model-prefix-routing.md`](docs/releases/v1.11.0-hermes-model-prefix-routing.md).
+
+### Verification
+- `npm run build:sdk`
+- `node --test tests/agent-execution-router.test.cjs tests/provider-cli-dispatch.test.cjs`
+
 ## 1.10.0 — 2026-05-03
 
 GSD Hermes package version: `1.10.0`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use it when you want:
 - ⚡ a Hermes-native install path that works globally or links cleanly into one repo;
 - 📁 inspectable project-local skills under `./.gsd-hermes` when you choose local mode;
 - 🛡 `model_overrides` that mean what they say for planner/executor/verifier agents;
-- 🔀 OpenAI/GPT agents routed through Codex CLI, Claude agents routed through Claude Code CLI, or explicit Hermes-native execution;
+- 🔀 OpenAI/GPT agents routed through Codex CLI, Claude agents routed through Claude Code CLI, or `hermes/*` routed through Hermes chat/tooling;
 - 🚦 fail-fast diagnostics instead of a configured GPT executor quietly running as `claude -p`.
 
 Upstream GSD now includes basic Hermes support. This package stays close to upstream, but keeps the Hermes-first packaging, compatibility gates, and strict provider-routed execution layer that make mixed-provider workflows safer to operate.
@@ -81,40 +81,36 @@ Then start a project:
 
 The point of this package is simple: if you say the executor should use GPT, it should not quietly become a Claude subprocess just because delegation fell back to an older path.
 
-`model_overrides` is the source of per-agent model intent. When `workflow.agent_execution_router` is set to `"provider-cli"`, GSD resolves each configured model into an execution driver before spawning work.
+`model_overrides` is the source of per-agent model intent. The simple Hermes-native path is now just a model prefix: use `hermes/<model>` and GSD routes that agent through Hermes chat/tool execution automatically — no `workflow.agent_execution_*` setup needed.
 
 ```json
 {
   "runtime": "hermes",
   "resolve_model_ids": "omit",
-  "workflow": {
-    "agent_execution_router": "provider-cli",
-    "agent_execution_driver": "provider-cli"
-  },
   "model_overrides": {
-    "gsd-executor": "openai/gpt-5.5",
-    "gsd-verifier": "anthropic/claude-opus-4-7"
+    "gsd-executor": "hermes/gpt-5-5",
+    "gsd-verifier": "hermes/claude-opus-4-7"
   }
 }
 ```
 
-| Configured model family | Default execution driver | Command shape |
+| Configured model | Default execution driver | Command shape |
 | --- | --- | --- |
+| `hermes/gpt-5-5` | Hermes chat + terminal/file toolsets | `hermes chat --toolsets terminal,file --model openai/gpt-5.5` |
+| `hermes/claude-opus-4-7` | Hermes chat + terminal/file toolsets | `hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7` |
 | `openai/*`, `gpt-*` | Codex CLI | `codex exec --model {model}` |
 | `anthropic/*`, `claude-*` | Claude Code CLI | `claude -p --model {model}` |
-| `openai/*`, `anthropic/*`, `google/*` with `workflow.agent_execution_driver: "hermes-chat"` | Hermes chat | `hermes chat --model {model} --provider {provider}` |
-| `openai/*`, `anthropic/*`, `google/*` with `workflow.agent_execution_driver: "hermes-terminal-tool"` | Hermes chat + terminal/file toolsets | `hermes chat --toolsets terminal,file --model {model}` |
 | unsupported / unavailable | none | fail fast with diagnostics |
 
 Guarantees:
 
-- `openai/gpt-5.5` must not silently run through `claude -p`.
-- `anthropic/claude-opus-4-7` must not silently run through `codex exec`.
-- Hermes-native drivers (`hermes-chat`, `hermes-terminal-tool`) preserve the fully-qualified `model_overrides` token and invoke `hermes chat`; they do not silently fall back to Claude/Codex CLIs.
+- `hermes/gpt-5-5` uses Hermes-native execution and must not silently run through `claude -p` or `codex exec`.
+- `openai/gpt-5.5` still routes directly to Codex CLI.
+- `anthropic/claude-opus-4-7` still routes directly to Claude Code CLI.
 - unsupported model families fail before spawn with actionable diagnostics.
 - init payloads expose both `model_binding_receipts` and `agent_execution_bindings` so the effective runtime/provider/model/driver is visible.
 
-Boundary: this proves GSD routing and CLI argument rendering. It does not claim wire-level provider API proof inside Hermes, Codex CLI, or Claude Code CLI.
+Boundary: this proves GSD routing and CLI argument rendering. `hermes/*` is an execution namespace for Hermes chat/tooling; it does not claim Hermes is a wire-level model provider.
 
 ---
 
@@ -128,20 +124,18 @@ Boundary: this proves GSD routing and CLI argument rendering. It does not claim 
   "model_profile": "quality",
   "resolve_model_ids": "omit",
   "workflow": {
-    "agent_execution_router": "provider-cli",
-    "agent_execution_driver": "hermes-terminal-tool",
     "cross_ai_execution": false
   },
   "model_overrides": {
-    "gsd-planner": "anthropic/claude-opus-4-7",
-    "gsd-executor": "openai/gpt-5.5",
-    "gsd-verifier": "openai/gpt-5.5",
-    "gsd-code-reviewer": "anthropic/claude-opus-4-7"
+    "gsd-planner": "hermes/claude-opus-4-7",
+    "gsd-executor": "hermes/gpt-5-5",
+    "gsd-verifier": "hermes/gpt-5-5",
+    "gsd-code-reviewer": "hermes/claude-opus-4-7"
   }
 }
 ```
 
-`cross_ai_execution` remains a legacy whole-plan fallback. Valid provider-cli bindings take priority and should not be overridden by `cross_ai_execution`. Leave `agent_execution_driver` unset or set it to `"provider-cli"` for direct Codex/Claude CLI routing; set it to `"hermes-chat"` or `"hermes-terminal-tool"` only when you explicitly want the selected model to run through Hermes itself.
+Want the provider-specific CLIs instead? Use `openai/gpt-5.5` for Codex CLI or `anthropic/claude-opus-4-7` for Claude Code CLI. `cross_ai_execution` remains a legacy whole-plan fallback and should not override valid per-agent bindings.
 
 ---
 
@@ -173,6 +167,7 @@ See [docs/COMMANDS.md](docs/COMMANDS.md) for the full command reference.
 - [docs/releases/v1.9.0-hermes-first-upstream-sync.md](docs/releases/v1.9.0-hermes-first-upstream-sync.md) — v1.9 sync/repositioning notes.
 - [docs/releases/v1.9.1-upstream-f2decefe-sync.md](docs/releases/v1.9.1-upstream-f2decefe-sync.md) — v1.9.1 upstream maintenance sync notes.
 - [docs/releases/v1.10.0-hermes-native-provider-routing.md](docs/releases/v1.10.0-hermes-native-provider-routing.md) — Hermes-native execution driver release notes.
+- [docs/releases/v1.11.0-hermes-model-prefix-routing.md](docs/releases/v1.11.0-hermes-model-prefix-routing.md) — simplified `hermes/<model>` routing release notes.
 - [CHANGELOG.md](CHANGELOG.md) — downstream release history.
 
 ---
@@ -210,7 +205,7 @@ npm pack --dry-run --json
 
 ## Upstream base
 
-`gsd-hermes@1.10.0` syncs to upstream `gsd-build/get-shit-done@f2decefe` while adding Hermes-native provider-routing drivers and preserving downstream package identity.
+`gsd-hermes@1.11.0` keeps the upstream `gsd-build/get-shit-done@f2decefe` base while simplifying Hermes-native routing to `hermes/<model>` model overrides and preserving downstream package identity.
 
 Public package identity remains:
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -12,7 +12,7 @@
 | Tier | What ships | Version format | npm tag | Branch | Install |
 |------|-----------|---------------|---------|--------|---------|
 | Patch | Bug fixes only | `1.9.1` | `latest` | `hotfix/1.9.1` | `npx gsd-hermes@latest` |
-| Minor | Upstream syncs, non-breaking features | `1.10.0` | `latest` after validation | `release/1.10.0` | `npx gsd-hermes@latest` |
+| Minor | Upstream syncs, non-breaking features | `1.11.0` | `latest` after validation | `release/1.11.0` | `npx gsd-hermes@latest` |
 | Major | Breaking config/CLI/runtime changes | `2.0.0` | `latest` after validation | `release/2.0.0` | `npx gsd-hermes@latest` |
 
 Pre-releases, when needed, use the `next` dist-tag:

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -211,26 +211,27 @@ Execute all plans in a phase with wave-based parallelization, or run a specific 
 
 **Hermes runtime model receipts:** On Hermes, execute-phase init payloads include `model_binding_receipts` for executor and verifier agents. These receipts show the configured model, resolved model token, binding source, Hermes binding channel, and proof boundary before dispatch. Explicit per-agent `model_overrides` must either bind through the Hermes child construction path or fail before spawn; execute-phase must not silently fall back to the parent/default model.
 
-**Provider-routed execution:** When `workflow.agent_execution_router` is `"provider-cli"`, execute-phase also reads `agent_execution_bindings` and uses the matching strict execution route per agent before legacy fallback paths:
+**Provider-routed execution:** execute-phase reads `agent_execution_bindings` and uses the matching strict execution route per agent before legacy fallback paths. The easiest Hermes-native form is the model namespace `hermes/<model>` — no `workflow.agent_execution_*` fields are required:
 
 ```text
+model_overrides.gsd-executor = "hermes/gpt-5-5"
+→ hermes-terminal-tool
+→ hermes chat --toolsets terminal,file --model openai/gpt-5.5
+
+model_overrides.gsd-verifier = "hermes/claude-opus-4-7"
+→ hermes-terminal-tool
+→ hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7
+
 model_overrides.gsd-executor = "openai/gpt-5.5"
-workflow.agent_execution_driver = "provider-cli" (default)
 → codex-cli
 → codex exec --model gpt-5.5
 
 model_overrides.gsd-verifier = "anthropic/claude-opus-4-7"
-workflow.agent_execution_driver = "provider-cli" (default)
 → claude-cli
 → claude -p --model claude-opus-4-7
-
-model_overrides.gsd-executor = "openai/gpt-5.5"
-workflow.agent_execution_driver = "hermes-terminal-tool"
-→ hermes-terminal-tool
-→ hermes chat --toolsets terminal,file --model openai/gpt-5.5 --provider openai
 ```
 
-The guarantee is matching driver or fail-fast. OpenAI/GPT bindings must not silently run through `claude -p`, Anthropic/Claude bindings must not silently run through `codex exec`, Hermes-native driver preferences must not silently fall back to provider CLIs, and `workflow.cross_ai_execution` remains a lower-priority whole-plan fallback.
+The guarantee is matching driver or fail-fast. `hermes/*` bindings must not silently fall back to provider CLIs, OpenAI/GPT bindings must not silently run through `claude -p`, Anthropic/Claude bindings must not silently run through `codex exec`, and `workflow.cross_ai_execution` remains a lower-priority whole-plan fallback.
 
 ---
 
@@ -915,7 +916,7 @@ Configure GSD settings interactively — workflow toggles, advanced knobs, integ
 | Planning Tuning | `workflow.plan_bounce`, `workflow.plan_bounce_passes`, `workflow.plan_bounce_script`, `workflow.subagent_timeout`, `workflow.inline_plan_threshold` |
 | Execution Tuning | `workflow.node_repair`, `workflow.node_repair_budget`, `workflow.auto_prune_state` |
 | Discussion Tuning | `workflow.max_discuss_passes` |
-| Cross-AI / Provider Routing | `workflow.agent_execution_router`, `workflow.cross_ai_execution`, `workflow.cross_ai_command`, `workflow.cross_ai_timeout` |
+| Cross-AI / Provider Routing | `model_overrides` (`hermes/*`, `openai/*`, `anthropic/*`), `workflow.cross_ai_execution`, `workflow.cross_ai_command`, `workflow.cross_ai_timeout` |
 | Git Customization | `git.base_branch`, `git.phase_branch_template`, `git.milestone_branch_template` |
 | Runtime / Output | `response_language`, `context_window`, `search_gitignored`, `graphify.build_timeout` |
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,9 +4,9 @@
 
 ---
 
-## GSD Hermes v1.10.0 Release Note
+## GSD Hermes v1.11.0 Release Note
 
-`gsd-hermes@1.10.0` keeps the upstream base at `upstream/main@f2decefe` and extends the downstream strict-provider contract with Hermes-native execution drivers. For Hermes projects, `model_overrides` remain the source of model intent; `workflow.agent_execution_router: "provider-cli"` still binds OpenAI/GPT overrides to Codex CLI and Anthropic/Claude overrides to Claude CLI by default, while `workflow.agent_execution_driver: "hermes-chat"` or `"hermes-terminal-tool"` explicitly routes supported provider families through `hermes chat` without silently falling back to Claude/Codex CLIs.
+`gsd-hermes@1.11.0` keeps the upstream base at `upstream/main@f2decefe` and simplifies Hermes-native provider routing. For Hermes projects, `model_overrides` remain the source of model intent: `hermes/gpt-5-5` and `hermes/claude-opus-4-7` automatically route through Hermes chat/tool execution without requiring `workflow.agent_execution_router` or `workflow.agent_execution_driver`. Plain `openai/*` and `anthropic/*` overrides still keep the strict direct Codex/Claude CLI routes.
 
 ---
 
@@ -210,9 +210,9 @@ All workflow toggles follow the **absent = enabled** pattern. If a key is missin
 | `workflow.plan_chunked` | boolean | `false` | Enable chunked planning mode. When `true` (or when `--chunked` flag is passed to `/gsd-plan-phase`), the orchestrator splits the single long-lived planner Task into a short outline Task followed by N short per-plan Tasks (~3-5 min each). Each plan is committed individually for crash resilience. If a Task hangs and the terminal is force-killed, rerunning with `--chunked` resumes from the last completed plan. Particularly useful on Windows where long-lived Tasks may hang on stdio. Added in v1.38 |
 | `workflow.code_review_command` | string | (none) | Shell command for external code review integration in `/gsd-ship`. Receives changed file paths via stdin. Non-zero exit blocks the ship workflow. Added in v1.36 |
 | `workflow.tdd_mode` | boolean | `false` | Enable TDD pipeline as a first-class execution mode. When `true`, the planner aggressively applies `type: tdd` to eligible tasks (business logic, APIs, validations, algorithms) and the executor enforces RED/GREEN/REFACTOR gate sequence. An end-of-phase collaborative review checkpoint verifies gate compliance. Added in v1.36 |
-| `workflow.cross_ai_execution` | boolean | `false` | Legacy whole-plan external AI CLI fallback. In gsd-hermes provider-cli mode, valid `agent_execution_bindings` take priority and `cross_ai_execution` must not reroute a configured per-agent provider binding. Added in v1.36 |
-| `workflow.agent_execution_router` | string | (none) | Optional per-agent execution router. `provider-cli` turns explicit `model_overrides` into strict provider-family execution bindings. Default driver mapping routes Anthropic/Claude models to Claude CLI and OpenAI/GPT models to Codex CLI. Experimental in v1.8; Hermes-native driver preferences added in v1.10. |
-| `workflow.agent_execution_driver` | string | `provider-cli` | Optional driver preference used only when `workflow.agent_execution_router` is `"provider-cli"`. `provider-cli` keeps direct Codex/Claude CLI routing; `hermes-chat` renders `hermes chat --model ... --provider ...`; `hermes-terminal-tool` renders `hermes chat --toolsets terminal,file --model ...`. Unsupported or unavailable drivers fail fast. Added in v1.10. |
+| `workflow.cross_ai_execution` | boolean | `false` | Legacy whole-plan external AI CLI fallback. In gsd-hermes strict routing, valid `agent_execution_bindings` take priority and `cross_ai_execution` must not reroute a configured per-agent binding. Added in v1.36 |
+| `workflow.agent_execution_router` | string | (none) | Advanced compatibility switch for explicit per-agent execution bindings. Normal Hermes-native usage should prefer `model_overrides` values like `hermes/gpt-5-5`; the SDK auto-emits bindings for `hermes/*` without this setting. `provider-cli` remains available for forcing direct provider-family CLI bindings. Experimental in v1.8; simplified `hermes/*` routing added in v1.11. |
+| `workflow.agent_execution_driver` | string | `provider-cli` | Advanced compatibility preference used only with the explicit router. Most users should not set it; use `hermes/<model>` in `model_overrides` for Hermes-native execution. `provider-cli` keeps direct Codex/Claude CLI routing; `hermes-chat` and `hermes-terminal-tool` remain available for advanced tests/migrations. Unsupported or unavailable drivers fail fast. Added in v1.10; primary docs simplified in v1.11. |
 | `workflow.cross_ai_command` | string | (none) | Shell command template for cross-AI execution. Receives the phase prompt via stdin. Must produce SUMMARY.md-compatible output. Required when `cross_ai_execution` is `true`. Added in v1.36 |
 | `workflow.cross_ai_timeout` | number | `300` | Timeout in seconds for cross-AI execution commands. Prevents runaway external processes. Added in v1.36 |
 | `workflow.ai_integration_phase` | boolean | `true` | Enable the `/gsd-ai-integration-phase` command. When `false`, the command exits with a configuration gate message |
@@ -659,38 +659,46 @@ Proof boundary: current tests prove GSD resolver behavior, workflow receipt seri
 
 #### Provider-routed agent execution (gsd-hermes strict mode)
 
-Set `workflow.agent_execution_router` to `"provider-cli"` when you want `model_overrides` to select the matching strict execution route per GSD agent instead of relying on one global runtime default. This is the strict mode for mixed-provider Hermes workflows.
+Use `model_overrides` to choose the execution route per GSD agent. The normal Hermes-native form is now the `hermes/` model namespace — no `workflow.agent_execution_router` or `workflow.agent_execution_driver` is required.
 
-By default, `workflow.agent_execution_driver` is `"provider-cli"`, which means OpenAI/GPT goes to Codex CLI and Anthropic/Claude goes to Claude Code CLI. Set `workflow.agent_execution_driver` to `"hermes-chat"` or `"hermes-terminal-tool"` when you want the configured model/provider to run through Hermes itself instead of a provider-specific CLI.
-
-Copy/paste starting point:
+Copy/paste starting point for Hermes-native execution:
 
 ```json
 {
   "runtime": "hermes",
   "resolve_model_ids": "omit",
   "workflow": {
-    "agent_execution_router": "provider-cli",
-    "agent_execution_driver": "provider-cli",
     "cross_ai_execution": false
   },
   "model_overrides": {
-    "gsd-executor": "openai/gpt-5.5",
-    "gsd-verifier": "anthropic/claude-opus-4-7"
+    "gsd-executor": "hermes/gpt-5-5",
+    "gsd-verifier": "hermes/claude-opus-4-7"
   }
 }
 ```
 
-| `model_overrides` family | `agent_execution_driver` | `agent_execution_bindings.*.execution_driver` | Command shape |
-| --- | --- | --- | --- |
-| `openai/*`, `gpt-*`, `o3`, `o4-*` | `provider-cli` | `codex-cli` | `codex exec --model {cli_model}` |
-| `anthropic/*`, `claude-*`, `opus`, `sonnet`, `haiku` | `provider-cli` | `claude-cli` | `claude -p --model {cli_model}` |
-| `openai/*`, `anthropic/*`, `google/*` | `hermes-chat` | `hermes-chat` | `hermes chat --model {cli_model} --provider {provider}` |
-| `openai/*`, `anthropic/*`, `google/*` | `hermes-terminal-tool` | `hermes-terminal-tool` | `hermes chat --toolsets terminal,file --model {cli_model} --provider {provider}` |
+| `model_overrides` value | `agent_execution_bindings.*.execution_driver` | Command shape |
+| --- | --- | --- |
+| `hermes/gpt-5-5` | `hermes-terminal-tool` | `hermes chat --toolsets terminal,file --model openai/gpt-5.5` |
+| `hermes/claude-opus-4-7` | `hermes-terminal-tool` | `hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7` |
+| `openai/gpt-5.5`, `gpt-*`, `o3`, `o4-*` | `codex-cli` | `codex exec --model {cli_model}` |
+| `anthropic/claude-opus-4-7`, `claude-*`, `opus`, `sonnet`, `haiku` | `claude-cli` | `claude -p --model {cli_model}` |
 
 Examples:
 
 ```text
+model_overrides.gsd-executor = "hermes/gpt-5-5"
+→ provider_family=openai
+→ execution_driver=hermes-terminal-tool
+→ cli_model=openai/gpt-5.5
+→ hermes chat --toolsets terminal,file --model openai/gpt-5.5
+
+model_overrides.gsd-verifier = "hermes/claude-opus-4-7"
+→ provider_family=anthropic
+→ execution_driver=hermes-terminal-tool
+→ cli_model=anthropic/claude-opus-4-7
+→ hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7
+
 model_overrides.gsd-executor = "openai/gpt-5.5"
 → provider_family=openai
 → execution_driver=codex-cli
@@ -698,25 +706,17 @@ model_overrides.gsd-executor = "openai/gpt-5.5"
 → codex exec --model gpt-5.5
 
 model_overrides.gsd-verifier = "anthropic/claude-opus-4-7"
-workflow.agent_execution_driver = "provider-cli"
 → provider_family=anthropic
 → execution_driver=claude-cli
 → cli_model=claude-opus-4-7
 → claude -p --model claude-opus-4-7
-
-model_overrides.gsd-executor = "openai/gpt-5.5"
-workflow.agent_execution_driver = "hermes-terminal-tool"
-→ provider_family=openai
-→ execution_driver=hermes-terminal-tool
-→ cli_model=openai/gpt-5.5
-→ hermes chat --toolsets terminal,file --model openai/gpt-5.5 --provider openai
 ```
 
-Provider-cli mode is fail-fast. Unsupported provider families, missing `cli_model`, missing CLI binaries, or unavailable CLI authentication stop the workflow with an actionable diagnostic. They must not silently fall back to the parent model, Hermes `delegation.model`, or an unrelated CLI such as `claude -p` for OpenAI/GPT bindings.
+This is fail-fast. Unsupported provider families, missing `cli_model`, missing CLI binaries, or unavailable CLI authentication stop the workflow with an actionable diagnostic. `hermes/*` must not silently fall back to Codex/Claude CLIs, OpenAI/GPT must not silently fall back to `claude -p`, and Anthropic/Claude must not silently fall back to `codex exec`.
 
-Hermes-native driver preferences keep this same guarantee but change the execution surface. `hermes-chat` and `hermes-terminal-tool` preserve the fully-qualified configured model token (`openai/gpt-5.5`, `anthropic/claude-opus-4-7`, etc.) and render `hermes chat --model ... --provider ...`; they do not normalize OpenAI to Codex CLI model names or Anthropic to Claude CLI aliases. `hermes-terminal-tool` additionally requests the `terminal,file` toolsets for code-writing executor work.
+Advanced compatibility: `workflow.agent_execution_router: "provider-cli"` and `workflow.agent_execution_driver` still exist for v1.10 configs and test fixtures, but they are no longer needed for the main Hermes-native path. Prefer `hermes/<model>` unless you are deliberately testing a specific legacy driver preference.
 
-`workflow.cross_ai_execution` remains a legacy whole-plan fallback. It is lower priority than valid provider-cli direct bindings and should be used only when you deliberately want to bypass per-agent routing with an explicit `workflow.cross_ai_command`.
+`workflow.cross_ai_execution` remains a legacy whole-plan fallback. It is lower priority than valid per-agent bindings and should be used only when you deliberately want to bypass per-agent routing with an explicit `workflow.cross_ai_command`.
 
 `model_overrides` can be set in either `.planning/config.json` (per-project)
 or `~/.gsd/defaults.json` (global). Per-project entries win on conflict and

--- a/docs/hermes-compatibility.md
+++ b/docs/hermes-compatibility.md
@@ -48,7 +48,7 @@ Validation evidence: `node --test tests/runtime-model-parity.test.cjs` (enrolled
 | Resolver | `resolved_by_gsd` | GSD recognized the agent and resolved the configured model/profile/omit path into a binding token or an explicit rejection. | Proves GSD resolver behavior only. |
 | Workflow handoff | `passed_to_runtime` | GSD has a non-empty explicit token ready for a runtime handoff. | Proves workflow payload construction, not provider use. |
 | Hermes child construction | `runtime_binding_channel`, child construction tests | Hermes receives the intended child model through direct `delegate_task(model=...)` or batch `tasks[].model`. | Proves child `AIAgent(model=...)` construction, not live provider wire-level dispatch. |
-| Provider-routed CLI command | `agent_execution_bindings`, provider-cli dispatcher tests | GSD selects `codex exec --model ...` for OpenAI/GPT-family models and `claude -p --model ...` for Anthropic/Claude-family models. | Proves deterministic command routing and normalized CLI model arguments, not provider wire-level API routing inside external CLI tools. |
+| Provider-routed CLI command | `agent_execution_bindings`, provider-cli dispatcher tests | GSD selects `hermes chat --model ...` for `hermes/*` overrides, `codex exec --model ...` for OpenAI/GPT-family models, and `claude -p --model ...` for Anthropic/Claude-family models. | Proves deterministic command routing and normalized CLI model arguments, not provider wire-level API routing inside external CLI tools. |
 | Provider diagnostics | sanitized provider metadata | Safe metadata can expose provider/model/proof source without raw headers, request bodies, messages, or secrets. | Diagnostic proof only; credentials and raw payloads must never be stored. |
 | Provider wire-level proof | `runtime_enforced` when supported by sanitized request evidence | A provider request or wire-level capture proves the live child request used `model=...`. | Highest-confidence proof; not claimed unless captured safely. |
 
@@ -60,18 +60,20 @@ Phase 12 adds fail-fast validation and proof tests: unsupported explicit Hermes 
 
 ### Provider-Routed CLI Enforcement
 
-`workflow.agent_execution_router: "provider-cli"` is the recommended strict route when operators need different GSD agents to run under different provider CLIs in a Hermes workflow. The SDK emits `agent_execution_bindings` from `model_overrides`; `/gsd-execute-phase` consumes those bindings before legacy Task/delegate/cross-AI fallback paths.
+`model_overrides` is the recommended strict route when operators need different GSD agents to run under different execution surfaces in a Hermes workflow. Use `hermes/<model>` for Hermes-native execution without `workflow.agent_execution_*` config, or plain `openai/*` / `anthropic/*` values for direct provider CLIs. The SDK emits `agent_execution_bindings` from `model_overrides`; `/gsd-execute-phase` consumes those bindings before legacy Task/delegate/cross-AI fallback paths.
 
 | Configured model | Provider family | Driver | Command proof |
 | --- | --- | --- | --- |
+| `hermes/gpt-5-5` | OpenAI/GPT | Hermes terminal tool | `hermes chat --toolsets terminal,file --model openai/gpt-5.5 ...` |
+| `hermes/claude-opus-4-7` | Anthropic/Claude | Hermes terminal tool | `hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7 ...` |
 | `openai/gpt-5.5` or `gpt-5.5` | OpenAI/GPT | Codex CLI | `codex exec --model gpt-5.5 ...` |
 | `anthropic/claude-opus-4-7` or `claude-opus-4-7` | Anthropic/Claude | Claude Code CLI | `claude -p --model claude-opus-4-7 ...` |
 
-This mode intentionally fails fast for unsupported families, missing `cli_model`, missing CLI binaries, or unavailable CLI authentication. A valid provider-cli binding has priority over `workflow.cross_ai_execution`; that legacy setting remains a whole-plan fallback and must not silently override per-agent provider routing.
+This mode intentionally fails fast for unsupported families, missing `cli_model`, missing CLI binaries, or unavailable CLI authentication. A valid per-agent binding has priority over `workflow.cross_ai_execution`; that legacy setting remains a whole-plan fallback and must not silently override per-agent provider routing.
 
-Proof boundary: provider-cli mode proves that GSD chose the matching CLI driver and passed the normalized `--model` argument. It does not prove what Anthropic, OpenAI, Codex CLI, or Claude Code CLI sends on the wire after that process starts. Wire-level proof would require separate sanitized provider diagnostics.
+Proof boundary: provider-routed mode proves that GSD chose the matching driver and passed the normalized `--model` argument. It does not prove what Hermes Agent, Anthropic, OpenAI, Codex CLI, or Claude Code CLI sends on the wire after that process starts. Wire-level proof would require separate sanitized provider diagnostics.
 
-Provider-cli mode is separate from Hermes native `delegate_task(model=...)` child-construction proof. Native delegate proof applies only when GSD uses Hermes child spawning; provider-cli proof applies when GSD deliberately uses external provider CLIs for per-agent routing.
+Provider-cli mode is separate from Hermes native `delegate_task(model=...)` child-construction proof. Native delegate proof applies only when GSD uses Hermes child spawning; provider-cli proof applies when GSD deliberately uses rendered commands (`hermes chat`, Codex CLI, or Claude Code CLI) for per-agent routing.
 
 Do not log secrets while collecting receipt evidence. Provider requests or diagnostic captures must redact API keys, tokens, cookies, passwords, authorization headers, client secrets, and credential-bearing URLs. Raw provider headers, request bodies, messages, and connection strings must not be persisted.
 

--- a/docs/releases/v1.11.0-hermes-model-prefix-routing.md
+++ b/docs/releases/v1.11.0-hermes-model-prefix-routing.md
@@ -1,0 +1,50 @@
+# GSD Hermes v1.11.0 — Hermes model-prefix routing
+
+Released: 2026-05-03
+
+## Summary
+
+`gsd-hermes@1.11.0` makes Hermes-native execution much simpler: put the execution surface directly in `model_overrides` with `hermes/<model>` and GSD routes that agent through Hermes chat/tool execution automatically.
+
+No normal project config needs `workflow.agent_execution_router` or `workflow.agent_execution_driver` for this path.
+
+## What changed
+
+- Added `hermes/*` model-prefix routing:
+  - `hermes/gpt-5-5` → Hermes-native execution via `hermes chat --toolsets terminal,file --model openai/gpt-5.5`
+  - `hermes/claude-opus-4-7` → Hermes-native execution via `hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7`
+- Kept existing strict provider-CLI routes intact:
+  - `openai/gpt-5.5` → `codex exec --model gpt-5.5`
+  - `anthropic/claude-opus-4-7` → `claude -p --model claude-opus-4-7`
+- Removed `--provider ...` from Hermes command rendering so Hermes can resolve provider selection from its normal model/config handling.
+- Kept `workflow.agent_execution_driver` as an advanced/backward-compatible setting for v1.10 configs and targeted tests, but moved it out of the main documented path.
+
+## Copy/paste config
+
+```json
+{
+  "runtime": "hermes",
+  "resolve_model_ids": "omit",
+  "workflow": {
+    "cross_ai_execution": false
+  },
+  "model_overrides": {
+    "gsd-executor": "hermes/gpt-5-5",
+    "gsd-verifier": "hermes/claude-opus-4-7"
+  }
+}
+```
+
+## Compatibility
+
+- `model_overrides` remains the source of per-agent model intent.
+- `cross_ai_execution` remains a lower-priority legacy whole-plan fallback.
+- Unsupported or unavailable routes fail fast; no valid `hermes/*`, OpenAI/GPT, or Anthropic/Claude binding may silently fall back to an unrelated runtime/CLI.
+
+## Verification
+
+Local release-prep validation included:
+
+- `npm run build:sdk`
+- `node --test tests/agent-execution-router.test.cjs tests/provider-cli-dispatch.test.cjs`
+- docs drift searches for `agent_execution_driver`, `agent_execution_router`, `--provider`, and `hermes/*` examples

--- a/get-shit-done/bin/lib/config-schema.cjs
+++ b/get-shit-done/bin/lib/config-schema.cjs
@@ -46,7 +46,7 @@ const VALID_CONFIG_KEYS = new Set([
   'planning.commit_docs', 'planning.search_gitignored', 'planning.sub_repos',
   'review.ollama_host', 'review.lm_studio_host', 'review.llama_cpp_host',
   'workflow.cross_ai_execution', 'workflow.cross_ai_command', 'workflow.cross_ai_timeout',
-  'workflow.agent_execution_router',
+  'workflow.agent_execution_router', 'workflow.agent_execution_driver',
   'workflow.subagent_timeout',
   'workflow.inline_plan_threshold',
   'hooks.context_warnings',

--- a/get-shit-done/bin/lib/provider-cli-dispatch.cjs
+++ b/get-shit-done/bin/lib/provider-cli-dispatch.cjs
@@ -64,13 +64,6 @@ function renderProviderCliReceipt(binding) {
   };
 }
 
-function providerNameForHermes(providerFamily) {
-  if (providerFamily === 'openai') return 'openai';
-  if (providerFamily === 'anthropic') return 'anthropic';
-  if (providerFamily === 'google') return 'google';
-  return null;
-}
-
 function renderHermesDisplay(argv, promptPath, workdir) {
   const prefix = `cd ${shellQuote(workdir)} && `;
   const queryIndex = argv.indexOf('--query');
@@ -123,17 +116,12 @@ function renderProviderCliCommand(binding, options = {}) {
       '-C', workdir,
     ];
   } else if (driver === 'hermes-chat' || driver === 'hermes-terminal-tool') {
-    const provider = providerNameForHermes(normalized.provider_family);
-    if (!provider) {
-      throw bindingError(normalized, 'Hermes-native command rendering requires a supported provider_family.');
-    }
     argv = [
       'hermes',
       'chat',
       '--quiet',
       '--source', 'gsd-provider-cli',
       '--model', cliModel,
-      '--provider', provider,
     ];
     if (driver === 'hermes-terminal-tool') {
       argv.push('--toolsets', 'terminal,file');
@@ -190,7 +178,7 @@ function preflightProviderCliDriver(binding, env = process.env) {
       command,
       receipt,
       message: `Cannot execute ${normalized.agent || 'agent'}: unsupported provider CLI binding.`,
-      suggested_fix: normalized.suggested_fix || 'Choose a supported provider-cli model override or disable workflow.agent_execution_router.',
+      suggested_fix: normalized.suggested_fix || 'Choose a supported model_overrides value such as hermes/gpt-5-5, openai/gpt-5.5, or anthropic/claude-opus-4-7.',
     };
   }
 
@@ -205,7 +193,7 @@ function preflightProviderCliDriver(binding, env = process.env) {
         ? 'Install/login Claude Code CLI or change this agent model_overrides entry to a provider routed to an available driver.'
         : driver === 'codex-cli'
           ? 'Install/login Codex CLI or change this agent model_overrides entry to a provider routed to an available driver.'
-          : 'Install/login Hermes Agent CLI and configure the requested provider credentials, or set workflow.agent_execution_driver to provider-cli.',
+          : 'Install/login Hermes Agent CLI and configure the requested provider credentials, or use a plain openai/* or anthropic/* model_overrides value for direct provider-CLI routing.',
       path_entries: pathEntriesFromEnv(env),
     };
   }

--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -341,7 +341,8 @@ Set via `manager.*` namespace (e.g., `"manager": { "flags": { "discuss": "--auto
 |-----|------|---------|----------------|-------------|
 | `parallelization` | boolean\|object | `true` | `true`, `false`, `{ "enabled": true }` | Enable parallel wave execution; object form allows additional sub-keys |
 | `model_overrides` | object\|null | `null` | `{ "<agent-type>": "<model-id>" }` | Override model selection per agent type |
-| `workflow.agent_execution_router` | string\|null | `null` | `"provider-cli"`, `null` | gsd-hermes per-agent provider routing. With `provider-cli`, `agent_execution_bindings` route Anthropic/Claude models to `claude -p` and OpenAI/GPT models to `codex exec`; unsupported drivers fail fast. |
+| `workflow.agent_execution_router` | string\|null | `null` | `"provider-cli"`, `null` | Advanced gsd-hermes compatibility switch for explicit per-agent provider routing. Normal Hermes-native usage should prefer `model_overrides` values like `hermes/gpt-5-5`, which auto-emit `agent_execution_bindings` without this setting. |
+| `workflow.agent_execution_driver` | string\|null | `"provider-cli"` | `"provider-cli"`, `"hermes-chat"`, `"hermes-terminal-tool"` | Advanced driver preference for explicit provider routing. Most projects should leave this unset and use `hermes/<model>` for Hermes-native execution. |
 | `agent_skills` | object | `{}` | `{ "<agent-type>": "<skill-set>" }` | Assign skill sets to specific agent types |
 | `sub_repos` | array | `[]` | Array of relative path strings | Child directories with independent `.git` repos (auto-detected) |
 
@@ -364,7 +365,7 @@ Several config fields affect each other or trigger special behavior:
 
 2. **`branching_strategy` controls branch templates** -- The `phase_branch_template` and `milestone_branch_template` fields are only used when `branching_strategy` is set to `"phase"` or `"milestone"` respectively. When `branching_strategy` is `"none"`, all template fields are ignored.
 
-3. **`workflow.agent_execution_router` has priority over legacy `workflow.cross_ai_execution`** -- `provider-cli` is per-agent provider routing driven by `model_overrides` and `agent_execution_bindings`; `cross_ai_execution` is a legacy whole-plan fallback. A valid provider-cli binding must not be silently overridden by cross-AI fallback.
+3. **Per-agent execution bindings have priority over legacy `workflow.cross_ai_execution`** -- `model_overrides` values such as `hermes/gpt-5-5`, `openai/gpt-5.5`, and `anthropic/claude-opus-4-7` drive `agent_execution_bindings`; `cross_ai_execution` is a legacy whole-plan fallback. A valid per-agent binding must not be silently overridden by cross-AI fallback.
 
 4. **`context_window` threshold triggers** -- When `context_window >= 500000`, workflows enable adaptive context enrichment: full-body reads of prior phase SUMMARYs, cross-phase context injection in plan-phase, and deeper read depth for anti-pattern references. Below 500000, only frontmatter and summaries are read.
 

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -10,7 +10,7 @@ Orchestrator coordinates, not executes. Each subagent loads the full execute-pla
 
 <runtime_compatibility>
 **Subagent spawning is runtime-specific:**
-- **Provider CLI router (gsd-hermes):** When `agent_execution_bindings.router == "provider-cli"`, consume the SDK binding first and dispatch via the selected CLI driver (`codex exec` or `claude -p`) with prompt-file/stdin delivery. This branch is sequential on the current working tree in Phase 8.2 unless a later phase adds safe external worktree orchestration.
+- **Provider-routed execution (gsd-hermes):** When `agent_execution_bindings.router == "provider-cli"`, consume the SDK binding first and dispatch via the selected driver (`hermes chat`, `codex exec`, or `claude -p`) with prompt-file/stdin delivery. `hermes/<model>` overrides auto-select Hermes chat/tool execution without requiring workflow `agent_execution_*` config. This branch is sequential on the current working tree in Phase 8.2 unless a later phase adds safe external worktree orchestration.
 - **Claude Code:** Uses `Task(subagent_type="gsd-executor", ...)` — blocks until complete, returns result
 - **Copilot:** Subagent spawning does not reliably return completion signals. **Default to
   sequential inline execution**: read and follow execute-plan.md directly for each plan
@@ -71,13 +71,13 @@ Parse JSON for: `executor_model`, `verifier_model`, `model_binding_receipts`, `a
 ```
 `runtime_enforced=unknown is not provider proof`; runtime_binding_channel.kind=hermes-delegate-task-model with proof_level=child-construction maps Hermes explicit tokens to `delegate_task(model=...)`/`tasks[].model`; if unavailable, stop before spawning. Keep `executor_model === "inherit"` by omitting `model=`.
 
-**Provider-cli execution receipt:** If `agent_execution_bindings.router == "provider-cli"`, render/select `agent_execution_bindings.agents.*` before any spawn/fallback as the canonical driver selection:
+**Provider-routed execution receipt:** If `agent_execution_bindings.router == "provider-cli"`, render/select `agent_execution_bindings.agents.*` before any spawn/fallback as the canonical driver selection. `hermes/*` model overrides may create this receipt automatically even when workflow `agent_execution_*` settings are absent:
 
 ```text
 ## Provider CLI execution receipt — router={router} strict={strict}
 - executor/verifier: configured={configured_model} provider={provider_family} driver={execution_driver} cli_model={cli_model} source={source} status={status} diagnostic={diagnostic}
 ```
-Proof boundary: provider-cli proves deterministic CLI driver selection and model argument passing (`codex exec --model ...` or `claude -p --model ...`), not wire-level provider API proof. Unsupported/missing drivers fail before execution. do not re-derive provider family from raw model strings and do not let legacy `cross_ai_execution` override valid provider-routed bindings.
+Proof boundary: provider-routed execution proves deterministic driver selection and model argument passing (`hermes chat --model ...`, `codex exec --model ...`, or `claude -p --model ...`), not wire-level provider API proof. Unsupported/missing drivers fail before execution. Do not re-derive provider family from raw model strings and do not let legacy `cross_ai_execution` override valid provider-routed bindings.
 
 **Model resolution:** If `executor_model` is `"inherit"`, omit the `model=` parameter from all `Task()` calls — do NOT pass `model="inherit"` to Task. Omitting the `model=` parameter causes Claude Code to inherit the current orchestrator model automatically. Only set `model=` when `executor_model` is an explicit model name (e.g., `"claude-sonnet-4-6"`, `"claude-opus-4-7"`).
 
@@ -304,13 +304,13 @@ that should be delegated to an external AI command and executes them via stdin-b
 delivery. Plans handled here are removed from the execute_waves plan list so the normal
 executor skips them.
 
-**Activation logic (legacy whole-plan fallback, lower priority than provider-cli):**
+**Activation logic (legacy whole-plan fallback, lower priority than provider-routed bindings):**
 
-1. If `agent_execution_bindings.router == "provider-cli"` and the selected binding is valid, prefer provider-cli direct execution and skip legacy `workflow.cross_ai_execution`. This prevents a valid OpenAI/GPT binding from being silently rerouted to an unrelated `claude -p` fallback.
+1. If `agent_execution_bindings.router == "provider-cli"` and the selected binding is valid, prefer the per-agent binding and skip legacy `workflow.cross_ai_execution`. This prevents `hermes/*`, OpenAI/GPT, or Anthropic/Claude bindings from being silently rerouted to an unrelated fallback.
 2. If `CROSS_AI_DISABLED` is true (`--no-cross-ai` flag): skip this step entirely.
-3. If `CROSS_AI_FORCE` is true (`--cross-ai` flag): this is an explicit request to bypass provider-cli routing and use legacy whole-plan cross-AI. Before doing so, warn that provider-cli would otherwise have priority; if `workflow.agent_execution_router` is `provider-cli`, require the user to confirm or disable that router.
+3. If `CROSS_AI_FORCE` is true (`--cross-ai` flag): this is an explicit request to bypass per-agent routing and use legacy whole-plan cross-AI. Before doing so, warn that provider-routed bindings would otherwise have priority; if `agent_execution_bindings.router == "provider-cli"`, require the user to confirm or disable the binding source.
 4. Otherwise: check each plan's frontmatter for `cross_ai: true` AND verify config
-   `workflow.cross_ai_execution` is `true`. Plans matching both conditions are marked for cross-AI only when provider-cli router is absent/disabled or no valid provider-cli binding exists.
+   `workflow.cross_ai_execution` is `true`. Plans matching both conditions are marked for cross-AI only when provider-routed bindings are absent/disabled or no valid binding exists.
 
 ```bash
 CROSS_AI_ENABLED=$(gsd-sdk query config-get workflow.cross_ai_execution 2>/dev/null || echo "false")
@@ -481,7 +481,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
 
    **Sequential dispatch for parallel execution (waves with 2+ agents):** Dispatch each `Task()` call one at a time with `run_in_background: true`; do not send multiple Task calls in one message. WRONG: multiple Task() calls in a single message. `git worktree add` locks `.git/config.lock`, so sequential dispatch avoids lock contention while agents still run in parallel after creation.
 
-   **Provider-cli dispatch (gsd-hermes, highest-priority direct binding):** Before any `Task()`/delegate fallback, if `agent_execution_bindings.router == "provider-cli"`, select `agent_execution_bindings.agents.executor`; require `status=resolved` and `execution_driver in {claude-cli,codex-cli,hermes-chat,hermes-terminal-tool}` or fail fast with `configured_model`, `provider_family`, `diagnostic`, and `suggested_fix`. Emit the Provider CLI receipt, state that provider-routed shell execution is sequential on the current working tree (no `Task(isolation="worktree")` claim), write the full prompt to `.planning/tmp/provider-cli/{phase_number}-{plan_id}-executor.md`, preflight/render via `node get-shit-done/bin/gsd-provider-cli-dispatch.cjs`, then execute exactly the rendered command display from the helper. Direct provider CLI drivers use stdin: `codex-cli` → `codex exec --model {cli_model} --full-auto -C {workdir} < {prompt_path}`; `claude-cli` → `claude -p --model {cli_model} --agent gsd-executor --permission-mode acceptEdits < {prompt_path}`. Hermes-native drivers use `hermes chat` with a query loaded from the prompt file: `hermes-chat` → `cd {workdir} && hermes chat --quiet --source gsd-provider-cli --model {cli_model} --provider {provider} --query "$(cat {prompt_path})"`; `hermes-terminal-tool` adds `--toolsets terminal,file`. Non-zero exit is plan failure; never silently fall back to `Task()` or a different CLI after provider-cli selected a driver. This branch consumes SDK binding fields only — no raw `configured_model` regexes.
+   **Provider-routed dispatch (gsd-hermes, highest-priority direct binding):** Before any `Task()`/delegate fallback, if `agent_execution_bindings.router == "provider-cli"`, select `agent_execution_bindings.agents.executor`; require `status=resolved` and `execution_driver in {claude-cli,codex-cli,hermes-chat,hermes-terminal-tool}` or fail fast with `configured_model`, `provider_family`, `diagnostic`, and `suggested_fix`. `hermes/<model>` overrides can produce `hermes-terminal-tool` here without any workflow `agent_execution_*` config. Emit the execution receipt, state that provider-routed shell execution is sequential on the current working tree (no `Task(isolation="worktree")` claim), write the full prompt to `.planning/tmp/provider-cli/{phase_number}-{plan_id}-executor.md`, preflight/render via `node get-shit-done/bin/gsd-provider-cli-dispatch.cjs`, then execute exactly the rendered command display from the helper. Direct provider CLI drivers use stdin: `codex-cli` → `codex exec --model {cli_model} --full-auto -C {workdir} < {prompt_path}`; `claude-cli` → `claude -p --model {cli_model} --agent gsd-executor --permission-mode acceptEdits < {prompt_path}`. Hermes-native drivers use `hermes chat` with a query loaded from the prompt file: `hermes-chat` → `cd {workdir} && hermes chat --quiet --source gsd-provider-cli --model {cli_model} --query "$(cat {prompt_path})"`; `hermes-terminal-tool` adds `--toolsets terminal,file`. Non-zero exit is plan failure; never silently fall back to `Task()` or a different CLI after provider-routed execution selected a driver. This branch consumes SDK binding fields only — no raw `configured_model` regexes.
 
    ```
    Task(
@@ -1345,7 +1345,7 @@ Verify phase achieved its GOAL, not just completed tasks.
 VERIFIER_SKILLS=$(gsd-sdk query agent-skills gsd-verifier)
 ```
 
-**Provider-cli verifier dispatch (gsd-hermes):** If `agent_execution_bindings.router == "provider-cli"`, select `agent_execution_bindings.agents.verifier` before `Task()` fallback, render/preflight with `get-shit-done/bin/gsd-provider-cli-dispatch.cjs`, write `.planning/tmp/provider-cli/{phase_number}-verifier.md`, and run the selected stdin command. Require `{phase_dir}/*-VERIFICATION.md`; CLI non-zero or missing verification fails with the binding diagnostic and must not retry through another runtime. Anthropic verifier → `claude -p --model {cli_model}`; OpenAI verifier → `codex exec --model {cli_model}`. The `Task(subagent_type="gsd-verifier", model="{verifier_model}")` block is fallback only when provider-cli is absent/disabled.
+**Provider-routed verifier dispatch (gsd-hermes):** If `agent_execution_bindings.router == "provider-cli"`, select `agent_execution_bindings.agents.verifier` before `Task()` fallback, render/preflight with `get-shit-done/bin/gsd-provider-cli-dispatch.cjs`, write `.planning/tmp/provider-cli/{phase_number}-verifier.md`, and run the selected stdin command. Require `{phase_dir}/*-VERIFICATION.md`; CLI non-zero or missing verification fails with the binding diagnostic and must not retry through another runtime. `hermes/*` verifier → `hermes chat --toolsets terminal,file --model {cli_model}`; Anthropic verifier → `claude -p --model {cli_model}`; OpenAI verifier → `codex exec --model {cli_model}`. The `Task(subagent_type="gsd-verifier", model="{verifier_model}")` block is fallback only when provider-routed bindings are absent/disabled.
 
 ```
 Task(

--- a/get-shit-done/workflows/settings-advanced.md
+++ b/get-shit-done/workflows/settings-advanced.md
@@ -59,8 +59,10 @@ Discussion Tuning:
 - `workflow.max_discuss_passes` (default: `3`)
 
 Cross-AI Execution / Provider Routing:
-- `workflow.agent_execution_router` (default: `null`; set `"provider-cli"` for per-agent provider→CLI routing)
-- `workflow.cross_ai_execution` (default: `false`; legacy whole-plan fallback, lower priority than valid provider-cli bindings)
+- `model_overrides.<agent>` values like `hermes/gpt-5-5` or `hermes/claude-opus-4-7` are the preferred Hermes-native routing path
+- `workflow.agent_execution_router` (default: `null`; advanced compatibility switch for explicit provider→CLI routing)
+- `workflow.agent_execution_driver` (default: `provider-cli`; advanced compatibility preference, normally unset)
+- `workflow.cross_ai_execution` (default: `false`; legacy whole-plan fallback, lower priority than valid per-agent bindings)
 - `workflow.cross_ai_command` (default: `null`)
 - `workflow.cross_ai_timeout` (default: `300`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Hermes-first Get Shit Done distribution with strict provider-routed agent execution.",
   "bin": {
     "gsd-hermes": "bin/install.js",

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -51,9 +51,9 @@ export interface WorkflowConfig {
   skip_discuss: boolean;
   /** Maximum self-discuss passes in auto/headless mode before forcing proceed. Default: 3. */
   max_discuss_passes: number;
-  /** Per-agent execution router. `provider-cli` maps model provider families to strict execution drivers. */
+  /** Advanced per-agent execution router. Normal Hermes-native usage should prefer `model_overrides` values like `hermes/gpt-5-5`. */
   agent_execution_router?: 'provider-cli' | string;
-  /** Optional driver preference for provider-cli routing (`hermes-chat` / `hermes-terminal-tool` use Hermes-native execution). */
+  /** Advanced driver preference for explicit provider routing; most projects should leave unset. */
   agent_execution_driver?: 'provider-cli' | 'hermes-chat' | 'hermes-terminal-tool' | string;
   /** Subagent timeout in ms (matches `get-shit-done/bin/lib/core.cjs` default 300000). */
   subagent_timeout: number;

--- a/sdk/src/query/agent-execution-router.ts
+++ b/sdk/src/query/agent-execution-router.ts
@@ -77,6 +77,42 @@ function normalizeHermesModel(model: string | null | undefined): string | null {
   return trimmed === '' ? null : trimmed;
 }
 
+function isHermesPrefixedModel(model: string | null | undefined): boolean {
+  return typeof model === 'string' && model.trim().toLowerCase().startsWith('hermes/');
+}
+
+function stripHermesPrefix(model: string): string {
+  return isHermesPrefixedModel(model) ? model.trim().slice('hermes/'.length) : model.trim();
+}
+
+function normalizeOpenAiHermesModel(model: string): string {
+  const unprefixed = model.toLowerCase().startsWith('openai/') ? model.slice('openai/'.length) : model;
+  const dotAlias = unprefixed.replace(/^gpt-(\d+)-(\d+)(.*)$/i, 'gpt-$1.$2$3');
+  return `openai/${dotAlias}`;
+}
+
+function normalizeHermesRoutedModel(model: string | null | undefined, providerFamily: ModelFamily): string | null {
+  if (!model) return null;
+  const inner = stripHermesPrefix(model);
+  if (inner === '') return null;
+
+  if (providerFamily === 'anthropic') {
+    const unprefixed = stripProviderPrefix(inner, 'anthropic');
+    return `anthropic/${MODEL_ALIAS_MAP[unprefixed] ?? unprefixed}`;
+  }
+
+  if (providerFamily === 'openai') {
+    return normalizeOpenAiHermesModel(inner);
+  }
+
+  if (providerFamily === 'google') {
+    const unprefixed = inner.toLowerCase().startsWith('google/') ? inner.slice('google/'.length) : inner;
+    return `google/${unprefixed}`;
+  }
+
+  return inner;
+}
+
 function providerFamilySupportedByHermes(providerFamily: ModelFamily): boolean {
   return providerFamily === 'anthropic' || providerFamily === 'openai' || providerFamily === 'google';
 }
@@ -86,13 +122,19 @@ export function resolveAgentExecutionBinding(
   options: { driverPreference?: AgentExecutionDriverPreference } = {},
 ): AgentExecutionBinding {
   const providerModel = receipt.model_token ?? receipt.resolved_model ?? receipt.configured_model;
-  const providerFamily = receipt.provider_family === 'unknown'
+  const hermesPrefixed = isHermesPrefixedModel(providerModel);
+  const providerFamily = receipt.provider_family === 'unknown' || hermesPrefixed
     ? detectModelFamily(providerModel)
     : receipt.provider_family;
-  const driverPreference = options.driverPreference ?? 'provider-cli';
-  const cliModel = driverPreference === 'provider-cli'
-    ? normalizeCliModel(providerModel, providerFamily)
-    : normalizeHermesModel(providerModel);
+  const requestedPreference = options.driverPreference ?? 'provider-cli';
+  const driverPreference = hermesPrefixed && requestedPreference === 'provider-cli'
+    ? 'hermes-terminal-tool'
+    : requestedPreference;
+  const cliModel = hermesPrefixed
+    ? normalizeHermesRoutedModel(providerModel, providerFamily)
+    : driverPreference === 'provider-cli'
+      ? normalizeCliModel(providerModel, providerFamily)
+      : normalizeHermesModel(providerModel);
 
   if (receipt.status !== 'resolved' || receipt.binding_kind !== 'explicit' || !providerModel) {
     return {
@@ -106,7 +148,7 @@ export function resolveAgentExecutionBinding(
       source: receipt.source,
       strict: true,
       diagnostic: `Provider-routed execution requires an explicit model_overrides binding for ${receipt.agent}.`,
-      suggested_fix: `Set model_overrides.${receipt.agent} to an Anthropic/Claude or OpenAI/GPT model, or disable workflow.agent_execution_router.`,
+      suggested_fix: `Set model_overrides.${receipt.agent} to hermes/gpt-5-5, hermes/claude-opus-4-7, an OpenAI/GPT model, or an Anthropic/Claude model.`,
     };
   }
 
@@ -123,7 +165,7 @@ export function resolveAgentExecutionBinding(
         cli_model: cliModel,
         source: receipt.source,
         strict: true,
-        diagnostic: `${receipt.agent} routes through ${label} with explicit model '${providerModel}'. Hermes is the execution surface; provider selection remains model-driven and must not fall back to Claude/Codex CLI.`,
+        diagnostic: `${receipt.agent} routes through ${label} with explicit model '${providerModel}'. Hermes is the execution surface; provider selection remains model-driven and must not use provider-specific CLIs.`,
         suggested_fix: null,
       };
     }
@@ -139,7 +181,7 @@ export function resolveAgentExecutionBinding(
       source: receipt.source,
       strict: true,
       diagnostic: `Hermes-native provider-routed execution does not support provider family '${providerFamily}' for ${receipt.agent}.`,
-      suggested_fix: `Use an Anthropic/Claude, OpenAI/GPT, or Google/Gemini model override for ${receipt.agent}; set workflow.agent_execution_driver to provider-cli; or disable workflow.agent_execution_router.`,
+      suggested_fix: `Use hermes/gpt-5-5, hermes/claude-opus-4-7, or a supported plain OpenAI/GPT or Anthropic/Claude override for ${receipt.agent}.`,
     };
   }
 
@@ -186,8 +228,15 @@ export function resolveAgentExecutionBinding(
     source: receipt.source,
     strict: true,
     diagnostic: `Provider-routed execution does not support provider family '${providerFamily}' for ${receipt.agent}.`,
-    suggested_fix: `Use an Anthropic/Claude or OpenAI/GPT model override for ${receipt.agent}, or disable workflow.agent_execution_router.`,
+    suggested_fix: `Use an Anthropic/Claude, OpenAI/GPT, hermes/gpt-5-5, or hermes/claude-opus-4-7 model override for ${receipt.agent}.`,
   };
+}
+
+function hasHermesPrefixedReceipt(modelBindingReceipts: { agents: Record<string, RuntimeModelReceipt> }): boolean {
+  return Object.values(modelBindingReceipts.agents).some((receipt) => {
+    const providerModel = receipt.model_token ?? receipt.resolved_model ?? receipt.configured_model;
+    return isHermesPrefixedModel(providerModel);
+  });
 }
 
 export function buildAgentExecutionBindings(
@@ -195,16 +244,20 @@ export function buildAgentExecutionBindings(
   modelBindingReceipts: { agents: Record<string, RuntimeModelReceipt> },
 ): AgentExecutionBindings | null {
   const router = resolveAgentExecutionRouterMode(config);
-  if (router !== 'provider-cli') return null;
+  const hermesPrefixed = hasHermesPrefixedReceipt(modelBindingReceipts);
+  if (router !== 'provider-cli' && !hermesPrefixed) return null;
 
-  const driverPreference = resolveAgentExecutionDriverPreference(config);
+  const configDriverPreference = resolveAgentExecutionDriverPreference(config);
+  const driverPreference = hermesPrefixed && configDriverPreference === 'provider-cli'
+    ? 'hermes-terminal-tool'
+    : configDriverPreference;
   const agents: Record<string, AgentExecutionBinding> = {};
   for (const [role, receipt] of Object.entries(modelBindingReceipts.agents)) {
-    agents[role] = resolveAgentExecutionBinding(receipt, { driverPreference });
+    agents[role] = resolveAgentExecutionBinding(receipt, { driverPreference: configDriverPreference });
   }
 
   return {
-    router,
+    router: 'provider-cli',
     strict: true,
     driver_preference: driverPreference,
     agents,

--- a/sdk/src/query/config-schema.ts
+++ b/sdk/src/query/config-schema.ts
@@ -48,7 +48,7 @@ export const VALID_CONFIG_KEYS: ReadonlySet<string> = new Set([
   'planning.commit_docs', 'planning.search_gitignored', 'planning.sub_repos',
   'review.ollama_host', 'review.lm_studio_host', 'review.llama_cpp_host',
   'workflow.cross_ai_execution', 'workflow.cross_ai_command', 'workflow.cross_ai_timeout',
-  'workflow.agent_execution_router',
+  'workflow.agent_execution_router', 'workflow.agent_execution_driver',
   'workflow.subagent_timeout',
   'workflow.inline_plan_threshold',
   'hooks.context_warnings',

--- a/sdk/src/query/runtime-model-contract.ts
+++ b/sdk/src/query/runtime-model-contract.ts
@@ -181,9 +181,13 @@ function isGoogleModel(model: string): boolean {
   return /^(?:gemini(?:$|[-.])|google\/)/i.test(model);
 }
 
+function unwrapHermesModelPrefix(model: string): string {
+  return model.toLowerCase().startsWith('hermes/') ? model.slice('hermes/'.length) : model;
+}
+
 export function detectModelFamily(model: string | null | undefined): ModelFamily {
   if (!model) return 'unknown';
-  const normalized = model.trim();
+  const normalized = unwrapHermesModelPrefix(model.trim());
   if (normalized === '') return 'unknown';
   if (isAnthropicModel(normalized)) return 'anthropic';
   if (isOpenAiModel(normalized)) return 'openai';

--- a/tests/agent-execution-router.test.cjs
+++ b/tests/agent-execution-router.test.cjs
@@ -108,7 +108,81 @@ describe('provider-routed agent execution bindings', () => {
     assert.equal(binding.strict, true);
   });
 
-  test('routes explicit overrides through Hermes chat when requested by config', () => {
+  test('routes hermes-prefixed GPT overrides through Hermes by default without workflow.agent_execution_* config', () => {
+    const receipt = contract.toRuntimeModelReceipt(
+      contract.resolveAgentBinding({
+        runtime: 'hermes',
+        resolve_model_ids: 'omit',
+        model_overrides: { 'gsd-executor': 'hermes/gpt-5-5' },
+        workflow: {},
+      }, 'gsd-executor'),
+      'executor'
+    );
+
+    const binding = router.resolveAgentExecutionBinding(receipt);
+    assert.equal(binding.status, 'resolved');
+    assert.equal(binding.provider_family, 'openai');
+    assert.equal(binding.execution_driver, 'hermes-terminal-tool');
+    assert.equal(binding.cli_model, 'openai/gpt-5.5');
+    assert.equal(binding.strict, true);
+    assert.match(binding.diagnostic, /Hermes/i);
+    assert.doesNotMatch(binding.diagnostic, /Claude Code CLI|Codex CLI/i);
+  });
+
+  test('routes hermes-prefixed Claude overrides through Hermes by default without workflow.agent_execution_* config', () => {
+    const receipt = contract.toRuntimeModelReceipt(
+      contract.resolveAgentBinding({
+        runtime: 'hermes',
+        resolve_model_ids: 'omit',
+        model_overrides: { 'gsd-verifier': 'hermes/claude-opus-4-7' },
+        workflow: {},
+      }, 'gsd-verifier'),
+      'verifier'
+    );
+
+    const binding = router.resolveAgentExecutionBinding(receipt);
+    assert.equal(binding.status, 'resolved');
+    assert.equal(binding.provider_family, 'anthropic');
+    assert.equal(binding.execution_driver, 'hermes-terminal-tool');
+    assert.equal(binding.cli_model, 'anthropic/claude-opus-4-7');
+    assert.equal(binding.strict, true);
+  });
+
+  test('keeps non-hermes model overrides on provider-specific CLIs when another agent uses hermes prefix', () => {
+    const executorReceipt = contract.toRuntimeModelReceipt(
+      contract.resolveAgentBinding({
+        runtime: 'hermes',
+        resolve_model_ids: 'omit',
+        model_overrides: {
+          'gsd-executor': 'hermes/gpt-5-5',
+          'gsd-verifier': 'anthropic/claude-opus-4-7',
+        },
+        workflow: {},
+      }, 'gsd-executor'),
+      'executor'
+    );
+    const verifierReceipt = contract.toRuntimeModelReceipt(
+      contract.resolveAgentBinding({
+        runtime: 'hermes',
+        resolve_model_ids: 'omit',
+        model_overrides: {
+          'gsd-executor': 'hermes/gpt-5-5',
+          'gsd-verifier': 'anthropic/claude-opus-4-7',
+        },
+        workflow: {},
+      }, 'gsd-verifier'),
+      'verifier'
+    );
+
+    const bindings = router.buildAgentExecutionBindings({ runtime: 'hermes', workflow: {} }, {
+      agents: { executor: executorReceipt, verifier: verifierReceipt },
+    });
+    assert.equal(bindings.agents.executor.execution_driver, 'hermes-terminal-tool');
+    assert.equal(bindings.agents.verifier.execution_driver, 'claude-cli');
+    assert.equal(bindings.agents.verifier.cli_model, 'claude-opus-4-7');
+  });
+
+  test('routes explicit overrides through Hermes chat when requested by advanced config', () => {
     const receipt = contract.toRuntimeModelReceipt(
       contract.resolveAgentBinding({
         runtime: 'hermes',
@@ -131,7 +205,7 @@ describe('provider-routed agent execution bindings', () => {
     assert.match(binding.diagnostic, /Hermes chat/i);
   });
 
-  test('routes explicit overrides through Hermes terminal tool when requested by config', () => {
+  test('routes explicit overrides through Hermes terminal tool when requested by advanced config', () => {
     const receipt = contract.toRuntimeModelReceipt(
       contract.resolveAgentBinding({
         runtime: 'hermes',
@@ -271,7 +345,31 @@ describe('init.execute-phase provider-routed bindings', () => {
     assert.equal(json.agent_execution_bindings.agents.verifier.cli_model, 'anthropic/claude-opus-4-7');
   });
 
-  test('omits agent_execution_bindings when provider-cli router is disabled', () => {
+  test('init.execute-phase auto-emits Hermes-native bindings from hermes-prefixed model overrides without workflow.agent_execution_* config', () => {
+    writeConfig(tmpDir, {
+      runtime: 'hermes',
+      resolve_model_ids: 'omit',
+      model_overrides: {
+        'gsd-executor': 'hermes/gpt-5.5',
+        'gsd-verifier': 'hermes/claude-opus-4-7',
+      },
+      workflow: {},
+    });
+
+    const json = runSdkJson(tmpDir, ['query', 'init.execute-phase', '8.1']);
+    assert.equal(json.executor_model, 'hermes/gpt-5.5');
+    assert.equal(json.verifier_model, 'hermes/claude-opus-4-7');
+    assert.equal(json.agent_execution_bindings.router, 'provider-cli');
+    assert.equal(json.agent_execution_bindings.driver_preference, 'hermes-terminal-tool');
+    assert.equal(json.agent_execution_bindings.agents.executor.execution_driver, 'hermes-terminal-tool');
+    assert.equal(json.agent_execution_bindings.agents.executor.provider_family, 'openai');
+    assert.equal(json.agent_execution_bindings.agents.executor.cli_model, 'openai/gpt-5.5');
+    assert.equal(json.agent_execution_bindings.agents.verifier.execution_driver, 'hermes-terminal-tool');
+    assert.equal(json.agent_execution_bindings.agents.verifier.provider_family, 'anthropic');
+    assert.equal(json.agent_execution_bindings.agents.verifier.cli_model, 'anthropic/claude-opus-4-7');
+  });
+
+  test('omits agent_execution_bindings when provider-cli router is disabled and no hermes-prefixed overrides exist', () => {
     writeConfig(tmpDir, {
       runtime: 'hermes',
       resolve_model_ids: 'omit',

--- a/tests/hermes-provider-routing-regression.test.cjs
+++ b/tests/hermes-provider-routing-regression.test.cjs
@@ -101,26 +101,27 @@ describe('Hermes provider-routed execution regression fixture', () => {
   });
 });
 
-describe('execute-phase provider-cli workflow guardrails', () => {
-  test('workflow keeps provider-cli as canonical direct binding before legacy fallback', () => {
+describe('execute-phase provider-routed workflow guardrails', () => {
+  test('workflow keeps provider-routed bindings canonical before legacy fallback', () => {
     const workflow = require('node:fs').readFileSync(EXECUTE_PHASE, 'utf8');
 
     assert.match(workflow, /agent_execution_bindings\.router == "provider-cli"/);
     assert.match(workflow, /Provider CLI execution receipt/);
-    assert.match(workflow, /Proof boundary: provider-cli proves deterministic CLI driver selection/);
-    assert.match(workflow, /canonical driver selection/);
+    assert.match(workflow, /overrides may create this receipt automatically/i);
+    assert.match(workflow, /Proof boundary: provider-routed execution proves deterministic driver selection/);
+    assert.match(workflow, /hermes chat --model/);
     assert.match(workflow, /codex exec --model/);
     assert.match(workflow, /claude -p --model/);
-    assert.match(workflow, /legacy whole-plan fallback, lower priority than provider-cli/i);
+    assert.match(workflow, /legacy whole-plan fallback, lower priority than provider-routed bindings/i);
     assert.match(workflow, /do not let legacy `cross_ai_execution` override valid provider-routed bindings/);
-    assert.match(workflow, /valid OpenAI\/GPT binding from being silently rerouted to an unrelated `claude -p` fallback/);
+    assert.match(workflow, /silently rerouted to an unrelated fallback/);
   });
 
-  test('workflow does not describe cross_ai_execution as overriding provider-cli', () => {
+  test('workflow does not describe cross_ai_execution as overriding provider-routed bindings', () => {
     const workflow = require('node:fs').readFileSync(EXECUTE_PHASE, 'utf8');
 
-    assert.doesNotMatch(workflow, /cross_ai_execution[^\n]{0,120}overrides[^\n]{0,120}provider-cli/i);
-    assert.doesNotMatch(workflow, /provider-cli[^\n]{0,120}lower priority[^\n]{0,120}cross_ai_execution/i);
+    assert.doesNotMatch(workflow, /cross_ai_execution[^\n]{0,120}overrides[^\n]{0,120}provider-routed/i);
+    assert.doesNotMatch(workflow, /provider-routed[^\n]{0,120}lower priority[^\n]{0,120}cross_ai_execution/i);
     assert.doesNotMatch(workflow, /OpenAI[^\n]{0,120}fallback[^\n]{0,120}claude -p/i);
   });
 });

--- a/tests/provider-cli-dispatch.test.cjs
+++ b/tests/provider-cli-dispatch.test.cjs
@@ -145,8 +145,7 @@ describe('provider CLI dispatch helper', () => {
     assert.deepEqual(command.argv.slice(0, 4), ['hermes', 'chat', '--quiet', '--source']);
     assert.equal(command.argv.includes('--model'), true);
     assert.equal(command.argv[command.argv.indexOf('--model') + 1], 'openai/gpt-5.5');
-    assert.equal(command.argv.includes('--provider'), true);
-    assert.equal(command.argv[command.argv.indexOf('--provider') + 1], 'openai');
+    assert.equal(command.argv.includes('--provider'), false);
     assert.equal(command.argv.includes('claude'), false);
     assert.equal(command.argv.includes('codex'), false);
     assert.match(command.display, /hermes chat .*--model openai\/gpt-5\.5/);
@@ -166,8 +165,8 @@ describe('provider CLI dispatch helper', () => {
     assert.equal(command.argv[command.argv.indexOf('--toolsets') + 1], 'terminal,file');
     assert.equal(command.argv.includes('--model'), true);
     assert.equal(command.argv[command.argv.indexOf('--model') + 1], 'anthropic/claude-opus-4-7');
-    assert.equal(command.argv[command.argv.indexOf('--provider') + 1], 'anthropic');
-    assert.doesNotMatch(command.display, /claude -p|codex exec/);
+    assert.equal(command.argv.includes('--provider'), false);
+    assert.doesNotMatch(command.display, /--provider|claude -p|codex exec/);
   });
 
   test('preflight reports missing Hermes CLI for Hermes-native drivers', () => {


### PR DESCRIPTION
## Summary

- Add `hermes/<model>` model-prefix routing so `model_overrides` can select Hermes-native execution without advanced workflow `agent_execution_*` settings.
- Keep strict direct routes for plain `openai/*` → Codex CLI and `anthropic/*` → Claude Code CLI, including mixed-agent safety.
- Render Hermes-native commands without `--provider`; Hermes receives the fully qualified model token and handles provider routing itself.
- Update README, configuration docs, command docs, execute-phase workflow guidance, changelog, and v1.11 release notes.

## Validation

- [x] `git diff --check`
- [x] conflict-marker scan
- [x] `npm run build:sdk`
- [x] `node --test tests/hermes-provider-routing-regression.test.cjs tests/agent-execution-router.test.cjs tests/provider-cli-dispatch.test.cjs`
- [x] `npm run test:hermes`
- [x] `npm test`
- [x] `npm run lint:tests`
- [x] `npm run lint:changeset`
- [x] `npm pack --dry-run --json > /tmp/gsd-hermes-pack-1.11.0.json`

Closes #57
