### PR TITLE
fix: delegate Hermes routed provider selection

### DIFF
--- a/.changeset/canonical-hermes-gpt-provider.md
+++ b/.changeset/canonical-hermes-gpt-provider.md
@@ -1,0 +1,5 @@
+---
+"gsd-hermes": patch
+---
+
+Use `hermes/gpt-5.5` as the canonical Hermes-native GPT example and ensure Hermes-native strict execution delegates provider selection to the currently configured Hermes provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,30 @@ syncs from.
 
 ## [Unreleased]
 
+## 1.11.1 — 2026-05-03
+
+GSD Hermes package version: `1.11.1`
+Upstream GSD base: `upstream/main@f2decefe` / upstream `get-shit-done-cc@1.40.0-rc.1` development line
+
+### Changed
+- Canonicalized Hermes-native GPT examples to `hermes/gpt-5.5`; `hermes/gpt-5-5` remains a tested backward-compatible alias.
+- Hermes-native strict execution now passes unqualified model tokens such as `gpt-5.5` or `claude-opus-4-7` to `hermes chat` without `--provider`, so provider selection comes from the currently configured Hermes provider.
+
+### Documentation
+- Added release notes: [`docs/releases/v1.11.1-canonical-hermes-gpt-provider.md`](docs/releases/v1.11.1-canonical-hermes-gpt-provider.md).
+
 ## 1.11.0 — 2026-05-03
 
 GSD Hermes package version: `1.11.0`
 Upstream GSD base: `upstream/main@f2decefe` / upstream `get-shit-done-cc@1.40.0-rc.1` development line
 
 ### Added
-- **Hermes model-prefix routing** — `model_overrides` values such as `hermes/gpt-5-5` and `hermes/claude-opus-4-7` now auto-select Hermes-native `hermes chat` execution without requiring `workflow.agent_execution_router` or `workflow.agent_execution_driver` in normal project config.
+- **Hermes model-prefix routing** — `model_overrides` values such as `hermes/gpt-5.5` and `hermes/claude-opus-4-7` now auto-select Hermes-native `hermes chat` execution without requiring `workflow.agent_execution_router` or `workflow.agent_execution_driver` in normal project config.
 - **Per-agent mixed routing safety** — `hermes/*` routes through Hermes while plain `openai/*` and `anthropic/*` overrides in the same phase continue to use Codex CLI and Claude Code CLI respectively.
 
 ### Changed
 - Simplified README, configuration, command, and execute-phase workflow docs so the primary UX is model-string-first instead of `agent_execution_*`-first.
-- Hermes command rendering now omits `--provider ...`; Hermes receives a fully qualified model token such as `openai/gpt-5.5` or `anthropic/claude-opus-4-7` and resolves provider handling through its own config/runtime behavior.
+- Hermes command rendering now omits `--provider ...`; Hermes receives a fully qualified model token such as `openai/gpt-5.5` or `anthropic/claude-opus-4-7` and resolves provider handling through its own config/model handling rather than through GSD-specific provider CLI fallback.
 
 ### Documentation
 - Added release notes: [`docs/releases/v1.11.0-hermes-model-prefix-routing.md`](docs/releases/v1.11.0-hermes-model-prefix-routing.md).

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The point of this package is simple: if you say the executor should use GPT, it 
   "runtime": "hermes",
   "resolve_model_ids": "omit",
   "model_overrides": {
-    "gsd-executor": "hermes/gpt-5-5",
+    "gsd-executor": "hermes/gpt-5.5",
     "gsd-verifier": "hermes/claude-opus-4-7"
   }
 }
@@ -96,21 +96,21 @@ The point of this package is simple: if you say the executor should use GPT, it 
 
 | Configured model | Default execution driver | Command shape |
 | --- | --- | --- |
-| `hermes/gpt-5-5` | Hermes chat + terminal/file toolsets | `hermes chat --toolsets terminal,file --model openai/gpt-5.5` |
-| `hermes/claude-opus-4-7` | Hermes chat + terminal/file toolsets | `hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7` |
+| `hermes/gpt-5.5` | Hermes chat + terminal/file toolsets | `hermes chat --toolsets terminal,file --model gpt-5.5` |
+| `hermes/claude-opus-4-7` | Hermes chat + terminal/file toolsets | `hermes chat --toolsets terminal,file --model claude-opus-4-7` |
 | `openai/*`, `gpt-*` | Codex CLI | `codex exec --model {model}` |
 | `anthropic/*`, `claude-*` | Claude Code CLI | `claude -p --model {model}` |
 | unsupported / unavailable | none | fail fast with diagnostics |
 
 Guarantees:
 
-- `hermes/gpt-5-5` uses Hermes-native execution and must not silently run through `claude -p` or `codex exec`.
+- `hermes/gpt-5.5` uses Hermes-native execution and must not silently run through `claude -p` or `codex exec`; Hermes provider selection comes from the currently configured Hermes provider.
 - `openai/gpt-5.5` still routes directly to Codex CLI.
 - `anthropic/claude-opus-4-7` still routes directly to Claude Code CLI.
-- unsupported model families fail before spawn with actionable diagnostics.
+- unsupported direct provider-CLI model families fail before spawn with actionable diagnostics; `hermes/*` routes are only blocked when Hermes command rendering/preflight cannot produce a valid Hermes invocation.
 - init payloads expose both `model_binding_receipts` and `agent_execution_bindings` so the effective runtime/provider/model/driver is visible.
 
-Boundary: this proves GSD routing and CLI argument rendering. `hermes/*` is an execution namespace for Hermes chat/tooling; it does not claim Hermes is a wire-level model provider.
+Boundary: this proves GSD routing and CLI argument rendering. `hermes/*` is an execution namespace for Hermes chat/tooling; it does not claim Hermes is a wire-level model provider, and GSD intentionally does not pass `--provider` for Hermes-native routes.
 
 ---
 
@@ -128,8 +128,8 @@ Boundary: this proves GSD routing and CLI argument rendering. `hermes/*` is an e
   },
   "model_overrides": {
     "gsd-planner": "hermes/claude-opus-4-7",
-    "gsd-executor": "hermes/gpt-5-5",
-    "gsd-verifier": "hermes/gpt-5-5",
+    "gsd-executor": "hermes/gpt-5.5",
+    "gsd-verifier": "hermes/gpt-5.5",
     "gsd-code-reviewer": "hermes/claude-opus-4-7"
   }
 }
@@ -168,6 +168,7 @@ See [docs/COMMANDS.md](docs/COMMANDS.md) for the full command reference.
 - [docs/releases/v1.9.1-upstream-f2decefe-sync.md](docs/releases/v1.9.1-upstream-f2decefe-sync.md) — v1.9.1 upstream maintenance sync notes.
 - [docs/releases/v1.10.0-hermes-native-provider-routing.md](docs/releases/v1.10.0-hermes-native-provider-routing.md) — Hermes-native execution driver release notes.
 - [docs/releases/v1.11.0-hermes-model-prefix-routing.md](docs/releases/v1.11.0-hermes-model-prefix-routing.md) — simplified `hermes/<model>` routing release notes.
+- [docs/releases/v1.11.1-canonical-hermes-gpt-provider.md](docs/releases/v1.11.1-canonical-hermes-gpt-provider.md) — canonical `hermes/gpt-5.5` examples and Hermes configured-provider delegation notes.
 - [CHANGELOG.md](CHANGELOG.md) — downstream release history.
 
 ---
@@ -205,7 +206,7 @@ npm pack --dry-run --json
 
 ## Upstream base
 
-`gsd-hermes@1.11.0` keeps the upstream `gsd-build/get-shit-done@f2decefe` base while simplifying Hermes-native routing to `hermes/<model>` model overrides and preserving downstream package identity.
+`gsd-hermes@1.11.1` keeps the upstream `gsd-build/get-shit-done@f2decefe` base while simplifying Hermes-native routing to `hermes/<model>` model overrides and preserving downstream package identity.
 
 Public package identity remains:
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -211,16 +211,16 @@ Execute all plans in a phase with wave-based parallelization, or run a specific 
 
 **Hermes runtime model receipts:** On Hermes, execute-phase init payloads include `model_binding_receipts` for executor and verifier agents. These receipts show the configured model, resolved model token, binding source, Hermes binding channel, and proof boundary before dispatch. Explicit per-agent `model_overrides` must either bind through the Hermes child construction path or fail before spawn; execute-phase must not silently fall back to the parent/default model.
 
-**Provider-routed execution:** execute-phase reads `agent_execution_bindings` and uses the matching strict execution route per agent before legacy fallback paths. The easiest Hermes-native form is the model namespace `hermes/<model>` — no `workflow.agent_execution_*` fields are required:
+**Provider-routed execution:** execute-phase reads `agent_execution_bindings` and uses the matching strict execution route per agent before legacy fallback paths. The easiest Hermes-native form is the model namespace `hermes/<model>` — no `workflow.agent_execution_*` fields are required, and Hermes-native routes intentionally use the provider currently configured in Hermes:
 
 ```text
-model_overrides.gsd-executor = "hermes/gpt-5-5"
+model_overrides.gsd-executor = "hermes/gpt-5.5"
 → hermes-terminal-tool
-→ hermes chat --toolsets terminal,file --model openai/gpt-5.5
+→ hermes chat --toolsets terminal,file --model gpt-5.5
 
 model_overrides.gsd-verifier = "hermes/claude-opus-4-7"
 → hermes-terminal-tool
-→ hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7
+→ hermes chat --toolsets terminal,file --model claude-opus-4-7
 
 model_overrides.gsd-executor = "openai/gpt-5.5"
 → codex-cli

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,9 +4,9 @@
 
 ---
 
-## GSD Hermes v1.11.0 Release Note
+## GSD Hermes v1.11.1 Release Note
 
-`gsd-hermes@1.11.0` keeps the upstream base at `upstream/main@f2decefe` and simplifies Hermes-native provider routing. For Hermes projects, `model_overrides` remain the source of model intent: `hermes/gpt-5-5` and `hermes/claude-opus-4-7` automatically route through Hermes chat/tool execution without requiring `workflow.agent_execution_router` or `workflow.agent_execution_driver`. Plain `openai/*` and `anthropic/*` overrides still keep the strict direct Codex/Claude CLI routes.
+`gsd-hermes@1.11.1` keeps the upstream base at `upstream/main@f2decefe`, uses `hermes/gpt-5.5` as the canonical Hermes-native GPT example, and ensures Hermes-native provider routing delegates provider selection to Hermes itself. For Hermes projects, `model_overrides` remain the source of model intent: `hermes/gpt-5.5` and `hermes/claude-opus-4-7` automatically route through Hermes chat/tool execution without requiring `workflow.agent_execution_router` or `workflow.agent_execution_driver`. Hermes-native routes do not pass `--provider`; they use the provider currently configured in Hermes. Plain `openai/*` and `anthropic/*` overrides continue to route directly to Codex CLI and Claude CLI respectively. See [`docs/releases/v1.11.1-canonical-hermes-gpt-provider.md`](releases/v1.11.1-canonical-hermes-gpt-provider.md).
 
 ---
 
@@ -211,8 +211,8 @@ All workflow toggles follow the **absent = enabled** pattern. If a key is missin
 | `workflow.code_review_command` | string | (none) | Shell command for external code review integration in `/gsd-ship`. Receives changed file paths via stdin. Non-zero exit blocks the ship workflow. Added in v1.36 |
 | `workflow.tdd_mode` | boolean | `false` | Enable TDD pipeline as a first-class execution mode. When `true`, the planner aggressively applies `type: tdd` to eligible tasks (business logic, APIs, validations, algorithms) and the executor enforces RED/GREEN/REFACTOR gate sequence. An end-of-phase collaborative review checkpoint verifies gate compliance. Added in v1.36 |
 | `workflow.cross_ai_execution` | boolean | `false` | Legacy whole-plan external AI CLI fallback. In gsd-hermes strict routing, valid `agent_execution_bindings` take priority and `cross_ai_execution` must not reroute a configured per-agent binding. Added in v1.36 |
-| `workflow.agent_execution_router` | string | (none) | Advanced compatibility switch for explicit per-agent execution bindings. Normal Hermes-native usage should prefer `model_overrides` values like `hermes/gpt-5-5`; the SDK auto-emits bindings for `hermes/*` without this setting. `provider-cli` remains available for forcing direct provider-family CLI bindings. Experimental in v1.8; simplified `hermes/*` routing added in v1.11. |
-| `workflow.agent_execution_driver` | string | `provider-cli` | Advanced compatibility preference used only with the explicit router. Most users should not set it; use `hermes/<model>` in `model_overrides` for Hermes-native execution. `provider-cli` keeps direct Codex/Claude CLI routing; `hermes-chat` and `hermes-terminal-tool` remain available for advanced tests/migrations. Unsupported or unavailable drivers fail fast. Added in v1.10; primary docs simplified in v1.11. |
+| `workflow.agent_execution_router` | string | (none) | Advanced compatibility switch for explicit per-agent execution bindings. Normal Hermes-native usage should prefer `model_overrides` values like `hermes/gpt-5.5`; the SDK auto-emits bindings for `hermes/*` without this setting. `provider-cli` remains available for forcing direct provider-family CLI bindings. Experimental in v1.8; simplified `hermes/*` routing added in v1.11. |
+| `workflow.agent_execution_driver` | string | `provider-cli` | Advanced compatibility preference used only with the explicit router. Most users should not set it; use `hermes/<model>` in `model_overrides` for Hermes-native execution. `provider-cli` keeps direct Codex/Claude CLI routing; `hermes-chat` and `hermes-terminal-tool` invoke `hermes chat` without `--provider`, leaving provider selection to the currently configured Hermes provider. Unsupported or unavailable drivers fail fast. Added in v1.10; primary docs simplified in v1.11. |
 | `workflow.cross_ai_command` | string | (none) | Shell command template for cross-AI execution. Receives the phase prompt via stdin. Must produce SUMMARY.md-compatible output. Required when `cross_ai_execution` is `true`. Added in v1.36 |
 | `workflow.cross_ai_timeout` | number | `300` | Timeout in seconds for cross-AI execution commands. Prevents runaway external processes. Added in v1.36 |
 | `workflow.ai_integration_phase` | boolean | `true` | Enable the `/gsd-ai-integration-phase` command. When `false`, the command exits with a configuration gate message |
@@ -671,7 +671,7 @@ Copy/paste starting point for Hermes-native execution:
     "cross_ai_execution": false
   },
   "model_overrides": {
-    "gsd-executor": "hermes/gpt-5-5",
+    "gsd-executor": "hermes/gpt-5.5",
     "gsd-verifier": "hermes/claude-opus-4-7"
   }
 }
@@ -679,25 +679,27 @@ Copy/paste starting point for Hermes-native execution:
 
 | `model_overrides` value | `agent_execution_bindings.*.execution_driver` | Command shape |
 | --- | --- | --- |
-| `hermes/gpt-5-5` | `hermes-terminal-tool` | `hermes chat --toolsets terminal,file --model openai/gpt-5.5` |
-| `hermes/claude-opus-4-7` | `hermes-terminal-tool` | `hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7` |
+| `hermes/gpt-5.5` | `hermes-terminal-tool` | `hermes chat --toolsets terminal,file --model gpt-5.5` |
+| `hermes/claude-opus-4-7` | `hermes-terminal-tool` | `hermes chat --toolsets terminal,file --model claude-opus-4-7` |
 | `openai/gpt-5.5`, `gpt-*`, `o3`, `o4-*` | `codex-cli` | `codex exec --model {cli_model}` |
 | `anthropic/claude-opus-4-7`, `claude-*`, `opus`, `sonnet`, `haiku` | `claude-cli` | `claude -p --model {cli_model}` |
 
 Examples:
 
 ```text
-model_overrides.gsd-executor = "hermes/gpt-5-5"
+model_overrides.gsd-executor = "hermes/gpt-5.5"
 → provider_family=openai
 → execution_driver=hermes-terminal-tool
-→ cli_model=openai/gpt-5.5
-→ hermes chat --toolsets terminal,file --model openai/gpt-5.5
+→ cli_model=gpt-5.5
+→ hermes chat --toolsets terminal,file --model gpt-5.5
+→ provider selection comes from the currently configured Hermes provider
 
 model_overrides.gsd-verifier = "hermes/claude-opus-4-7"
 → provider_family=anthropic
 → execution_driver=hermes-terminal-tool
-→ cli_model=anthropic/claude-opus-4-7
-→ hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7
+→ cli_model=claude-opus-4-7
+→ hermes chat --toolsets terminal,file --model claude-opus-4-7
+→ provider selection comes from the currently configured Hermes provider
 
 model_overrides.gsd-executor = "openai/gpt-5.5"
 → provider_family=openai

--- a/docs/hermes-compatibility.md
+++ b/docs/hermes-compatibility.md
@@ -64,14 +64,14 @@ Phase 12 adds fail-fast validation and proof tests: unsupported explicit Hermes 
 
 | Configured model | Provider family | Driver | Command proof |
 | --- | --- | --- | --- |
-| `hermes/gpt-5-5` | OpenAI/GPT | Hermes terminal tool | `hermes chat --toolsets terminal,file --model openai/gpt-5.5 ...` |
-| `hermes/claude-opus-4-7` | Anthropic/Claude | Hermes terminal tool | `hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7 ...` |
+| `hermes/gpt-5.5` | OpenAI/GPT | Hermes terminal tool | `hermes chat --toolsets terminal,file --model gpt-5.5 ...` |
+| `hermes/claude-opus-4-7` | Anthropic/Claude | Hermes terminal tool | `hermes chat --toolsets terminal,file --model claude-opus-4-7 ...` |
 | `openai/gpt-5.5` or `gpt-5.5` | OpenAI/GPT | Codex CLI | `codex exec --model gpt-5.5 ...` |
 | `anthropic/claude-opus-4-7` or `claude-opus-4-7` | Anthropic/Claude | Claude Code CLI | `claude -p --model claude-opus-4-7 ...` |
 
-This mode intentionally fails fast for unsupported families, missing `cli_model`, missing CLI binaries, or unavailable CLI authentication. A valid per-agent binding has priority over `workflow.cross_ai_execution`; that legacy setting remains a whole-plan fallback and must not silently override per-agent provider routing.
+This mode intentionally fails fast for direct provider-CLI routes with unsupported families, missing `cli_model`, missing CLI binaries, or unavailable CLI authentication. For `hermes/*` routes, GSD renders `hermes chat` without `--provider` and leaves provider selection to the currently configured Hermes provider; failures should come from missing Hermes CLI/preflight or Hermes itself, not from GSD falling back to Codex/Claude. A valid per-agent binding has priority over `workflow.cross_ai_execution`; that legacy setting remains a whole-plan fallback and must not silently override per-agent provider routing.
 
-Proof boundary: provider-routed mode proves that GSD chose the matching driver and passed the normalized `--model` argument. It does not prove what Hermes Agent, Anthropic, OpenAI, Codex CLI, or Claude Code CLI sends on the wire after that process starts. Wire-level proof would require separate sanitized provider diagnostics.
+Proof boundary: provider-routed mode proves that GSD chose the matching driver and passed the normalized `--model` argument. For Hermes-native routes, this proof also covers that GSD did not pass `--provider`; it does not prove what Hermes Agent, Anthropic, OpenAI, Codex CLI, or Claude Code CLI sends on the wire after that process starts. Wire-level proof would require separate sanitized provider diagnostics.
 
 Provider-cli mode is separate from Hermes native `delegate_task(model=...)` child-construction proof. Native delegate proof applies only when GSD uses Hermes child spawning; provider-cli proof applies when GSD deliberately uses rendered commands (`hermes chat`, Codex CLI, or Claude Code CLI) for per-agent routing.
 

--- a/docs/releases/v1.11.0-hermes-model-prefix-routing.md
+++ b/docs/releases/v1.11.0-hermes-model-prefix-routing.md
@@ -11,8 +11,8 @@ No normal project config needs `workflow.agent_execution_router` or `workflow.ag
 ## What changed
 
 - Added `hermes/*` model-prefix routing:
-  - `hermes/gpt-5-5` → Hermes-native execution via `hermes chat --toolsets terminal,file --model openai/gpt-5.5`
-  - `hermes/claude-opus-4-7` → Hermes-native execution via `hermes chat --toolsets terminal,file --model anthropic/claude-opus-4-7`
+  - `hermes/gpt-5.5` → Hermes-native execution via `hermes chat --toolsets terminal,file --model gpt-5.5`
+  - `hermes/claude-opus-4-7` → Hermes-native execution via `hermes chat --toolsets terminal,file --model claude-opus-4-7`
 - Kept existing strict provider-CLI routes intact:
   - `openai/gpt-5.5` → `codex exec --model gpt-5.5`
   - `anthropic/claude-opus-4-7` → `claude -p --model claude-opus-4-7`
@@ -29,7 +29,7 @@ No normal project config needs `workflow.agent_execution_router` or `workflow.ag
     "cross_ai_execution": false
   },
   "model_overrides": {
-    "gsd-executor": "hermes/gpt-5-5",
+    "gsd-executor": "hermes/gpt-5.5",
     "gsd-verifier": "hermes/claude-opus-4-7"
   }
 }

--- a/docs/releases/v1.11.1-canonical-hermes-gpt-provider.md
+++ b/docs/releases/v1.11.1-canonical-hermes-gpt-provider.md
@@ -1,0 +1,23 @@
+# GSD Hermes v1.11.1 — Canonical Hermes GPT model and provider delegation
+
+Released: 2026-05-03
+
+## Summary
+
+`gsd-hermes@1.11.1` tightens the `hermes/<model>` UX introduced in v1.11.0:
+
+- `hermes/gpt-5.5` is now the canonical documented GPT model-prefix example.
+- `hermes/gpt-5-5` remains a backward-compatible alias and still normalizes to `gpt-5.5` for Hermes execution.
+- Hermes-native strict execution now passes unqualified model tokens such as `gpt-5.5` or `claude-opus-4-7` to `hermes chat` and never passes `--provider`, so provider selection comes from the currently configured Hermes provider.
+
+## Compatibility
+
+Plain provider-specific overrides are unchanged:
+
+- `openai/gpt-5.5` continues to route directly to Codex CLI as `codex exec --model gpt-5.5`.
+- `anthropic/claude-opus-4-7` continues to route directly to Claude Code CLI as `claude -p --model claude-opus-4-7`.
+- `hermes/*` remains the Hermes execution namespace and must not silently fall back to Codex or Claude CLI.
+
+## Verification
+
+Release-prep validation covered SDK routing, command rendering, docs drift, and package dry-run gates.

--- a/get-shit-done/bin/lib/provider-cli-dispatch.cjs
+++ b/get-shit-done/bin/lib/provider-cli-dispatch.cjs
@@ -178,7 +178,7 @@ function preflightProviderCliDriver(binding, env = process.env) {
       command,
       receipt,
       message: `Cannot execute ${normalized.agent || 'agent'}: unsupported provider CLI binding.`,
-      suggested_fix: normalized.suggested_fix || 'Choose a supported model_overrides value such as hermes/gpt-5-5, openai/gpt-5.5, or anthropic/claude-opus-4-7.',
+      suggested_fix: normalized.suggested_fix || 'Choose a supported model_overrides value such as hermes/gpt-5.5, openai/gpt-5.5, or anthropic/claude-opus-4-7.',
     };
   }
 
@@ -193,7 +193,7 @@ function preflightProviderCliDriver(binding, env = process.env) {
         ? 'Install/login Claude Code CLI or change this agent model_overrides entry to a provider routed to an available driver.'
         : driver === 'codex-cli'
           ? 'Install/login Codex CLI or change this agent model_overrides entry to a provider routed to an available driver.'
-          : 'Install/login Hermes Agent CLI and configure the requested provider credentials, or use a plain openai/* or anthropic/* model_overrides value for direct provider-CLI routing.',
+          : 'Install/login Hermes Agent CLI and configure the requested provider in Hermes, or use a plain openai/* or anthropic/* model_overrides value for direct provider-CLI routing.',
       path_entries: pathEntriesFromEnv(env),
     };
   }

--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -341,8 +341,8 @@ Set via `manager.*` namespace (e.g., `"manager": { "flags": { "discuss": "--auto
 |-----|------|---------|----------------|-------------|
 | `parallelization` | boolean\|object | `true` | `true`, `false`, `{ "enabled": true }` | Enable parallel wave execution; object form allows additional sub-keys |
 | `model_overrides` | object\|null | `null` | `{ "<agent-type>": "<model-id>" }` | Override model selection per agent type |
-| `workflow.agent_execution_router` | string\|null | `null` | `"provider-cli"`, `null` | Advanced gsd-hermes compatibility switch for explicit per-agent provider routing. Normal Hermes-native usage should prefer `model_overrides` values like `hermes/gpt-5-5`, which auto-emit `agent_execution_bindings` without this setting. |
-| `workflow.agent_execution_driver` | string\|null | `"provider-cli"` | `"provider-cli"`, `"hermes-chat"`, `"hermes-terminal-tool"` | Advanced driver preference for explicit provider routing. Most projects should leave this unset and use `hermes/<model>` for Hermes-native execution. |
+| `workflow.agent_execution_router` | string\|null | `null` | `"provider-cli"`, `null` | Advanced gsd-hermes compatibility switch for explicit per-agent provider routing. Normal Hermes-native usage should prefer `model_overrides` values like `hermes/gpt-5.5`, which auto-emit `agent_execution_bindings` without this setting. |
+| `workflow.agent_execution_driver` | string\|null | `"provider-cli"` | `"provider-cli"`, `"hermes-chat"`, `"hermes-terminal-tool"` | Advanced driver preference for explicit provider routing. Most projects should leave this unset and use `hermes/<model>` for Hermes-native execution. Hermes drivers invoke `hermes chat` without `--provider`, so provider selection comes from the currently configured Hermes provider. |
 | `agent_skills` | object | `{}` | `{ "<agent-type>": "<skill-set>" }` | Assign skill sets to specific agent types |
 | `sub_repos` | array | `[]` | Array of relative path strings | Child directories with independent `.git` repos (auto-detected) |
 
@@ -365,7 +365,7 @@ Several config fields affect each other or trigger special behavior:
 
 2. **`branching_strategy` controls branch templates** -- The `phase_branch_template` and `milestone_branch_template` fields are only used when `branching_strategy` is set to `"phase"` or `"milestone"` respectively. When `branching_strategy` is `"none"`, all template fields are ignored.
 
-3. **Per-agent execution bindings have priority over legacy `workflow.cross_ai_execution`** -- `model_overrides` values such as `hermes/gpt-5-5`, `openai/gpt-5.5`, and `anthropic/claude-opus-4-7` drive `agent_execution_bindings`; `cross_ai_execution` is a legacy whole-plan fallback. A valid per-agent binding must not be silently overridden by cross-AI fallback.
+3. **Per-agent execution bindings have priority over legacy `workflow.cross_ai_execution`** -- `model_overrides` values such as `hermes/gpt-5.5`, `openai/gpt-5.5`, and `anthropic/claude-opus-4-7` drive `agent_execution_bindings`; `cross_ai_execution` is a legacy whole-plan fallback. A valid per-agent binding must not be silently overridden by cross-AI fallback.
 
 4. **`context_window` threshold triggers** -- When `context_window >= 500000`, workflows enable adaptive context enrichment: full-body reads of prior phase SUMMARYs, cross-phase context injection in plan-phase, and deeper read depth for anti-pattern references. Below 500000, only frontmatter and summaries are read.
 

--- a/get-shit-done/workflows/settings-advanced.md
+++ b/get-shit-done/workflows/settings-advanced.md
@@ -59,9 +59,9 @@ Discussion Tuning:
 - `workflow.max_discuss_passes` (default: `3`)
 
 Cross-AI Execution / Provider Routing:
-- `model_overrides.<agent>` values like `hermes/gpt-5-5` or `hermes/claude-opus-4-7` are the preferred Hermes-native routing path
+- `model_overrides.<agent>` values like `hermes/gpt-5.5` or `hermes/claude-opus-4-7` are the preferred Hermes-native routing path
 - `workflow.agent_execution_router` (default: `null`; advanced compatibility switch for explicit provider→CLI routing)
-- `workflow.agent_execution_driver` (default: `provider-cli`; advanced compatibility preference, normally unset)
+- `workflow.agent_execution_driver` (default: `provider-cli`; advanced compatibility preference, normally unset; Hermes drivers use the currently configured Hermes provider and do not pass `--provider`)
 - `workflow.cross_ai_execution` (default: `false`; legacy whole-plan fallback, lower priority than valid per-agent bindings)
 - `workflow.cross_ai_command` (default: `null`)
 - `workflow.cross_ai_timeout` (default: `300`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-hermes",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-hermes",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-hermes",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Hermes-first Get Shit Done distribution with strict provider-routed agent execution.",
   "bin": {
     "gsd-hermes": "bin/install.js",

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -51,9 +51,9 @@ export interface WorkflowConfig {
   skip_discuss: boolean;
   /** Maximum self-discuss passes in auto/headless mode before forcing proceed. Default: 3. */
   max_discuss_passes: number;
-  /** Advanced per-agent execution router. Normal Hermes-native usage should prefer `model_overrides` values like `hermes/gpt-5-5`. */
+  /** Advanced per-agent execution router. Normal Hermes-native usage should prefer `model_overrides` values like `hermes/gpt-5.5`. */
   agent_execution_router?: 'provider-cli' | string;
-  /** Advanced driver preference for explicit provider routing; most projects should leave unset. */
+  /** Advanced driver preference for explicit provider routing; Hermes drivers use the provider currently configured in Hermes. */
   agent_execution_driver?: 'provider-cli' | 'hermes-chat' | 'hermes-terminal-tool' | string;
   /** Subagent timeout in ms (matches `get-shit-done/bin/lib/core.cjs` default 300000). */
   subagent_timeout: number;

--- a/sdk/src/query/agent-execution-router.ts
+++ b/sdk/src/query/agent-execution-router.ts
@@ -49,7 +49,7 @@ export function resolveAgentExecutionDriverPreference(config: Pick<GSDConfig, 'w
   return raw === 'hermes-chat' || raw === 'hermes-terminal-tool' ? raw : 'provider-cli';
 }
 
-function stripProviderPrefix(model: string, provider: 'anthropic' | 'openai'): string {
+function stripProviderPrefix(model: string, provider: 'anthropic' | 'openai' | 'google'): string {
   const prefix = `${provider}/`;
   return model.toLowerCase().startsWith(prefix) ? model.slice(prefix.length) : model;
 }
@@ -71,12 +71,6 @@ export function normalizeCliModel(model: string | null | undefined, providerFami
   return trimmed;
 }
 
-function normalizeHermesModel(model: string | null | undefined): string | null {
-  if (!model) return null;
-  const trimmed = model.trim();
-  return trimmed === '' ? null : trimmed;
-}
-
 function isHermesPrefixedModel(model: string | null | undefined): boolean {
   return typeof model === 'string' && model.trim().toLowerCase().startsWith('hermes/');
 }
@@ -86,9 +80,8 @@ function stripHermesPrefix(model: string): string {
 }
 
 function normalizeOpenAiHermesModel(model: string): string {
-  const unprefixed = model.toLowerCase().startsWith('openai/') ? model.slice('openai/'.length) : model;
-  const dotAlias = unprefixed.replace(/^gpt-(\d+)-(\d+)(.*)$/i, 'gpt-$1.$2$3');
-  return `openai/${dotAlias}`;
+  const unprefixed = stripProviderPrefix(model, 'openai');
+  return unprefixed.replace(/^gpt-(\d+)-(\d+)(.*)$/i, 'gpt-$1.$2$3');
 }
 
 function normalizeHermesRoutedModel(model: string | null | undefined, providerFamily: ModelFamily): string | null {
@@ -98,7 +91,7 @@ function normalizeHermesRoutedModel(model: string | null | undefined, providerFa
 
   if (providerFamily === 'anthropic') {
     const unprefixed = stripProviderPrefix(inner, 'anthropic');
-    return `anthropic/${MODEL_ALIAS_MAP[unprefixed] ?? unprefixed}`;
+    return MODEL_ALIAS_MAP[unprefixed] ?? unprefixed;
   }
 
   if (providerFamily === 'openai') {
@@ -106,15 +99,10 @@ function normalizeHermesRoutedModel(model: string | null | undefined, providerFa
   }
 
   if (providerFamily === 'google') {
-    const unprefixed = inner.toLowerCase().startsWith('google/') ? inner.slice('google/'.length) : inner;
-    return `google/${unprefixed}`;
+    return stripProviderPrefix(inner, 'google');
   }
 
   return inner;
-}
-
-function providerFamilySupportedByHermes(providerFamily: ModelFamily): boolean {
-  return providerFamily === 'anthropic' || providerFamily === 'openai' || providerFamily === 'google';
 }
 
 export function resolveAgentExecutionBinding(
@@ -130,11 +118,9 @@ export function resolveAgentExecutionBinding(
   const driverPreference = hermesPrefixed && requestedPreference === 'provider-cli'
     ? 'hermes-terminal-tool'
     : requestedPreference;
-  const cliModel = hermesPrefixed
-    ? normalizeHermesRoutedModel(providerModel, providerFamily)
-    : driverPreference === 'provider-cli'
-      ? normalizeCliModel(providerModel, providerFamily)
-      : normalizeHermesModel(providerModel);
+  const cliModel = driverPreference === 'provider-cli'
+    ? normalizeCliModel(providerModel, providerFamily)
+    : normalizeHermesRoutedModel(providerModel, providerFamily);
 
   if (receipt.status !== 'resolved' || receipt.binding_kind !== 'explicit' || !providerModel) {
     return {
@@ -148,12 +134,12 @@ export function resolveAgentExecutionBinding(
       source: receipt.source,
       strict: true,
       diagnostic: `Provider-routed execution requires an explicit model_overrides binding for ${receipt.agent}.`,
-      suggested_fix: `Set model_overrides.${receipt.agent} to hermes/gpt-5-5, hermes/claude-opus-4-7, an OpenAI/GPT model, or an Anthropic/Claude model.`,
+      suggested_fix: `Set model_overrides.${receipt.agent} to hermes/gpt-5.5, hermes/claude-opus-4-7, an OpenAI/GPT model, or an Anthropic/Claude model.`,
     };
   }
 
   if (driverPreference === 'hermes-chat' || driverPreference === 'hermes-terminal-tool') {
-    if (providerFamilySupportedByHermes(providerFamily) && cliModel) {
+    if (cliModel) {
       const label = driverPreference === 'hermes-chat' ? 'Hermes chat' : 'Hermes terminal tool';
       return {
         agent: receipt.agent,
@@ -165,7 +151,7 @@ export function resolveAgentExecutionBinding(
         cli_model: cliModel,
         source: receipt.source,
         strict: true,
-        diagnostic: `${receipt.agent} routes through ${label} with explicit model '${providerModel}'. Hermes is the execution surface; provider selection remains model-driven and must not use provider-specific CLIs.`,
+        diagnostic: `${receipt.agent} routes through ${label} with explicit model '${providerModel}'. Hermes is the execution surface; provider selection is delegated to the currently configured Hermes provider and must not use provider-specific CLIs.`,
         suggested_fix: null,
       };
     }
@@ -180,8 +166,8 @@ export function resolveAgentExecutionBinding(
       cli_model: null,
       source: receipt.source,
       strict: true,
-      diagnostic: `Hermes-native provider-routed execution does not support provider family '${providerFamily}' for ${receipt.agent}.`,
-      suggested_fix: `Use hermes/gpt-5-5, hermes/claude-opus-4-7, or a supported plain OpenAI/GPT or Anthropic/Claude override for ${receipt.agent}.`,
+      diagnostic: `Hermes-native provider-routed execution could not derive a non-empty Hermes model token for ${receipt.agent}.`,
+      suggested_fix: `Set model_overrides.${receipt.agent} to a non-empty Hermes model such as hermes/gpt-5.5 or hermes/claude-opus-4-7. Hermes will use its currently configured provider.`,
     };
   }
 
@@ -228,7 +214,7 @@ export function resolveAgentExecutionBinding(
     source: receipt.source,
     strict: true,
     diagnostic: `Provider-routed execution does not support provider family '${providerFamily}' for ${receipt.agent}.`,
-    suggested_fix: `Use an Anthropic/Claude, OpenAI/GPT, hermes/gpt-5-5, or hermes/claude-opus-4-7 model override for ${receipt.agent}.`,
+    suggested_fix: `Use an Anthropic/Claude, OpenAI/GPT, hermes/gpt-5.5, or hermes/claude-opus-4-7 model override for ${receipt.agent}.`,
   };
 }
 

--- a/tests/agent-execution-router.test.cjs
+++ b/tests/agent-execution-router.test.cjs
@@ -108,7 +108,28 @@ describe('provider-routed agent execution bindings', () => {
     assert.equal(binding.strict, true);
   });
 
-  test('routes hermes-prefixed GPT overrides through Hermes by default without workflow.agent_execution_* config', () => {
+  test('routes canonical hermes/gpt-5.5 overrides through Hermes using the configured Hermes provider', () => {
+    const receipt = contract.toRuntimeModelReceipt(
+      contract.resolveAgentBinding({
+        runtime: 'hermes',
+        resolve_model_ids: 'omit',
+        model_overrides: { 'gsd-executor': 'hermes/gpt-5.5' },
+        workflow: {},
+      }, 'gsd-executor'),
+      'executor'
+    );
+
+    const binding = router.resolveAgentExecutionBinding(receipt);
+    assert.equal(binding.status, 'resolved');
+    assert.equal(binding.provider_family, 'openai');
+    assert.equal(binding.execution_driver, 'hermes-terminal-tool');
+    assert.equal(binding.cli_model, 'gpt-5.5');
+    assert.equal(binding.strict, true);
+    assert.match(binding.diagnostic, /configured Hermes provider/i);
+    assert.doesNotMatch(binding.diagnostic, /Claude Code CLI|Codex CLI/i);
+  });
+
+  test('keeps hermes/gpt-5-5 as a compatibility alias for hermes/gpt-5.5', () => {
     const receipt = contract.toRuntimeModelReceipt(
       contract.resolveAgentBinding({
         runtime: 'hermes',
@@ -123,10 +144,7 @@ describe('provider-routed agent execution bindings', () => {
     assert.equal(binding.status, 'resolved');
     assert.equal(binding.provider_family, 'openai');
     assert.equal(binding.execution_driver, 'hermes-terminal-tool');
-    assert.equal(binding.cli_model, 'openai/gpt-5.5');
-    assert.equal(binding.strict, true);
-    assert.match(binding.diagnostic, /Hermes/i);
-    assert.doesNotMatch(binding.diagnostic, /Claude Code CLI|Codex CLI/i);
+    assert.equal(binding.cli_model, 'gpt-5.5');
   });
 
   test('routes hermes-prefixed Claude overrides through Hermes by default without workflow.agent_execution_* config', () => {
@@ -144,7 +162,7 @@ describe('provider-routed agent execution bindings', () => {
     assert.equal(binding.status, 'resolved');
     assert.equal(binding.provider_family, 'anthropic');
     assert.equal(binding.execution_driver, 'hermes-terminal-tool');
-    assert.equal(binding.cli_model, 'anthropic/claude-opus-4-7');
+    assert.equal(binding.cli_model, 'claude-opus-4-7');
     assert.equal(binding.strict, true);
   });
 
@@ -154,7 +172,7 @@ describe('provider-routed agent execution bindings', () => {
         runtime: 'hermes',
         resolve_model_ids: 'omit',
         model_overrides: {
-          'gsd-executor': 'hermes/gpt-5-5',
+          'gsd-executor': 'hermes/gpt-5.5',
           'gsd-verifier': 'anthropic/claude-opus-4-7',
         },
         workflow: {},
@@ -166,7 +184,7 @@ describe('provider-routed agent execution bindings', () => {
         runtime: 'hermes',
         resolve_model_ids: 'omit',
         model_overrides: {
-          'gsd-executor': 'hermes/gpt-5-5',
+          'gsd-executor': 'hermes/gpt-5.5',
           'gsd-verifier': 'anthropic/claude-opus-4-7',
         },
         workflow: {},
@@ -200,7 +218,7 @@ describe('provider-routed agent execution bindings', () => {
     assert.equal(binding.status, 'resolved');
     assert.equal(binding.provider_family, 'openai');
     assert.equal(binding.execution_driver, 'hermes-chat');
-    assert.equal(binding.cli_model, 'openai/gpt-5.5');
+    assert.equal(binding.cli_model, 'gpt-5.5');
     assert.equal(binding.strict, true);
     assert.match(binding.diagnostic, /Hermes chat/i);
   });
@@ -223,9 +241,29 @@ describe('provider-routed agent execution bindings', () => {
     assert.equal(binding.status, 'resolved');
     assert.equal(binding.provider_family, 'anthropic');
     assert.equal(binding.execution_driver, 'hermes-terminal-tool');
-    assert.equal(binding.cli_model, 'anthropic/claude-opus-4-7');
+    assert.equal(binding.cli_model, 'claude-opus-4-7');
     assert.equal(binding.strict, true);
     assert.match(binding.diagnostic, /Hermes terminal tool/i);
+    assert.match(binding.diagnostic, /configured Hermes provider/i);
+  });
+
+  test('routes unknown families through Hermes when Hermes is the explicit execution surface', () => {
+    const receipt = contract.toRuntimeModelReceipt(
+      contract.resolveAgentBinding({
+        runtime: 'hermes',
+        resolve_model_ids: 'omit',
+        model_overrides: { 'gsd-executor': 'hermes/mistral-large-latest' },
+        workflow: {},
+      }, 'gsd-executor'),
+      'executor'
+    );
+
+    const binding = router.resolveAgentExecutionBinding(receipt);
+    assert.equal(binding.status, 'resolved');
+    assert.equal(binding.provider_family, 'unknown');
+    assert.equal(binding.execution_driver, 'hermes-terminal-tool');
+    assert.equal(binding.cli_model, 'mistral-large-latest');
+    assert.match(binding.diagnostic, /configured Hermes provider/i);
   });
 
   test('routes bare provider-family model tokens to the same CLI drivers', () => {
@@ -340,9 +378,9 @@ describe('init.execute-phase provider-routed bindings', () => {
     assert.equal(json.agent_execution_bindings.router, 'provider-cli');
     assert.equal(json.agent_execution_bindings.driver_preference, 'hermes-terminal-tool');
     assert.equal(json.agent_execution_bindings.agents.executor.execution_driver, 'hermes-terminal-tool');
-    assert.equal(json.agent_execution_bindings.agents.executor.cli_model, 'openai/gpt-5.5');
+    assert.equal(json.agent_execution_bindings.agents.executor.cli_model, 'gpt-5.5');
     assert.equal(json.agent_execution_bindings.agents.verifier.execution_driver, 'hermes-terminal-tool');
-    assert.equal(json.agent_execution_bindings.agents.verifier.cli_model, 'anthropic/claude-opus-4-7');
+    assert.equal(json.agent_execution_bindings.agents.verifier.cli_model, 'claude-opus-4-7');
   });
 
   test('init.execute-phase auto-emits Hermes-native bindings from hermes-prefixed model overrides without workflow.agent_execution_* config', () => {
@@ -363,10 +401,10 @@ describe('init.execute-phase provider-routed bindings', () => {
     assert.equal(json.agent_execution_bindings.driver_preference, 'hermes-terminal-tool');
     assert.equal(json.agent_execution_bindings.agents.executor.execution_driver, 'hermes-terminal-tool');
     assert.equal(json.agent_execution_bindings.agents.executor.provider_family, 'openai');
-    assert.equal(json.agent_execution_bindings.agents.executor.cli_model, 'openai/gpt-5.5');
+    assert.equal(json.agent_execution_bindings.agents.executor.cli_model, 'gpt-5.5');
     assert.equal(json.agent_execution_bindings.agents.verifier.execution_driver, 'hermes-terminal-tool');
     assert.equal(json.agent_execution_bindings.agents.verifier.provider_family, 'anthropic');
-    assert.equal(json.agent_execution_bindings.agents.verifier.cli_model, 'anthropic/claude-opus-4-7');
+    assert.equal(json.agent_execution_bindings.agents.verifier.cli_model, 'claude-opus-4-7');
   });
 
   test('omits agent_execution_bindings when provider-cli router is disabled and no hermes-prefixed overrides exist', () => {

--- a/tests/provider-cli-dispatch.test.cjs
+++ b/tests/provider-cli-dispatch.test.cjs
@@ -41,14 +41,14 @@ const ANTHROPIC_BINDING = {
 const HERMES_CHAT_BINDING = {
   ...OPENAI_BINDING,
   execution_driver: 'hermes-chat',
-  cli_model: 'openai/gpt-5.5',
+  cli_model: 'gpt-5.5',
   diagnostic: 'test hermes chat',
 };
 
 const HERMES_TERMINAL_BINDING = {
   ...ANTHROPIC_BINDING,
   execution_driver: 'hermes-terminal-tool',
-  cli_model: 'anthropic/claude-opus-4-7',
+  cli_model: 'claude-opus-4-7',
   diagnostic: 'test hermes terminal tool',
 };
 
@@ -144,11 +144,11 @@ describe('provider CLI dispatch helper', () => {
     assert.equal(command.driver, 'hermes-chat');
     assert.deepEqual(command.argv.slice(0, 4), ['hermes', 'chat', '--quiet', '--source']);
     assert.equal(command.argv.includes('--model'), true);
-    assert.equal(command.argv[command.argv.indexOf('--model') + 1], 'openai/gpt-5.5');
+    assert.equal(command.argv[command.argv.indexOf('--model') + 1], 'gpt-5.5');
     assert.equal(command.argv.includes('--provider'), false);
     assert.equal(command.argv.includes('claude'), false);
     assert.equal(command.argv.includes('codex'), false);
-    assert.match(command.display, /hermes chat .*--model openai\/gpt-5\.5/);
+    assert.match(command.display, /hermes chat .*--model gpt-5\.5/);
     assert.doesNotMatch(command.display, /claude -p|codex exec/);
   });
 
@@ -164,7 +164,7 @@ describe('provider CLI dispatch helper', () => {
     assert.equal(command.argv.includes('--toolsets'), true);
     assert.equal(command.argv[command.argv.indexOf('--toolsets') + 1], 'terminal,file');
     assert.equal(command.argv.includes('--model'), true);
-    assert.equal(command.argv[command.argv.indexOf('--model') + 1], 'anthropic/claude-opus-4-7');
+    assert.equal(command.argv[command.argv.indexOf('--model') + 1], 'claude-opus-4-7');
     assert.equal(command.argv.includes('--provider'), false);
     assert.doesNotMatch(command.display, /--provider|claude -p|codex exec/);
   });


### PR DESCRIPTION
## Summary

- canonicalize Hermes-native GPT examples to `hermes/gpt-5.5` while retaining `hermes/gpt-5-5` as a tested compatibility alias
- change Hermes-native strict execution to pass unqualified model tokens like `gpt-5.5` / `claude-opus-4-7` to `hermes chat`
- keep Hermes routes provider-neutral from GSD by not passing `--provider`, so Hermes uses its currently configured provider
- preserve direct provider-CLI routing for plain `openai/*` and `anthropic/*` overrides

Closes #59

## Verification

- `git ls-files .planning`
- `git grep -nE '^(<<<<<<<|>>>>>>>)( |$)|^=======$' -- . ':!package-lock.json' || true`
- `git diff --check`
- `npm run build:sdk`
- `node --test tests/agent-execution-router.test.cjs tests/provider-cli-dispatch.test.cjs tests/hermes-provider-routing-regression.test.cjs`
- `npm run test:hermes`
- `npm test`
- `npm run lint:tests`
- `npm run lint:changeset`
- `npm pack --dry-run --json > /tmp/gsd-hermes-pack-1.11.1.json`

## Release notes

- Version bumped to `1.11.1`.
- Added `docs/releases/v1.11.1-canonical-hermes-gpt-provider.md`.
